### PR TITLE
[Feat] 모의투자 체결 처리를 위한 엔티티 도메인 메서드 및 Repository 추가

### DIFF
--- a/src/main/java/org/solmate/domain/account/entity/Account.java
+++ b/src/main/java/org/solmate/domain/account/entity/Account.java
@@ -41,4 +41,12 @@ public class Account extends BaseEntity {
         this.user = user;
         this.cash = cash;
     }
+
+    public void addCash(BigDecimal amount) {
+        this.cash = this.cash.add(amount);
+    }
+
+    public void subtractCash(BigDecimal amount) {
+        this.cash = this.cash.subtract(amount);
+    }
 }

--- a/src/main/java/org/solmate/domain/account/repository/AccountRepository.java
+++ b/src/main/java/org/solmate/domain/account/repository/AccountRepository.java
@@ -1,0 +1,12 @@
+package org.solmate.domain.account.repository;
+
+import java.util.Optional;
+
+import org.solmate.domain.account.entity.Account;
+import org.solmate.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Optional<Account> findByUser(User user);
+}

--- a/src/main/java/org/solmate/domain/stock/repository/StockRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/StockRepository.java
@@ -1,0 +1,11 @@
+package org.solmate.domain.stock.repository;
+
+import java.util.Optional;
+
+import org.solmate.domain.stock.entity.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+    Optional<Stock> findByTickerCode(String tickerCode);
+}

--- a/src/main/java/org/solmate/domain/trade/entity/Holdings.java
+++ b/src/main/java/org/solmate/domain/trade/entity/Holdings.java
@@ -60,4 +60,17 @@ public class Holdings extends BaseEntity {
         this.avgPrice = avgPrice;
         this.returnRate = returnRate;
     }
+
+    public void updateQuantityAndAvgPrice(BigDecimal quantity, BigDecimal avgPrice) {
+        this.quantity = quantity;
+        this.avgPrice = avgPrice;
+    }
+
+    public void updateReturnRate(BigDecimal returnRate) {
+        this.returnRate = returnRate;
+    }
+
+    public void subtractQuantity(BigDecimal quantity) {
+        this.quantity = this.quantity.subtract(quantity);
+    }
 }

--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -66,4 +66,8 @@ public class TradeHistory extends BaseEntity {
         this.tradeType = tradeType;
         this.tradeStatus = tradeStatus;
     }
+
+    public void updateStatus(TradeStatus tradeStatus) {
+        this.tradeStatus = tradeStatus;
+    }
 }

--- a/src/main/java/org/solmate/domain/trade/repository/HoldingsRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/HoldingsRepository.java
@@ -1,0 +1,15 @@
+package org.solmate.domain.trade.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.solmate.domain.trade.entity.Holdings;
+import org.solmate.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HoldingsRepository extends JpaRepository<Holdings, Long> {
+
+    Optional<Holdings> findByUserAndTickerCode(User user, String tickerCode);
+
+    List<Holdings> findByUser(User user);
+}

--- a/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
@@ -1,0 +1,13 @@
+package org.solmate.domain.trade.repository;
+
+import java.util.List;
+
+import org.solmate.domain.trade.entity.TradeHistory;
+import org.solmate.domain.trade.enums.TradeStatus;
+import org.solmate.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeHistoryRepository extends JpaRepository<TradeHistory, Long> {
+
+    List<TradeHistory> findByUserAndTradeStatus(User user, TradeStatus tradeStatus);
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #

## 💡 작업 배경
모의투자 주문 체결 로직 구현을 위한 사전 준비 작업
체결/취소 처리 시 필요한 엔티티 도메인 메서드와 Repository를 추가

## 🧩 작업 내용
- 엔티티 도메인 메서드 추가 
  - **TradeHistory**: `updateStatus(TradeStatus)` - 주문 상태 변경 (PENDING → EXECUTED / CANCELLED)
  - **Holdings**: `updateQuantityAndAvgPrice(quantity, avgPrice)` - 매수 체결 시 보유 수량/평균단가 갱신                                                         
  - **Holdings**: `updateReturnRate(returnRate)` - 수익률 갱신                                                                                                   
  - **Holdings**: `subtractQuantity(quantity)` - 매도 주문 접수 시 보유 수량 선차감                                                                              
  - **Account**: `addCash(amount)` - 매도 체결 시 현금 입금                                                                                                      
  - **Account**: `subtractCash(amount)` - 매수 주문 접수 시 현금 선차감  
 
- Repository 추가
  | Repository | 위치 | 주요 쿼리 메서드 |                                                                                                                       
  |---|---|---|                                                                                                                                                  
  | `TradeHistoryRepository` | `domain/trade/repository/` | `findByUserAndTradeStatus()` |                                                                       
  | `HoldingsRepository` | `domain/trade/repository/` | `findByUserAndTickerCode()`, `findByUser()` |                                                            
  | `AccountRepository` | `domain/account/repository/` | `findByUser()` |                                                                                        
  | `StockRepository` | `domain/stock/repository/` | `findByTickerCode()` |    


