### PR TITLE
[Fix] Google 소셜 로그인 시 provider_token 컬럼 길이 초과 오류 수정

### DIFF
--- a/src/main/java/org/solmate/domain/auth/entity/Token.java
+++ b/src/main/java/org/solmate/domain/auth/entity/Token.java
@@ -29,7 +29,7 @@ public class Token {
     @JoinColumn(name = "login_type_id", nullable = false)
     private LoginType loginType;
 
-    @Column(name = "provider_token")
+    @Column(name = "provider_token", columnDefinition = "TEXT")
     private String providerToken;
 
     @Builder


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #14 

## 💡 작업 배경
Google OAuth 로그인 시 token 테이블에 provider_token 저장 실패 이슈 해결
Token 엔티티의 providerToken 컬럼이 기본값 varchar(255)로 생성됨
Google OAuth access_token / id_token은 255자를 초과하는 경우 발생

## 🧩 작업 내용
Token.java의 providerToken 컬럼에 columnDefinition = "TEXT" 추가  

