### PR TITLE
[Feat] 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     //email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/solmate/common/jwt/JwtProvider.java
+++ b/src/main/java/org/solmate/common/jwt/JwtProvider.java
@@ -29,7 +29,7 @@ public class JwtProvider {
 		this.refreshExpiration = refreshExpiration;
 	}
 
-	// access token 생성 (JWT)
+	// access token
 	public String generateAccessToken(Long userId) {
 		Date now = new Date();
 		return Jwts.builder()
@@ -50,8 +50,6 @@ public class JwtProvider {
 			.compact();
 	}
 
-
-	// token 유효성 검증
 	public boolean validateToken(String token) {
 		try {
 			Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
@@ -61,7 +59,6 @@ public class JwtProvider {
 		}
 	}
 
-	// token에서 userId 추출
 	public Long getUserId(String token) {
 		return Long.parseLong(
 			Jwts.parser().verifyWith(key).build()
@@ -71,7 +68,6 @@ public class JwtProvider {
 		);
 	}
 
-	// token 남은 만료시간 (ms)
 	public long getRemainingExpiration(String token) {
 		Date expiration = Jwts.parser().verifyWith(key).build()
 				.parseSignedClaims(token)

--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseStatus {
     INVALID_TOKEN("AUTH_401", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     VERIFICATION_CODE_EXPIRED("AUTH_400", HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
     INVALID_VERIFICATION_CODE("AUTH_400", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
+    EMAIL_VERIFICATION_NOT_FOUND("AUTH_404", HttpStatus.NOT_FOUND, "이메일 인증 요청을 먼저 진행해주세요."),
 
     /**
      * User
@@ -35,6 +36,7 @@ public enum ErrorStatus implements BaseStatus {
     USER_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     EMAIL_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     EMAIL_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    NICKNAME_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     EMAIL_NOT_VERIFIED("USER_400", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
     EMAIL_SEND_FAILED("USER_500", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
 

--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -26,13 +26,17 @@ public enum ErrorStatus implements BaseStatus {
     INVALID_PASSWORD_FORMAT("AUTH_400", HttpStatus.BAD_REQUEST, "비밀번호 양식이 올바르지 않습니다."),
     INVALID_PASSWORD("AUTH_401", HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다."),
     INVALID_TOKEN("AUTH_401", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    VERIFICATION_CODE_EXPIRED("AUTH_400", HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
+    INVALID_VERIFICATION_CODE("AUTH_400", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않습니다."),
 
     /**
      * User
      */
     USER_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     EMAIL_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
-    EMAIL_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
+    EMAIL_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    EMAIL_NOT_VERIFIED("USER_400", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
+    EMAIL_SEND_FAILED("USER_500", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -25,7 +25,8 @@ public enum SuccessStatus implements BaseStatus {
     LOGOUT_SUCCESS("AUTH_200", HttpStatus.OK, "로그아웃 성공"),
     REISSUE_SUCCESS("AUTH_200", HttpStatus.OK, "토큰 재발급 성공"),
     EMAIL_SEND_SUCCESS("AUTH_200", HttpStatus.OK, "인증 메일 발송 성공"),
-    EMAIL_VERIFY_SUCCESS("AUTH_200", HttpStatus.OK, "이메일 인증 성공");
+    EMAIL_VERIFY_SUCCESS("AUTH_200", HttpStatus.OK, "이메일 인증 성공"),
+    NICKNAME_CHECK_SUCCESS("AUTH_200", HttpStatus.OK, "사용 가능한 닉네임입니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -23,7 +23,9 @@ public enum SuccessStatus implements BaseStatus {
     SIGNUP_SUCCESS("AUTH_201", HttpStatus.CREATED, "회원가입 성공"),
     LOGIN_SUCCESS("AUTH_200", HttpStatus.OK, "로그인 성공"),
     LOGOUT_SUCCESS("AUTH_200", HttpStatus.OK, "로그아웃 성공"),
-    REISSUE_SUCCESS("AUTH_200", HttpStatus.OK, "토큰 재발급 성공");
+    REISSUE_SUCCESS("AUTH_200", HttpStatus.OK, "토큰 재발급 성공"),
+    EMAIL_SEND_SUCCESS("AUTH_200", HttpStatus.OK, "인증 메일 발송 성공"),
+    EMAIL_VERIFY_SUCCESS("AUTH_200", HttpStatus.OK, "이메일 인증 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/solmate/domain/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import org.solmate.domain.auth.service.AuthService;
 import org.solmate.domain.auth.service.EmailVerificationService;
 import org.solmate.domain.auth.service.GoogleService;
 import org.springframework.http.ResponseEntity;
+import org.solmate.domain.user.service.UserService;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +38,14 @@ public class AuthController {
     private final AuthService authService;
     private final GoogleService googleService;
     private final EmailVerificationService emailVerificationService;
+    private final UserService userService;
+
+    @Operation(summary = "닉네임 중복 확인")
+    @GetMapping("/nickname/check")
+    public ResponseEntity<ApiResponse<Void>> checkNickname(@RequestParam String nickname) {
+        userService.checkNicknameNotDuplicated(nickname);
+        return ApiResponse.success(SuccessStatus.NICKNAME_CHECK_SUCCESS);
+    }
 
     @Operation(summary = "인증 메일 발송")
     @PostMapping("/email/send")

--- a/src/main/java/org/solmate/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/solmate/domain/auth/controller/AuthController.java
@@ -4,10 +4,13 @@ import java.util.Map;
 
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.auth.dto.request.ConfirmEmailVerificationRequest;
+import org.solmate.domain.auth.dto.request.EmailVerificationRequest;
 import org.solmate.domain.auth.dto.request.LoginRequest;
 import org.solmate.domain.auth.dto.request.SignUpRequest;
 import org.solmate.domain.auth.dto.response.LoginResponse;
 import org.solmate.domain.auth.service.AuthService;
+import org.solmate.domain.auth.service.EmailVerificationService;
 import org.solmate.domain.auth.service.GoogleService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -33,6 +36,25 @@ public class AuthController {
 
     private final AuthService authService;
     private final GoogleService googleService;
+    private final EmailVerificationService emailVerificationService;
+
+    @Operation(summary = "인증 메일 발송")
+    @PostMapping("/email/send")
+    public ResponseEntity<ApiResponse<Void>> sendEmailVerification(
+            @RequestBody @Valid EmailVerificationRequest request
+    ) {
+        emailVerificationService.requestEmailVerificationCode(request.email());
+        return ApiResponse.success(SuccessStatus.EMAIL_SEND_SUCCESS);
+    }
+
+    @Operation(summary = "이메일 인증 코드 확인")
+    @PostMapping("/email/verify")
+    public ResponseEntity<ApiResponse<Void>> verifyEmail(
+            @RequestBody @Valid ConfirmEmailVerificationRequest request
+    ) {
+        emailVerificationService.confirmEmailVerificationCode(request.email(), request.emailVerificationCode());
+        return ApiResponse.success(SuccessStatus.EMAIL_VERIFY_SUCCESS);
+    }
 
     @Operation(summary = "회원가입")
     @PostMapping("/signup")

--- a/src/main/java/org/solmate/domain/auth/dto/request/ConfirmEmailVerificationRequest.java
+++ b/src/main/java/org/solmate/domain/auth/dto/request/ConfirmEmailVerificationRequest.java
@@ -11,7 +11,7 @@ public record ConfirmEmailVerificationRequest(
         String email,
 
         @NotBlank(message = "인증코드는 필수입니다.")
-        @Size(min = 4, max = 4, message = "인증코드는 4자리여야 합니다.")
+        @Size(min = 6, max = 6, message = "인증코드는 6자리여야 합니다.")
         String emailVerificationCode
 ) {
 }

--- a/src/main/java/org/solmate/domain/auth/dto/request/ConfirmEmailVerificationRequest.java
+++ b/src/main/java/org/solmate/domain/auth/dto/request/ConfirmEmailVerificationRequest.java
@@ -1,0 +1,17 @@
+package org.solmate.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ConfirmEmailVerificationRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Size(max = 30, message = "이메일은 30자를 초과할 수 없습니다.")
+        String email,
+
+        @NotBlank(message = "인증코드는 필수입니다.")
+        @Size(min = 4, max = 4, message = "인증코드는 4자리여야 합니다.")
+        String emailVerificationCode
+) {
+}

--- a/src/main/java/org/solmate/domain/auth/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/org/solmate/domain/auth/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,12 @@
+package org.solmate.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record EmailVerificationRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Size(max = 30, message = "이메일은 30자를 초과할 수 없습니다.")
+        String email
+) {}

--- a/src/main/java/org/solmate/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/org/solmate/domain/auth/entity/EmailVerification.java
@@ -1,0 +1,57 @@
+package org.solmate.domain.auth.entity;
+
+import org.solmate.common.base.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class EmailVerification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long emailVerificationId;
+
+    @Column(nullable = false, length = 30)
+    private String email;
+
+    @Column(nullable = false, length = 6)
+    private String verificationCode;
+
+    @Column(nullable = false)
+    private boolean isVerified = false;
+
+    public void updateIsVerified(Boolean isVerified) {
+        this.isVerified = isVerified;
+    }
+
+    public void updateVerificationCode(String verificationCode) {
+        this.verificationCode = verificationCode;
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/org/solmate/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/org/solmate/domain/auth/repository/EmailVerificationRepository.java
@@ -1,0 +1,11 @@
+package org.solmate.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.solmate.domain.auth.entity.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+	Optional<EmailVerification> findByEmail(String email);
+}
+

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
         String accessToken = jwtProvider.generateAccessToken(user.getId());
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());
 
-        // Redis에 refresh token 저장 (key: "refresh:userId")
+
         redisTemplate.opsForValue().set(
                 "refresh:" + user.getId(),
                 refreshToken,
@@ -80,10 +80,10 @@ public class AuthService {
                 TimeUnit.MILLISECONDS
         );
 
-        // refresh token → HttpOnly 쿠키
+
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(false)  // prod 환경에서는 true
+                .secure(false)  // prod 환경에서는 true로 바꾸어 줄 예정!!
                 .path("/")
                 .maxAge(refreshExpiration / 1000)
                 .sameSite("Strict")
@@ -112,13 +112,11 @@ public class AuthService {
 
     // 로그아웃
     public void logout(String accessToken, String refreshToken, HttpServletResponse response) {
-        // refresh token → Redis 삭제
         if (jwtProvider.validateToken(refreshToken)) {
             Long userId = jwtProvider.getUserId(refreshToken);
             redisTemplate.delete("refresh:" + userId);
         }
 
-        // access token → 블랙리스트 등록 (남은 만료시간만큼 TTL)
         if (jwtProvider.validateToken(accessToken)) {
             long remaining = jwtProvider.getRemainingExpiration(accessToken);
             redisTemplate.opsForValue().set(
@@ -129,7 +127,6 @@ public class AuthService {
             );
         }
 
-        // 쿠키 만료
         ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
                 .path("/")

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import org.solmate.common.jwt.JwtProvider;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.auth.dto.request.LoginRequest;
 import org.solmate.domain.auth.dto.request.SignUpRequest;
+import org.solmate.domain.auth.service.EmailVerificationService;
 import org.solmate.domain.auth.dto.response.LoginResponse;
 import org.solmate.domain.auth.entity.LoginType;
 import org.solmate.domain.auth.enums.OAuthProvider;
@@ -36,6 +37,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate redisTemplate;
+    private final EmailVerificationService emailVerificationService;
 
     @Value("${jwt.refresh-token-expiration}")
     private long refreshExpiration;
@@ -45,7 +47,9 @@ public class AuthService {
 
     // 회원가입
     public void signUp(SignUpRequest request) {
+        emailVerificationService.isEmailVerified(request.email());
         userService.checkEmailNotDuplicated(request.email());
+        userService.checkNicknameNotDuplicated(request.nickname());
 
         User user = User.builder()
                 .email(request.email())

--- a/src/main/java/org/solmate/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/solmate/domain/auth/service/EmailVerificationService.java
@@ -79,7 +79,7 @@ public class EmailVerificationService {
     // 이메일 정보 조회
     private EmailVerification findEmailVerificationByEmail(String email) {
         return emailVerificationRepository.findByEmail(email)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EMAIL_VERIFICATION_NOT_FOUND));
     }
 
     // 인증 코드 만료 여부

--- a/src/main/java/org/solmate/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/solmate/domain/auth/service/EmailVerificationService.java
@@ -1,0 +1,105 @@
+package org.solmate.domain.auth.service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.auth.entity.EmailVerification;
+import org.solmate.domain.auth.repository.EmailVerificationRepository;
+import org.solmate.domain.auth.util.EmailSender;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final EmailSender emailSender;
+    private static final SecureRandom random = new SecureRandom();
+
+    @Value("${mail.verification.expiration}")
+    private long expirationSeconds;
+
+    // 이메일 인증 코드 요청
+    @Transactional
+    public void requestEmailVerificationCode(String email) {
+        String verificationCode = createEmailVerificationCode();
+        emailVerificationRepository.findByEmail(email)
+                .ifPresentOrElse(
+                        existing -> updateEmailVerification(existing, verificationCode),
+                        () -> registerEmailVerification(email, verificationCode)
+                );
+
+        emailSender.send(email, verificationCode);
+    }
+
+    // 이메일 인증 코드 확인
+    @Transactional
+    public void confirmEmailVerificationCode(String email, String code) {
+        EmailVerification emailVerification = findEmailVerificationByEmail(email);
+
+        validateCodeExpiration(emailVerification.getUpdatedAt());
+        validateVerificationCode(code, emailVerification.getVerificationCode());
+
+        emailVerification.updateIsVerified(true);
+    }
+
+    // 이메일 검증 여부 검사
+    @Transactional
+    public void isEmailVerified(String email) {
+        EmailVerification emailVerification = findEmailVerificationByEmail(email);
+
+        if (!emailVerification.isVerified()) {
+            throw new GeneralException(ErrorStatus.EMAIL_NOT_VERIFIED);
+        }
+        emailVerificationRepository.deleteById(emailVerification.getEmailVerificationId());
+    }
+
+    private void updateEmailVerification(EmailVerification emailVerification, String verificationCode) {
+        emailVerification.updateIsVerified(false);
+        emailVerification.updateVerificationCode(verificationCode);
+    }
+
+
+    private void registerEmailVerification(String email, String verificationCode) {
+        EmailVerification newVerification = EmailVerification.builder()
+                .email(email)
+                .verificationCode(verificationCode)
+                .isVerified(false)
+                .build();
+
+        emailVerificationRepository.save(newVerification);
+    }
+
+    // 이메일 정보 조회
+    private EmailVerification findEmailVerificationByEmail(String email) {
+        return emailVerificationRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.EMAIL_NOT_FOUND));
+    }
+
+    // 인증 코드 만료 여부
+    private void validateCodeExpiration(LocalDateTime updatedAt) {
+        LocalDateTime now = LocalDateTime.now();
+        if (updatedAt.isBefore(now.minusSeconds(expirationSeconds))) {
+            throw new GeneralException(ErrorStatus.VERIFICATION_CODE_EXPIRED);
+        }
+    }
+
+    // 인증 코드 일치 여부
+    private void validateVerificationCode(String inputCode, String storedCode) {
+        if (!storedCode.equals(inputCode)) {
+            throw new GeneralException(ErrorStatus.INVALID_VERIFICATION_CODE);
+        }
+    }
+
+
+    private String createEmailVerificationCode() {
+        int code = random.nextInt(900000) + 100000;
+        return String.valueOf(code);
+    }
+}

--- a/src/main/java/org/solmate/domain/auth/util/EmailSender.java
+++ b/src/main/java/org/solmate/domain/auth/util/EmailSender.java
@@ -1,0 +1,52 @@
+package org.solmate.domain.auth.util;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailSender {
+
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String senderAddress;
+
+    // 이메일 인증 코드 발송
+    public void send(String recipientEmail, String verificationCode) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(senderAddress);
+            helper.setTo(recipientEmail);
+            helper.setSubject("[SOLMATE] 이메일 인증 코드입니다.");
+            helper.setText(buildHtmlContent(verificationCode), true);
+
+            mailSender.send(message);
+
+            log.info("이메일 전송 완료 → {}", recipientEmail);
+        } catch (Exception e) {
+            log.error("이메일 전송 실패 → {}", recipientEmail, e);
+            throw new GeneralException(ErrorStatus.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private String buildHtmlContent(String code) {
+        Context context = new Context();
+        context.setVariable("verificationCode", code);
+        return templateEngine.process("mail/verificationEmail", context);
+    }
+}

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -32,6 +32,12 @@ public class UserService {
         }
     }
 
+    public void checkNicknameNotDuplicated(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new GeneralException(ErrorStatus.NICKNAME_ALREADY_EXISTS);
+        }
+    }
+
     @Transactional
     public void updatePassword(User user, String encodedPassword) {
         user.updatePassword(encodedPassword);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,9 +15,42 @@ spring:
     generate-ddl: true
     show-sql: true
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
+mail:
+  verification:
+    expiration: 300
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION}
+
+social:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+
 logging:
   level:
-    org.springframework.web: debug
+    org.springframework.web: info
     org.springframework.web.client.DefaultRestClient: OFF
 
 springdoc:

--- a/src/main/resources/templates/mail/verificationEmail.html
+++ b/src/main/resources/templates/mail/verificationEmail.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', Dotum, '돋움', sans-serif;">
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #f4f4f4;">
+    <tr>
+        <td align="center">
+            <table width="600" border="0" cellspacing="0" cellpadding="0"
+                   style="max-width: 600px; margin: 20px auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 10px rgba(0,0,0,0.1);">
+
+                <tr>
+                    <td style="padding: 40px 30px;">
+                        <h2 style="margin: 0 0 20px 0; font-size: 24px; font-weight: 600; color: #333333;">이메일 인증 코드를
+                            확인해주세요.</h2>
+                        <p style="margin: 0 0 30px 0; font-size: 16px; line-height: 1.5; color: #555555;">
+                            안녕하세요. Solmate에 가입해주셔서 감사합니다.<br>
+                            아래 인증 코드를 입력하여 이메일 인증을 완료해주세요.
+                        </p>
+
+                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                                <td align="center"
+                                    style="padding: 20px; background-color: #f9f9f9; border-radius: 4px;">
+                                    <span style="font-size: 32px; font-weight: bold; color: #016794; letter-spacing: 8px;"
+                                          th:text="${verificationCode}"> 123456 </span>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <p style="margin: 30px 0 0 0; font-size: 14px; color: #888888;">
+                            * 이 인증 코드는 5분 동안 유효합니다.<br>
+                            * 본인이 요청하지 않은 인증 메일이라면 이 메일을 무시해주세요.
+                        </p>
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #11

## 💡 작업 배경
회원가입 시 실제 이메일인지에 대한 여부를 확인하기 위한 이메일 인증 플로우 구현이 필요했다. 
이로 인해 인증되지 않은 이메일로는 회원가입이 불가능하도록 제한하는 기능이 필요해졌다.


## 🧩 작업 내용
이메일 인증 구현
  - EmailVerification 엔티티 및 EmailVerificationRepository 추가
  - EmailSender - Google SMTP , Thymeleaf 템플릿 기반 인증 메일 발송
  - EmailVerificationService - 인증 코드 발급 / 검증 / 만료 처리 
  - 인증 코드 6자리 랜덤 생성, 유효시간 5분
  - Gmail SMTP 설정 

  API 추가 (/api/auth)
  - GET /nickname/check - 닉네임 중복 확인
  - POST /email/send - 인증 메일 발송
  - POST /email/verify - 인증 코드 확인
  - POST /signup - 이메일 인증 완료된 경우에만 회원가입 허용


## 📸 스크린샷(선택)
<img width="963" height="779" alt="Screenshot 2026-03-18 at 11 09 36 PM" src="https://github.com/user-attachments/assets/e5ca45a4-bb30-4558-90ef-0041840fde41" />
<img width="967" height="569" alt="Screenshot 2026-03-18 at 11 09 44 PM" src="https://github.com/user-attachments/assets/8b082459-3cc9-431d-93c5-eadc25a26c18" />
<img width="1023" height="747" alt="Screenshot 2026-03-18 at 11 14 42 PM" src="https://github.com/user-attachments/assets/dc1a79d5-38a4-476b-b34d-2f291f2f6061" />
<img width="959" height="412" alt="Screenshot 2026-03-18 at 11 15 05 PM" src="https://github.com/user-attachments/assets/7db3e23e-1cf7-4502-bdc1-a2cb85abd59a" />
<img width="1001" height="758" alt="Screenshot 2026-03-18 at 11 22 12 PM" src="https://github.com/user-attachments/assets/a040557e-0adc-484e-87d9-5d39d859a7fa" />


## 📝 기타
application-prod.yml 은 노션에 환경 변수 업데이트 해놓았습니다. 확인부탁드립니다~
