### PR TITLE
[Feat] 통합 체결가(US3)로 restapi, websocket으로 데이터 받아오도록 구현

### DIFF
--- a/src/main/java/org/solmate/domain/stock/dto/response/StockRealtimeResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockRealtimeResponse.java
@@ -1,0 +1,27 @@
+package org.solmate.domain.stock.dto.response;
+
+import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
+
+public record StockRealtimeResponse(
+        String stockCode,
+        long currentPrice,
+        long changePrice,
+        double changeRate,
+        long highPrice,
+        long lowPrice,
+        long volume,
+        String chetime
+) {
+    public static StockRealtimeResponse from(LsWsStockResponse.Body body) {
+        return new StockRealtimeResponse(
+                body.shcode(),
+                Long.parseLong(body.price().trim()),
+                Long.parseLong(body.change().trim()),
+                Double.parseDouble(body.drate().trim()),
+                Long.parseLong(body.high().trim()),
+                Long.parseLong(body.low().trim()),
+                Long.parseLong(body.volume().trim()),
+                body.chetime()
+        );
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
@@ -9,14 +9,14 @@ public record LsWsRequest(Header header, Body body) {
     public static LsWsRequest subscribe(String token, String stockCode) {
         return new LsWsRequest(
                 new Header(token, "3"),
-                new Body("S3_", stockCode)
+                new Body("US3", String.format("U%-9s", stockCode))
         );
     }
 
     public static LsWsRequest unsubscribe(String token, String stockCode) {
         return new LsWsRequest(
                 new Header(token, "4"),
-                new Body("S3_", stockCode)
+                new Body("US3", String.format("U%-9s", stockCode))
         );
     }
 }

--- a/src/main/java/org/solmate/external/ls/service/LsTokenService.java
+++ b/src/main/java/org/solmate/external/ls/service/LsTokenService.java
@@ -35,6 +35,11 @@ public class LsTokenService {
         return issueToken();
     }
 
+    public void clearToken() {
+        redisTemplate.delete(REDIS_TOKEN_KEY);
+        log.info("LS 토큰 캐시 삭제");
+    }
+
     private String issueToken() {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "client_credentials");

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -3,7 +3,11 @@ package org.solmate.external.ls.websocket;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
+import org.solmate.domain.stock.dto.response.StockRealtimeResponse;
 import org.solmate.domain.stock.service.CandleAccumulatorService;
 import org.solmate.external.ls.LsProperties;
 import org.solmate.external.ls.dto.websocket.LsWsRequest;
@@ -33,6 +37,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     private final SimpMessagingTemplate messagingTemplate;
     private final CandleAccumulatorService candleAccumulatorService;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ScheduledExecutorService reconnectScheduler = Executors.newSingleThreadScheduledExecutor();
 
     private WebSocketSession session;
     private final Set<String> subscribedCodes = ConcurrentHashMap.newKeySet();
@@ -48,14 +53,29 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             client.execute(this, lsProperties.getWsUrl()).whenComplete((sess, ex) -> {
                 if (ex != null) {
                     log.error("LS WebSocket 연결 실패", ex);
+                    scheduleReconnect();
                 } else {
                     this.session = sess;
                     log.info("LS WebSocket 연결 성공");
+                    resubscribeAll();
                 }
             });
         } catch (Exception e) {
             log.error("LS WebSocket 연결 오류", e);
+            scheduleReconnect();
         }
+    }
+
+    private void scheduleReconnect() {
+        log.info("LS WebSocket 5초 후 재연결 시도");
+        reconnectScheduler.schedule(this::connect, 5, TimeUnit.SECONDS);
+    }
+
+    private void resubscribeAll() {
+        if (subscribedCodes.isEmpty()) return;
+        log.info("LS WebSocket 재구독 시도: {}", subscribedCodes);
+        String token = lsTokenService.getToken();
+        subscribedCodes.forEach(code -> sendMessage(LsWsRequest.subscribe(token, code)));
     }
 
     public void subscribe(String stockCode) {
@@ -79,6 +99,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                 return;
             }
             String json = objectMapper.writeValueAsString(request);
+            log.info("LS WebSocket 전송: {}", json);
             session.sendMessage(new TextMessage(json));
         } catch (IOException e) {
             log.error("LS WebSocket 메시지 전송 실패", e);
@@ -92,9 +113,9 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             LsWsStockResponse response = objectMapper.readValue(message.getPayload(), LsWsStockResponse.class);
             if (response.header() == null || response.body() == null) return;
 
-            String stockCode = response.header().tr_key();
+            String stockCode = response.body().shcode();
             candleAccumulatorService.accumulate(response.body());
-            messagingTemplate.convertAndSend("/topic/stocks/" + stockCode, response.body());
+            messagingTemplate.convertAndSend("/topic/stocks/" + stockCode, StockRealtimeResponse.from(response.body()));
         } catch (Exception e) {
             log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());
         }
@@ -104,6 +125,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         log.warn("LS WebSocket 연결 종료: {}", status);
         this.session = null;
-        subscribedCodes.clear();
+        lsTokenService.clearToken();
+        scheduleReconnect();
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #19

## 💡 작업 배경
  LS 증권 WebSocket API를 활용하여 주식 실시간 체결 데이터를 수신하고, 프론트엔드에 STOMP로 브로드캐스트하는 실시간 시세 기능 구현

## 🧩 작업 내용
- 실시간 WebSocket 연동                                                         
  - LsWebSocketClient: LS 증권 WebSocket(US3 통합체결) 연결 및 구독/해제      
  - 연결 종료 시 자동 재연결 + 토큰 캐시 삭제 후 신규 토큰 발급                 
  - 재연결 시 기존 구독 종목 자동 재구독                                      
                                                                                
 -  STOMP 브로드캐스트                                                            
    - WebSocketConfig: 프론트엔드용 STOMP /ws 엔드포인트 설정                     
    - /topic/stocks/{stockCode}로 StockRealtimeResponse 브로드캐스트              
    - REST(최초 진입) / WebSocket(실시간 변동) 역할 분리                          
                                                                                  
-   1분봉 저장                                                                    
    - CandleAccumulatorService: tick 수신 시 Redis에 OHLCV 누적                   
    - CandleScheduler: 매 분 00초에 Redis → PostgreSQL MinuteCandle 저장          
                                                                                  
-  구독 API                                                                      
    - POST /api/stocks/{stockCode}/subscribe: 실시간 구독 시작                    
    - DELETE /api/stocks/{stockCode}/subscribe: 구독 해제 

## 📸 스크린샷(선택)
<img width="1108" height="786" alt="Screenshot 2026-03-20 at 9 11 33 AM" src="https://github.com/user-attachments/assets/ec5eba54-558c-491e-8bd1-b39a860a531c" />


<img width="772" height="553" alt="Screenshot 2026-03-20 at 9 11 44 AM" src="https://github.com/user-attachments/assets/e12d6f75-3052-48c9-87fe-76fe4d08646e" />

## 📝 기타
