### PR TITLE
[Feat] TradeHistory order_type 필드 추가

### DIFF
--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 import org.solmate.common.base.BaseEntity;
 import org.solmate.domain.stock.entity.Stock;
+import org.solmate.domain.trade.enums.OrderType;
 import org.solmate.domain.trade.enums.TradeStatus;
 import org.solmate.domain.trade.enums.TradeType;
 import org.solmate.domain.user.entity.User;
@@ -56,15 +57,20 @@ public class TradeHistory extends BaseEntity {
     @Column(name = "trade_status", nullable = false)
     private TradeStatus tradeStatus;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_type", nullable = false)
+    private OrderType orderType;
+
     @Builder
     public TradeHistory(User user, Stock stock, BigDecimal price, BigDecimal quantity,
-                        TradeType tradeType, TradeStatus tradeStatus) {
+                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType) {
         this.user = user;
         this.stock = stock;
         this.price = price;
         this.quantity = quantity;
         this.tradeType = tradeType;
         this.tradeStatus = tradeStatus;
+        this.orderType = orderType;
     }
 
     public void updateStatus(TradeStatus tradeStatus) {

--- a/src/main/java/org/solmate/domain/trade/enums/OrderType.java
+++ b/src/main/java/org/solmate/domain/trade/enums/OrderType.java
@@ -1,0 +1,6 @@
+package org.solmate.domain.trade.enums;
+
+public enum OrderType {
+    MARKET,  // 시장가
+    LIMIT    // 지정가
+}


### PR DESCRIPTION
 ## #️⃣  관련 이슈
  closed #21
                                                                                                                
  ## 💡 작업 배경                                                                                               
  DB 설계에 따라 Trade_history 테이블에 시장가/지정가 구분 컬럼이 필요함                                        
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - `OrderType` enum 추가 (MARKET, LIMIT)                                                                       
  - `TradeHistory` 엔티티에 `order_type` 필드 추가                                                              
  - `@Builder` 생성자에 `orderType` 파라미터 추가                                                               
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
                                                                                                                
  ## 📝 기타