### PR TITLE
[Feat] 종목 시세 조회 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     //email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    //websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
@@ -43,6 +43,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 
     // Springdoc OpenAPI (Swagger)
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
@@ -61,6 +62,7 @@ dependencies {
 
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/solmate/common/config/SecurityConfig.java
+++ b/src/main/java/org/solmate/common/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
 				.requestMatchers("/api/auth/**").permitAll()
 				.requestMatchers("/api/test/**").permitAll()
 				.requestMatchers("/ws/**").permitAll()
+				.requestMatchers("/static/**", "/*.html").permitAll()
+				.requestMatchers("/api/stocks/**").permitAll()
 				.anyRequest().authenticated()
 			)
 			.sessionManagement(session ->

--- a/src/main/java/org/solmate/common/config/SecurityConfig.java
+++ b/src/main/java/org/solmate/common/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
 				.requestMatchers("/", "/swagger-ui/**", "/api-docs/**").permitAll()
 				.requestMatchers("/api/auth/**").permitAll()
 				.requestMatchers("/api/test/**").permitAll()
+				.requestMatchers("/ws/**").permitAll()
 				.anyRequest().authenticated()
 			)
 			.sessionManagement(session ->

--- a/src/main/java/org/solmate/common/config/WebSocketConfig.java
+++ b/src/main/java/org/solmate/common/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package org.solmate.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -4,9 +4,12 @@ import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.stock.dto.response.StockQuoteResponse;
 import org.solmate.domain.stock.service.StockService;
+import org.solmate.external.ls.websocket.LsWebSocketClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,11 +24,26 @@ import lombok.RequiredArgsConstructor;
 public class StockController {
 
     private final StockService stockService;
+    private final LsWebSocketClient lsWebSocketClient;
 
     @Operation(summary = "주식 현재가 조회")
     @GetMapping("/{stockCode}/quote")
     public ResponseEntity<ApiResponse<StockQuoteResponse>> getQuote(@PathVariable String stockCode) {
         StockQuoteResponse response = stockService.getQuote(stockCode);
         return ApiResponse.success(SuccessStatus.SUCCESS_200, response);
+    }
+
+    @Operation(summary = "주식 실시간 시세 구독")
+    @PostMapping("/{stockCode}/subscribe")
+    public ResponseEntity<ApiResponse<Void>> subscribe(@PathVariable String stockCode) {
+        lsWebSocketClient.subscribe(stockCode);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+
+    @Operation(summary = "주식 실시간 시세 구독 해제")
+    @DeleteMapping("/{stockCode}/subscribe")
+    public ResponseEntity<ApiResponse<Void>> unsubscribe(@PathVariable String stockCode) {
+        lsWebSocketClient.unsubscribe(stockCode);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/repository/MinuteCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/MinuteCandleRepository.java
@@ -1,0 +1,7 @@
+package org.solmate.domain.stock.repository;
+
+import org.solmate.domain.stock.entity.MinuteCandle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MinuteCandleRepository extends JpaRepository<MinuteCandle, Long> {
+}

--- a/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
@@ -1,0 +1,30 @@
+package org.solmate.domain.stock.scheduler;
+
+import java.util.Set;
+
+import org.solmate.domain.stock.service.CandleAccumulatorService;
+import org.solmate.external.ls.websocket.LsWebSocketClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class CandleScheduler {
+
+    private final CandleAccumulatorService candleAccumulatorService;
+    private final LsWebSocketClient lsWebSocketClient;
+
+    // 매 분 00초에 실행
+    @Scheduled(cron = "0 * * * * *")
+    public void flushMinuteCandles() {
+        Set<String> subscribedCodes = lsWebSocketClient.getSubscribedCodes();
+        log.info("1분봉 스케줄러 실행 - 구독 종목 수: {}", subscribedCodes.size());
+        subscribedCodes.forEach(candleAccumulatorService::flushToDb);
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -1,0 +1,85 @@
+package org.solmate.domain.stock.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+import org.solmate.domain.stock.entity.MinuteCandle;
+import org.solmate.domain.stock.repository.MinuteCandleRepository;
+import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CandleAccumulatorService {
+
+    private static final String CANDLE_KEY_PREFIX = "candle:1min:";
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+
+    private final StringRedisTemplate redisTemplate;
+    private final MinuteCandleRepository minuteCandleRepository;
+
+    public void accumulate(LsWsStockResponse.Body body) {
+        String stockCode = body.shcode();
+        long price = Long.parseLong(body.price().trim());
+        long cvolume = Long.parseLong(body.cvolume().trim());
+        String key = CANDLE_KEY_PREFIX + stockCode;
+
+        Map<Object, Object> current = redisTemplate.opsForHash().entries(key);
+
+        if (current.isEmpty()) {
+
+            redisTemplate.opsForHash().putAll(key, Map.of(
+                    "open", String.valueOf(price),
+                    "high", String.valueOf(price),
+                    "low", String.valueOf(price),
+                    "close", String.valueOf(price),
+                    "volume", String.valueOf(cvolume),
+                    "startTime", LocalDateTime.now().format(TIME_FORMATTER)
+            ));
+        } else {
+            long high = Math.max(price, Long.parseLong((String) current.get("high")));
+            long low = Math.min(price, Long.parseLong((String) current.get("low")));
+            long volume = Long.parseLong((String) current.get("volume")) + cvolume;
+
+            redisTemplate.opsForHash().putAll(key, Map.of(
+                    "high", String.valueOf(high),
+                    "low", String.valueOf(low),
+                    "close", String.valueOf(price),
+                    "volume", String.valueOf(volume)
+            ));
+        }
+    }
+
+    public void flushToDb(String stockCode) {
+        String key = CANDLE_KEY_PREFIX + stockCode;
+        Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
+        if (data.isEmpty()) return;
+
+        try {
+            String startTime = (String) data.get("startTime");
+            LocalDateTime candleTime = LocalDateTime.parse(startTime, TIME_FORMATTER);
+
+            MinuteCandle candle = MinuteCandle.builder()
+                    .stockCode(stockCode)
+                    .openPrice(Long.parseLong((String) data.get("open")))
+                    .highPrice(Long.parseLong((String) data.get("high")))
+                    .lowPrice(Long.parseLong((String) data.get("low")))
+                    .closePrice(Long.parseLong((String) data.get("close")))
+                    .volume(Long.parseLong((String) data.get("volume")))
+                    .candleTime(candleTime)
+                    .build();
+
+            minuteCandleRepository.save(candle);
+            redisTemplate.delete(key);
+            log.info("1분봉 저장 완료: {} {}", stockCode, candleTime);
+        } catch (Exception e) {
+            log.error("1분봉 저장 실패: {}", stockCode, e);
+        }
+    }
+}

--- a/src/main/java/org/solmate/external/ls/LsProperties.java
+++ b/src/main/java/org/solmate/external/ls/LsProperties.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 public class LsProperties {
 
     private String baseUrl;
+    private String wsUrl;
     private String appKey;
     private String appSecret;
 }

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
@@ -1,0 +1,22 @@
+package org.solmate.external.ls.dto.websocket;
+
+public record LsWsRequest(Header header, Body body) {
+
+    public record Header(String token, String tr_type) {}
+
+    public record Body(String tr_cd, String tr_key) {}
+
+    public static LsWsRequest subscribe(String token, String stockCode) {
+        return new LsWsRequest(
+                new Header(token, "3"),
+                new Body("S3_", stockCode)
+        );
+    }
+
+    public static LsWsRequest unsubscribe(String token, String stockCode) {
+        return new LsWsRequest(
+                new Header(token, "4"),
+                new Body("S3_", stockCode)
+        );
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsStockResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsStockResponse.java
@@ -1,0 +1,26 @@
+package org.solmate.external.ls.dto.websocket;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsWsStockResponse(Header header, Body body) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Header(String tr_cd, String tr_key) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Body(
+            String shcode,      // 단축코드
+            String chetime,     // 체결시간 (HHMMSS)
+            String price,       // 현재가(체결가)
+            String cvolume,     // 체결량
+            String volume,      // 누적거래량
+            String value,       // 누적거래대금
+            String open,        // 시가
+            String high,        // 고가
+            String low,         // 저가
+            String sign,        // 전일대비구분
+            String change,      // 전일대비
+            String drate        // 등락율
+    ) {}
+}

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -1,0 +1,109 @@
+package org.solmate.external.ls.websocket;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.solmate.domain.stock.service.CandleAccumulatorService;
+import org.solmate.external.ls.LsProperties;
+import org.solmate.external.ls.dto.websocket.LsWsRequest;
+import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
+import org.solmate.external.ls.service.LsTokenService;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LsWebSocketClient extends TextWebSocketHandler {
+
+    private final LsProperties lsProperties;
+    private final LsTokenService lsTokenService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final CandleAccumulatorService candleAccumulatorService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private WebSocketSession session;
+    private final Set<String> subscribedCodes = ConcurrentHashMap.newKeySet();
+
+    public Set<String> getSubscribedCodes() {
+        return subscribedCodes;
+    }
+
+    @PostConstruct
+    public void connect() {
+        try {
+            StandardWebSocketClient client = new StandardWebSocketClient();
+            client.execute(this, lsProperties.getWsUrl()).whenComplete((sess, ex) -> {
+                if (ex != null) {
+                    log.error("LS WebSocket 연결 실패", ex);
+                } else {
+                    this.session = sess;
+                    log.info("LS WebSocket 연결 성공");
+                }
+            });
+        } catch (Exception e) {
+            log.error("LS WebSocket 연결 오류", e);
+        }
+    }
+
+    public void subscribe(String stockCode) {
+        if (subscribedCodes.contains(stockCode)) return;
+        sendMessage(LsWsRequest.subscribe(lsTokenService.getToken(), stockCode));
+        subscribedCodes.add(stockCode);
+        log.info("LS WebSocket 구독: {}", stockCode);
+    }
+
+    public void unsubscribe(String stockCode) {
+        if (!subscribedCodes.contains(stockCode)) return;
+        sendMessage(LsWsRequest.unsubscribe(lsTokenService.getToken(), stockCode));
+        subscribedCodes.remove(stockCode);
+        log.info("LS WebSocket 구독 해제: {}", stockCode);
+    }
+
+    private void sendMessage(LsWsRequest request) {
+        try {
+            if (session == null || !session.isOpen()) {
+                log.warn("LS WebSocket 세션이 열려있지 않습니다.");
+                return;
+            }
+            String json = objectMapper.writeValueAsString(request);
+            session.sendMessage(new TextMessage(json));
+        } catch (IOException e) {
+            log.error("LS WebSocket 메시지 전송 실패", e);
+        }
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+        try {
+            log.info("LS WebSocket 수신: {}", message.getPayload());
+            LsWsStockResponse response = objectMapper.readValue(message.getPayload(), LsWsStockResponse.class);
+            if (response.header() == null || response.body() == null) return;
+
+            String stockCode = response.header().tr_key();
+            candleAccumulatorService.accumulate(response.body());
+            messagingTemplate.convertAndSend("/topic/stocks/" + stockCode, response.body());
+        } catch (Exception e) {
+            log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        log.warn("LS WebSocket 연결 종료: {}", status);
+        this.session = null;
+        subscribedCodes.clear();
+    }
+}

--- a/src/main/resources/static/ws-test.html
+++ b/src/main/resources/static/ws-test.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>실시간 시세 테스트</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body { font-family: monospace; padding: 20px; background: #1a1a1a; color: #00ff00; }
+        input, button { padding: 8px; margin: 4px; font-size: 14px; }
+        #log { margin-top: 20px; border: 1px solid #333; padding: 10px; height: 500px; overflow-y: auto; }
+        .msg { border-bottom: 1px solid #333; padding: 4px 0; }
+    </style>
+</head>
+<body>
+    <h2>실시간 주식 시세 테스트</h2>
+    <input id="stockCode" type="text" value="005930" placeholder="종목코드" />
+    <button onclick="subscribe()">구독</button>
+    <button onclick="unsubscribe()">구독해제</button>
+    <button onclick="clearLog()">초기화</button>
+    <div id="status">연결 중...</div>
+    <div id="log"></div>
+
+    <script>
+        let stompClient = null;
+        let subscription = null;
+
+        const socket = new SockJS('http://localhost:8080/ws');
+        stompClient = Stomp.over(socket);
+        stompClient.debug = null;
+
+        stompClient.connect({}, function () {
+            document.getElementById('status').innerText = '✅ STOMP 연결됨';
+        }, function (err) {
+            document.getElementById('status').innerText = '❌ 연결 실패: ' + err;
+        });
+
+        function subscribe() {
+            const code = document.getElementById('stockCode').value;
+
+            // 백엔드에 LS WebSocket 구독 요청
+            fetch(`http://localhost:8080/api/stocks/${code}/subscribe`, { method: 'POST' });
+
+            // STOMP 토픽 구독
+            subscription = stompClient.subscribe(`/topic/stocks/${code}`, function (msg) {
+                const data = JSON.parse(msg.body);
+                const now = new Date().toLocaleTimeString();
+                const div = document.createElement('div');
+                div.className = 'msg';
+                div.innerHTML = `[${now}] 종목: ${data.shcode} | 현재가: <b>${data.price}</b> | 체결량: ${data.cvolume} | 체결시간: ${data.chetime}`;
+                const log = document.getElementById('log');
+                log.prepend(div);
+            });
+
+            document.getElementById('status').innerText = `✅ ${code} 구독 중`;
+        }
+
+        function unsubscribe() {
+            const code = document.getElementById('stockCode').value;
+            fetch(`http://localhost:8080/api/stocks/${code}/subscribe`, { method: 'DELETE' });
+            if (subscription) subscription.unsubscribe();
+            document.getElementById('status').innerText = '구독 해제됨';
+        }
+
+        function clearLog() {
+            document.getElementById('log').innerHTML = '';
+        }
+    </script>
+</body>
+</html>

--- a/src/main/resources/static/ws-test.html
+++ b/src/main/resources/static/ws-test.html
@@ -47,7 +47,7 @@
                 const now = new Date().toLocaleTimeString();
                 const div = document.createElement('div');
                 div.className = 'msg';
-                div.innerHTML = `[${now}] 종목: ${data.shcode} | 현재가: <b>${data.price}</b> | 체결량: ${data.cvolume} | 체결시간: ${data.chetime}`;
+                div.innerHTML = `[${data.chetime}] ${data.stockCode} | 현재가: <b>${data.currentPrice}</b> | 전일대비: ${data.changePrice} (${data.changeRate}%) | 고가: ${data.highPrice} | 저가: ${data.lowPrice} | 거래량: ${data.volume}`;
                 const log = document.getElementById('log');
                 log.prepend(div);
             });


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #19

## 💡 작업 배경
  LS 증권 WebSocket API를 활용하여 주식 실시간 체결 데이터를 수신하고, 프론트엔드에 STOMP로 브로드캐스트하는 실시간 시세 기능 구현

## 🧩 작업 내용
- 실시간 WebSocket 연동                                                         
  - LsWebSocketClient: LS 증권 WebSocket(US3 통합체결) 연결 및 구독/해제      
  - 연결 종료 시 자동 재연결 + 토큰 캐시 삭제 후 신규 토큰 발급                 
  - 재연결 시 기존 구독 종목 자동 재구독                                      
                                                                                
 -  STOMP 브로드캐스트                                                            
    - WebSocketConfig: 프론트엔드용 STOMP /ws 엔드포인트 설정                     
    - /topic/stocks/{stockCode}로 StockRealtimeResponse 브로드캐스트              
    - REST(최초 진입) / WebSocket(실시간 변동) 역할 분리                          
                                                                                  
-   1분봉 저장                                                                    
    - CandleAccumulatorService: tick 수신 시 Redis에 OHLCV 누적                   
    - CandleScheduler: 매 분 00초에 Redis → PostgreSQL MinuteCandle 저장          
                                                                                  
-  구독 API                                                                      
    - POST /api/stocks/{stockCode}/subscribe: 실시간 구독 시작                    
    - DELETE /api/stocks/{stockCode}/subscribe: 구독 해제 

## 📸 스크린샷(선택)
<img width="1108" height="786" alt="Screenshot 2026-03-20 at 9 11 33 AM" src="https://github.com/user-attachments/assets/ec5eba54-558c-491e-8bd1-b39a860a531c" />


<img width="772" height="553" alt="Screenshot 2026-03-20 at 9 11 44 AM" src="https://github.com/user-attachments/assets/e12d6f75-3052-48c9-87fe-76fe4d08646e" />

## 📝 기타
