### PR TITLE
[Feat] 거래 주문 조회 및 취소 API 구현   

### DIFF
--- a/.run/SolmateApplication.run.xml
+++ b/.run/SolmateApplication.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SolmateApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ACTIVE_PROFILES" value="local" />
+    <module name="solmate.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="org.solmate.SolmateApplication" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=local" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/src/main/java/org/solmate/domain/trade/controller/TradeController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeController.java
@@ -1,0 +1,62 @@
+package org.solmate.domain.trade.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.trade.dto.response.TradeHistoryResponse;
+import org.solmate.domain.trade.service.TradeHistoryService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Trade", description = "주문 조회/취소 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class TradeController {
+
+    private final TradeHistoryService tradeHistoryService;
+
+    /**
+     * 거래 주문 목록 조회 (스크롤 기반)
+     */
+    @Operation(summary = "거래 주문 목록 조회")
+    @GetMapping("/stocks/{stockCode}/orders")
+    public ResponseEntity<ApiResponse<List<TradeHistoryResponse>>> getOrders(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "10") int limit,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime cursorCreatedAt,
+
+            @RequestParam(required = false)
+            Long cursorId
+    ) {
+        List<TradeHistoryResponse> response =
+                tradeHistoryService.getOrders(userId, stockCode, limit, cursorCreatedAt, cursorId);
+
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, response);
+    }
+
+    /**
+     * 주문 취소
+     */
+    @Operation(summary = "주문 취소")
+    @PatchMapping("/orders/{orderId}/cancel")
+    public ResponseEntity<ApiResponse<Void>> cancelOrder(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long orderId
+    ) {
+        tradeHistoryService.cancelOrder(userId, orderId);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
@@ -1,0 +1,45 @@
+package org.solmate.domain.trade.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.solmate.domain.trade.entity.TradeHistory;
+import org.solmate.domain.trade.enums.OrderType;
+import org.solmate.domain.trade.enums.TradeStatus;
+import org.solmate.domain.trade.enums.TradeType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TradeHistoryResponse {
+
+    private Long orderId;
+
+    private TradeType tradeType;
+    private OrderType orderType;
+
+    private BigDecimal price;
+    private BigDecimal quantity;
+    private BigDecimal totalAmount;
+
+    private TradeStatus tradeStatus;
+    private LocalDateTime createdAt;
+
+    private boolean cancelable;
+
+    public static TradeHistoryResponse from(TradeHistory entity) {
+        return TradeHistoryResponse.builder()
+                .orderId(entity.getId())
+                .tradeType(entity.getTradeType())
+                .orderType(entity.getOrderType())
+                .price(entity.getPrice())
+                .quantity(entity.getQuantity())
+                .totalAmount(entity.getPrice().multiply(entity.getQuantity()))
+                .tradeStatus(entity.getTradeStatus())
+                .createdAt(entity.getCreatedAt())
+                .cancelable(entity.getTradeStatus() == TradeStatus.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 import org.solmate.common.base.BaseEntity;
 import org.solmate.domain.stock.entity.Stock;
+import org.solmate.domain.trade.enums.OrderType;
 import org.solmate.domain.trade.enums.TradeStatus;
 import org.solmate.domain.trade.enums.TradeType;
 import org.solmate.domain.user.entity.User;
@@ -23,7 +24,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 @Entity
 @Table(name = "trade_history")
 @Getter
@@ -56,15 +56,20 @@ public class TradeHistory extends BaseEntity {
     @Column(name = "trade_status", nullable = false)
     private TradeStatus tradeStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_type", nullable = false)
+    private OrderType orderType;
+
     @Builder
     public TradeHistory(User user, Stock stock, BigDecimal price, BigDecimal quantity,
-                        TradeType tradeType, TradeStatus tradeStatus) {
+                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType) {
         this.user = user;
         this.stock = stock;
         this.price = price;
         this.quantity = quantity;
         this.tradeType = tradeType;
         this.tradeStatus = tradeStatus;
+        this.orderType = orderType;
     }
 
     public void updateStatus(TradeStatus tradeStatus) {

--- a/src/main/java/org/solmate/domain/trade/enums/OrderType.java
+++ b/src/main/java/org/solmate/domain/trade/enums/OrderType.java
@@ -1,0 +1,6 @@
+package org.solmate.domain.trade.enums;
+
+public enum OrderType {
+    MARKET,
+    LIMIT
+}


### PR DESCRIPTION
  #️ 관련 이슈                                                                                                                                                                
                                                                                                                                                                              
  closed #21                                                                                                                                                                  
                                                                                                                                                                              
  💡 작업 배경                                                                                                                                                                
                                                                                                                                                                              
  모의투자 기능 구현을 위해 거래 주문 조회 및 취소 API가 필요했습니다.                                                                                                        
  기존 TradeHistory 엔티티에 orderType 컬럼이 누락되어 있어 함께 추가했습니다.                                                                                                
                                                                                                                                                                              
  🧩 작업 내용                                                                                                                                                                
                                                                                                                                                                              
  - TradeHistory 엔티티에 order_type 컬럼 추가 (MARKET / LIMIT)                                                                                                               
  - TradeHistoryResponse DTO 생성 (주문 ID, 거래 유형, 가격, 수량, 총액, 상태, 취소 가능 여부 포함)                                                                         
  - TradeController 구현                                                                                                                                                      
    - GET /api/v1/stocks/{stockCode}/orders : 종목별 거래 주문 목록 조회 (커서 기반 스크롤)                                                                                 
    - PATCH /api/v1/orders/{orderId}/cancel : 주문 취소 (PENDING 상태만 가능)                                                                                                 
                                                                                                                                                                              
  📸 스크린샷(선택)                                                                                                                                                           
                                                                                                                                                                              
  📝 기타                                                                                                                                                                     
        