### PR TITLE
[Feat] 실시간 지수 조회 API

### DIFF
--- a/src/main/java/org/solmate/domain/market/controller/MarketIndicatorController.java
+++ b/src/main/java/org/solmate/domain/market/controller/MarketIndicatorController.java
@@ -1,0 +1,22 @@
+package org.solmate.domain.market.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.solmate.domain.market.dto.response.MarketIndicatorResponse;
+import org.solmate.domain.market.service.MarketIndicatorService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class MarketIndicatorController {
+
+    private final MarketIndicatorService marketIndicatorService;
+
+    @GetMapping("/market-indicators")
+    public ResponseEntity<MarketIndicatorResponse> getMarketIndicators() {
+        return ResponseEntity.ok(marketIndicatorService.getMarketIndicators());
+    }
+}

--- a/src/main/java/org/solmate/domain/market/dto/response/MarketIndicatorResponse.java
+++ b/src/main/java/org/solmate/domain/market/dto/response/MarketIndicatorResponse.java
@@ -1,0 +1,25 @@
+package org.solmate.domain.market.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MarketIndicatorResponse {
+
+    private IndexInfo kospi;
+    private IndexInfo kosdaq;
+    private IndexInfo usdKrw;
+
+    @Getter
+    @Builder
+    public static class IndexInfo {
+        private String cur;     // 현재 지수
+        private String change;  // 전일 대비 (pt)
+        private String rate;    // 등락률 (%)
+        private String sign;    // 부호 (1=상한, 2=상승, 3=보합, 4=하한, 5=하락)
+        private String high;    // 당일 고가
+        private String low;     // 당일 저가
+        private String asOf;    // 업데이트 시간 (HHMMSS)
+    }
+}

--- a/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
+++ b/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
@@ -1,0 +1,59 @@
+package org.solmate.domain.market.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.solmate.domain.market.dto.response.MarketIndicatorResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketIndicatorService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String KOSPI_KEY = "market:indicator:KOSPI";
+    private static final String KOSDAQ_KEY = "market:indicator:KOSDAQ";
+    private static final String USD_KRW_KEY = "market:indicator:USD_KRW";
+
+    public MarketIndicatorResponse getMarketIndicators() {
+        return MarketIndicatorResponse.builder()
+                .kospi(getIndexInfo(KOSPI_KEY))
+                .kosdaq(getIndexInfo(KOSDAQ_KEY))
+                .usdKrw(getIndexInfo(USD_KRW_KEY))
+                .build();
+    }
+
+    private MarketIndicatorResponse.IndexInfo getIndexInfo(String redisKey) {
+        try {
+            // Redis에서 JSON 문자열 조회
+            String json = stringRedisTemplate.opsForValue().get(redisKey);
+
+            // 데이터 없으면 null 반환
+            if (json == null) {
+                log.warn("Redis에 데이터 없음 - {}", redisKey);
+                return null;
+            }
+
+            // JSON 문자열 → IndexInfo 객체로 변환
+            JsonNode node = objectMapper.readTree(json);
+            return MarketIndicatorResponse.IndexInfo.builder()
+                    .cur(node.get("cur").asText())
+                    .change(node.get("change").asText())
+                    .rate(node.get("rate").asText())
+                    .sign(node.get("sign").asText())
+                    .high(node.get("high").asText())
+                    .low(node.get("low").asText())
+                    .asOf(node.get("asOf").asText())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("시장 지표 Redis 조회 실패 - {}: {}", redisKey, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsCurrencyResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsCurrencyResponse.java
@@ -1,0 +1,21 @@
+package org.solmate.external.ls.dto.websocket;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsWsCurrencyResponse(Header header, Body body) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Header(String tr_cd, String tr_key) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Body(
+            String time,    // 시간 (HHMMSS)
+            String price,   // 현재 환율
+            String sign,    // 전일대비구분
+            String change,  // 전일 대비
+            String drate,   // 등락률
+            String high,    // 당일 고가
+            String low      // 당일 저가
+    ) {}
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsIndexResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsIndexResponse.java
@@ -1,0 +1,21 @@
+package org.solmate.external.ls.dto.websocket;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsWsIndexResponse(Header header, Body body) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Header(String tr_cd, String tr_key) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Body(
+            String time,        // 시간 (HHMMSS)
+            String jisu,        // 현재 지수
+            String sign,        // 전일대비구분
+            String change,      // 전일비
+            String drate,       // 등락률
+            String highjisu,    // 고가지수
+            String lowjisu      // 저가지수
+    ) {}
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
@@ -19,4 +19,32 @@ public record LsWsRequest(Header header, Body body) {
                 new Body("US3", String.format("U%-9s", stockCode))
         );
     }
+
+    public static LsWsRequest subscribeIndex(String token, String indexCode) {
+        return new LsWsRequest(
+                new Header(token, "3"),
+                new Body("IJ_", indexCode)
+        );
+    }
+
+    public static LsWsRequest unsubscribeIndex(String token, String indexCode) {
+        return new LsWsRequest(
+                new Header(token, "4"),
+                new Body("IJ_", indexCode)
+        );
+    }
+
+    public static LsWsRequest subscribeCurrency(String token, String currencyCode) {
+        return new LsWsRequest(
+                new Header(token, "3"),
+                new Body("CUR", String.format("%-6s", currencyCode))
+        );
+    }
+
+    public static LsWsRequest unsubscribeCurrency(String token, String currencyCode) {
+        return new LsWsRequest(
+                new Header(token, "4"),
+                new Body("CUR", String.format("%-6s", currencyCode))
+        );
+    }
 }

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -27,6 +27,10 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.solmate.external.ls.dto.websocket.LsWsIndexResponse;
+import org.solmate.external.ls.dto.websocket.LsWsCurrencyResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -46,6 +50,12 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         return subscribedCodes;
     }
 
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String KOSPI_REDIS_KEY = "market:indicator:KOSPI";
+    private static final String KOSDAQ_REDIS_KEY = "market:indicator:KOSDAQ";
+    private static final String USD_KRW_REDIS_KEY = "market:indicator:USD_KRW";
+
     @PostConstruct
     public void connect() {
         try {
@@ -58,6 +68,11 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                     this.session = sess;
                     log.info("LS WebSocket 연결 성공");
                     resubscribeAll();
+
+                    String token = lsTokenService.getToken();
+                    sendMessage(LsWsRequest.subscribeIndex(token, "001")); // KOSPI
+                    sendMessage(LsWsRequest.subscribeIndex(token, "301")); // KOSDAQ
+                    sendMessage(LsWsRequest.subscribeCurrency(token, "USD")); // 환율
                 }
             });
         } catch (Exception e) {
@@ -110,14 +125,88 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
             log.info("LS WebSocket 수신: {}", message.getPayload());
+
+            // tr_cd 먼저 확인
+            var root = objectMapper.readTree(message.getPayload());
+            var header = root.get("header");
+            if (header == null || root.get("body") == null || root.get("body").isNull()) return;
+
+            String trCd = header.get("tr_cd") != null ? header.get("tr_cd").asText() : "";
+
+            // 지수 데이터 처리
+            if ("IJ_".equals(trCd)) {
+                LsWsIndexResponse response = objectMapper.readValue(message.getPayload(), LsWsIndexResponse.class);
+                handleIndexMessage(response);
+                return;
+            }
+
+            // 환율 추가
+            if ("CUR".equals(trCd)) {
+                LsWsCurrencyResponse response = objectMapper.readValue(message.getPayload(), LsWsCurrencyResponse.class);
+                handleCurrencyMessage(response);
+                return;
+            }
+
+            // 종목 데이터 처리 (기존 코드)
             LsWsStockResponse response = objectMapper.readValue(message.getPayload(), LsWsStockResponse.class);
             if (response.header() == null || response.body() == null) return;
 
             String stockCode = response.body().shcode();
             candleAccumulatorService.accumulate(response.body());
             messagingTemplate.convertAndSend("/topic/stocks/" + stockCode, StockRealtimeResponse.from(response.body()));
+
         } catch (Exception e) {
             log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());
+        }
+    }
+
+    // 지수 처리 메서드 추가
+    private void handleIndexMessage(LsWsIndexResponse response) {
+        try {
+            if (response.body() == null) return;
+
+            String trKey = response.header().tr_key();
+            String redisKey = "001".equals(trKey) ? KOSPI_REDIS_KEY : KOSDAQ_REDIS_KEY;
+
+            String json = objectMapper.writeValueAsString(
+                    objectMapper.createObjectNode()
+                            .put("cur", response.body().jisu())
+                            .put("change", response.body().change())
+                            .put("rate", response.body().drate())
+                            .put("sign", response.body().sign())
+                            .put("high", response.body().highjisu())
+                            .put("low", response.body().lowjisu())
+                            .put("asOf", response.body().time())
+            );
+
+            stringRedisTemplate.opsForValue().set(redisKey, json);
+            log.info("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
+
+        } catch (Exception e) {
+            log.error("시장 지표 Redis 저장 실패: {}", e.getMessage());
+        }
+    }
+
+    private void handleCurrencyMessage(LsWsCurrencyResponse response) {
+        try {
+            if (response.body() == null) return;
+
+            String json = objectMapper.writeValueAsString(
+                    objectMapper.createObjectNode()
+                            .put("cur", response.body().price())
+                            .put("change", response.body().change())
+                            .put("rate", response.body().drate())
+                            .put("sign", response.body().sign())
+                            .put("high", response.body().high())
+                            .put("low", response.body().low())
+                            .put("asOf", response.body().time())
+            );
+
+            stringRedisTemplate.opsForValue().set(USD_KRW_REDIS_KEY, json);
+            log.info("환율 Redis 저장 완료 - {}: {}", USD_KRW_REDIS_KEY, json);
+
+        } catch (Exception e) {
+            log.error("환율 Redis 저장 실패: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #27 

## 💡 작업 배경
1. LS 웹소켓 지수/환율 구독 추가 (LsWsRequest.java)
subscribeIndex() / unsubscribeIndex() 메서드 추가 (KOSPI, KOSDAQ)
subscribeCurrency() / unsubscribeCurrency() 메서드 추가 (USD/KRW)

2. LS 웹소켓 응답 DTO 추가
LsWsIndexResponse.java - 지수 응답 파싱 (IJ_ TR)
LsWsCurrencyResponse.java - 환율 응답 파싱 (CUR TR)

3. LS 웹소켓 클라이언트 수정 (LsWebSocketClient.java)
앱 시작 시 KOSPI(001), KOSDAQ(301), USD/KRW 자동 구독
handleTextMessage()에 IJ_, CUR TR 분기 처리 추가
handleIndexMessage() - 지수 데이터 Redis 저장
handleCurrencyMessage() - 환율 데이터 Redis 저장

4. 시장 지표 조회 API 구현
MarketIndicatorResponse.java - 응답 DTO (kospi, kosdaq, usdKrw)
MarketIndicatorService.java - Redis에서 시장 지표 조회
MarketIndicatorController.java - GET /api/v1/market-indicators 엔드포인트

## 🧩 작업 내용
Redis 저장 구조
```
Key: market:indicator:KOSPI
Key: market:indicator:KOSDAQ
Key: market:indicator:USD_KRW
Value: {"cur":"...", "change":"...", "rate":"...", "sign":"...", "high":"...", "low":"...", "asOf":"..."}
```

## 📸 스크린샷(선택)


## 📝 기타
