### PR TITLE
[refactor] 지수 API 폴더 분리

### DIFF
--- a/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
+++ b/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
@@ -1,10 +1,11 @@
 package org.solmate.domain.market.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.solmate.domain.market.dto.response.MarketIndicatorResponse;
+import org.solmate.external.ls.dto.websocket.LsWsCurrencyResponse;
+import org.solmate.external.ls.dto.websocket.LsWsIndexResponse;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,7 @@ public class MarketIndicatorService {
     private static final String KOSDAQ_KEY = "market:indicator:KOSDAQ";
     private static final String USD_KRW_KEY = "market:indicator:USD_KRW";
 
+    // 조회
     public MarketIndicatorResponse getMarketIndicators() {
         return MarketIndicatorResponse.builder()
                 .kospi(getIndexInfo(KOSPI_KEY))
@@ -28,19 +30,66 @@ public class MarketIndicatorService {
                 .build();
     }
 
+    // 지수 Redis 저장 (LsWebSocketClient에서 호출)
+    public void saveIndex(LsWsIndexResponse response) {
+        try {
+            if (response.body() == null) return;
+
+            String trKey = response.header().tr_key();
+            String redisKey = "001".equals(trKey) ? KOSPI_KEY : KOSDAQ_KEY;
+
+            String json = objectMapper.writeValueAsString(
+                    objectMapper.createObjectNode()
+                            .put("cur", response.body().jisu())
+                            .put("change", response.body().change())
+                            .put("rate", response.body().drate())
+                            .put("sign", response.body().sign())
+                            .put("high", response.body().highjisu())
+                            .put("low", response.body().lowjisu())
+                            .put("asOf", response.body().time())
+            );
+
+            stringRedisTemplate.opsForValue().set(redisKey, json);
+            log.info("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
+
+        } catch (Exception e) {
+            log.error("시장 지표 Redis 저장 실패: {}", e.getMessage());
+        }
+    }
+
+    // 환율 Redis 저장 (LsWebSocketClient에서 호출)
+    public void saveCurrency(LsWsCurrencyResponse response) {
+        try {
+            if (response.body() == null) return;
+
+            String json = objectMapper.writeValueAsString(
+                    objectMapper.createObjectNode()
+                            .put("cur", response.body().price())
+                            .put("change", response.body().change())
+                            .put("rate", response.body().drate())
+                            .put("sign", response.body().sign())
+                            .put("high", response.body().high())
+                            .put("low", response.body().low())
+                            .put("asOf", response.body().time())
+            );
+
+            stringRedisTemplate.opsForValue().set(USD_KRW_KEY, json);
+            log.info("환율 Redis 저장 완료 - {}: {}", USD_KRW_KEY, json);
+
+        } catch (Exception e) {
+            log.error("환율 Redis 저장 실패: {}", e.getMessage());
+        }
+    }
+
     private MarketIndicatorResponse.IndexInfo getIndexInfo(String redisKey) {
         try {
-            // Redis에서 JSON 문자열 조회
             String json = stringRedisTemplate.opsForValue().get(redisKey);
-
-            // 데이터 없으면 null 반환
             if (json == null) {
                 log.warn("Redis에 데이터 없음 - {}", redisKey);
                 return null;
             }
 
-            // JSON 문자열 → IndexInfo 객체로 변환
-            JsonNode node = objectMapper.readTree(json);
+            var node = objectMapper.readTree(json);
             return MarketIndicatorResponse.IndexInfo.builder()
                     .cur(node.get("cur").asText())
                     .change(node.get("change").asText())

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.solmate.external.ls.dto.websocket.LsWsIndexResponse;
 import org.solmate.external.ls.dto.websocket.LsWsCurrencyResponse;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.solmate.domain.market.service.MarketIndicatorService;
 
 @Slf4j
 @Component
@@ -50,11 +50,8 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         return subscribedCodes;
     }
 
-    private final StringRedisTemplate stringRedisTemplate;
 
-    private static final String KOSPI_REDIS_KEY = "market:indicator:KOSPI";
-    private static final String KOSDAQ_REDIS_KEY = "market:indicator:KOSDAQ";
-    private static final String USD_KRW_REDIS_KEY = "market:indicator:USD_KRW";
+    private final MarketIndicatorService marketIndicatorService;
 
     @PostConstruct
     public void connect() {
@@ -136,14 +133,14 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             // 지수 데이터 처리
             if ("IJ_".equals(trCd)) {
                 LsWsIndexResponse response = objectMapper.readValue(message.getPayload(), LsWsIndexResponse.class);
-                handleIndexMessage(response);
+                marketIndicatorService.saveIndex(response);
                 return;
             }
 
             // 환율 추가
             if ("CUR".equals(trCd)) {
                 LsWsCurrencyResponse response = objectMapper.readValue(message.getPayload(), LsWsCurrencyResponse.class);
-                handleCurrencyMessage(response);
+                marketIndicatorService.saveCurrency(response);
                 return;
             }
 
@@ -160,55 +157,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         }
     }
 
-    // 지수 처리 메서드 추가
-    private void handleIndexMessage(LsWsIndexResponse response) {
-        try {
-            if (response.body() == null) return;
 
-            String trKey = response.header().tr_key();
-            String redisKey = "001".equals(trKey) ? KOSPI_REDIS_KEY : KOSDAQ_REDIS_KEY;
-
-            String json = objectMapper.writeValueAsString(
-                    objectMapper.createObjectNode()
-                            .put("cur", response.body().jisu())
-                            .put("change", response.body().change())
-                            .put("rate", response.body().drate())
-                            .put("sign", response.body().sign())
-                            .put("high", response.body().highjisu())
-                            .put("low", response.body().lowjisu())
-                            .put("asOf", response.body().time())
-            );
-
-            stringRedisTemplate.opsForValue().set(redisKey, json);
-            log.info("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
-
-        } catch (Exception e) {
-            log.error("시장 지표 Redis 저장 실패: {}", e.getMessage());
-        }
-    }
-
-    private void handleCurrencyMessage(LsWsCurrencyResponse response) {
-        try {
-            if (response.body() == null) return;
-
-            String json = objectMapper.writeValueAsString(
-                    objectMapper.createObjectNode()
-                            .put("cur", response.body().price())
-                            .put("change", response.body().change())
-                            .put("rate", response.body().drate())
-                            .put("sign", response.body().sign())
-                            .put("high", response.body().high())
-                            .put("low", response.body().low())
-                            .put("asOf", response.body().time())
-            );
-
-            stringRedisTemplate.opsForValue().set(USD_KRW_REDIS_KEY, json);
-            log.info("환율 Redis 저장 완료 - {}: {}", USD_KRW_REDIS_KEY, json);
-
-        } catch (Exception e) {
-            log.error("환율 Redis 저장 실패: {}", e.getMessage());
-        }
-    }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #27 

## 💡 작업 배경
LsWebSocketClient가 LS 웹소켓 연결/수신과 Redis 저장을 동시에 담당하고 있어 단일 책임 원칙에 맞지 않았습니다. Redis 저장 로직을 MarketIndicatorService로 분리하여 각 클래스가 하나의 역할만 담당하도록 리팩토링했습니다.

## 🧩 작업 내용
1. LsWebSocketClient.java 수정

handleIndexMessage() 삭제 → marketIndicatorService.saveIndex() 호출로 교체
handleCurrencyMessage() 삭제 → marketIndicatorService.saveCurrency() 호출로 교체
Redis 관련 필드 및 상수 삭제 (StringRedisTemplate, Redis Key 상수)
MarketIndicatorService 의존성 추가

2. MarketIndicatorService.java 수정

saveIndex() 메서드 추가 - 지수 데이터 Redis 저장 (KOSPI/KOSDAQ)
saveCurrency() 메서드 추가 - 환율 데이터 Redis 저장 (USD/KRW)

변경 후 흐름
```
LsWebSocketClient       MarketIndicatorService        Redis
  (LS 데이터 수신)   →    (저장/조회 로직 담당)    →   (저장)
```

## 📸 스크린샷(선택)


## 📝 기타
