### PR TITLE
[Feat] 실시간 호가 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/org/solmate/common/config/RedisConfig.java
+++ b/src/main/java/org/solmate/common/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 public class RedisConfig {
@@ -17,5 +18,10 @@ public class RedisConfig {
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public ObjectMapper objectMapper() {
+		return new ObjectMapper();
 	}
 }

--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -2,7 +2,9 @@ package org.solmate.domain.stock.controller;
 
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.stock.dto.response.StockOrderBookResponse;
 import org.solmate.domain.stock.dto.response.StockQuoteResponse;
+import org.solmate.domain.stock.service.OrderBookService;
 import org.solmate.domain.stock.service.StockService;
 import org.solmate.external.ls.websocket.LsWebSocketClient;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class StockController {
 
     private final StockService stockService;
+    private final OrderBookService orderBookService;
     private final LsWebSocketClient lsWebSocketClient;
 
     @Operation(summary = "주식 현재가 조회")
@@ -45,5 +48,12 @@ public class StockController {
     public ResponseEntity<ApiResponse<Void>> unsubscribe(@PathVariable String stockCode) {
         lsWebSocketClient.unsubscribe(stockCode);
         return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+
+    @Operation(summary = "실시간 호가 조회 (매도 5단계 / 매수 5단계)")
+    @GetMapping("/{stockCode}/orderbook")
+    public ResponseEntity<ApiResponse<StockOrderBookResponse>> getOrderBook(@PathVariable String stockCode) {
+        StockOrderBookResponse response = orderBookService.getOrderBook(stockCode);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, response);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockOrderBookResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockOrderBookResponse.java
@@ -6,24 +6,21 @@ import org.solmate.external.ls.dto.websocket.LsWsOrderBookResponse;
 
 public record StockOrderBookResponse(
         String stockCode,
+        long currentPrice,
+        double changeRate,
         List<PriceLevel> sellLevels,
         List<PriceLevel> buyLevels,
         String timestamp
 ) {
     public record PriceLevel(long price, long quantity) {}
 
-    public static StockOrderBookResponse from(LsWsOrderBookResponse.Body body) {
+    public static StockOrderBookResponse from(LsWsOrderBookResponse.Body body, long currentPrice, double changeRate) {
         List<PriceLevel> sellLevels = List.of(
                 new PriceLevel(parseLong(body.offerho1()), parseLong(body.unt_offerrem1())),
                 new PriceLevel(parseLong(body.offerho2()), parseLong(body.unt_offerrem2())),
                 new PriceLevel(parseLong(body.offerho3()), parseLong(body.unt_offerrem3())),
                 new PriceLevel(parseLong(body.offerho4()), parseLong(body.unt_offerrem4())),
-                new PriceLevel(parseLong(body.offerho5()), parseLong(body.unt_offerrem5())),
-                new PriceLevel(parseLong(body.offerho6()), parseLong(body.unt_offerrem6())),
-                new PriceLevel(parseLong(body.offerho7()), parseLong(body.unt_offerrem7())),
-                new PriceLevel(parseLong(body.offerho8()), parseLong(body.unt_offerrem8())),
-                new PriceLevel(parseLong(body.offerho9()), parseLong(body.unt_offerrem9())),
-                new PriceLevel(parseLong(body.offerho10()), parseLong(body.unt_offerrem10()))
+                new PriceLevel(parseLong(body.offerho5()), parseLong(body.unt_offerrem5()))
         );
 
         List<PriceLevel> buyLevels = List.of(
@@ -31,15 +28,10 @@ public record StockOrderBookResponse(
                 new PriceLevel(parseLong(body.bidho2()), parseLong(body.unt_bidrem2())),
                 new PriceLevel(parseLong(body.bidho3()), parseLong(body.unt_bidrem3())),
                 new PriceLevel(parseLong(body.bidho4()), parseLong(body.unt_bidrem4())),
-                new PriceLevel(parseLong(body.bidho5()), parseLong(body.unt_bidrem5())),
-                new PriceLevel(parseLong(body.bidho6()), parseLong(body.unt_bidrem6())),
-                new PriceLevel(parseLong(body.bidho7()), parseLong(body.unt_bidrem7())),
-                new PriceLevel(parseLong(body.bidho8()), parseLong(body.unt_bidrem8())),
-                new PriceLevel(parseLong(body.bidho9()), parseLong(body.unt_bidrem9())),
-                new PriceLevel(parseLong(body.bidho10()), parseLong(body.unt_bidrem10()))
+                new PriceLevel(parseLong(body.bidho5()), parseLong(body.unt_bidrem5()))
         );
 
-        return new StockOrderBookResponse(body.shcode(), sellLevels, buyLevels, body.hotime());
+        return new StockOrderBookResponse(body.shcode(), currentPrice, changeRate, sellLevels, buyLevels, body.hotime());
     }
 
     private static long parseLong(String value) {

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockOrderBookResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockOrderBookResponse.java
@@ -1,0 +1,49 @@
+package org.solmate.domain.stock.dto.response;
+
+import java.util.List;
+
+import org.solmate.external.ls.dto.websocket.LsWsOrderBookResponse;
+
+public record StockOrderBookResponse(
+        String stockCode,
+        List<PriceLevel> sellLevels,
+        List<PriceLevel> buyLevels,
+        String timestamp
+) {
+    public record PriceLevel(long price, long quantity) {}
+
+    public static StockOrderBookResponse from(LsWsOrderBookResponse.Body body) {
+        List<PriceLevel> sellLevels = List.of(
+                new PriceLevel(parseLong(body.offerho1()), parseLong(body.unt_offerrem1())),
+                new PriceLevel(parseLong(body.offerho2()), parseLong(body.unt_offerrem2())),
+                new PriceLevel(parseLong(body.offerho3()), parseLong(body.unt_offerrem3())),
+                new PriceLevel(parseLong(body.offerho4()), parseLong(body.unt_offerrem4())),
+                new PriceLevel(parseLong(body.offerho5()), parseLong(body.unt_offerrem5())),
+                new PriceLevel(parseLong(body.offerho6()), parseLong(body.unt_offerrem6())),
+                new PriceLevel(parseLong(body.offerho7()), parseLong(body.unt_offerrem7())),
+                new PriceLevel(parseLong(body.offerho8()), parseLong(body.unt_offerrem8())),
+                new PriceLevel(parseLong(body.offerho9()), parseLong(body.unt_offerrem9())),
+                new PriceLevel(parseLong(body.offerho10()), parseLong(body.unt_offerrem10()))
+        );
+
+        List<PriceLevel> buyLevels = List.of(
+                new PriceLevel(parseLong(body.bidho1()), parseLong(body.unt_bidrem1())),
+                new PriceLevel(parseLong(body.bidho2()), parseLong(body.unt_bidrem2())),
+                new PriceLevel(parseLong(body.bidho3()), parseLong(body.unt_bidrem3())),
+                new PriceLevel(parseLong(body.bidho4()), parseLong(body.unt_bidrem4())),
+                new PriceLevel(parseLong(body.bidho5()), parseLong(body.unt_bidrem5())),
+                new PriceLevel(parseLong(body.bidho6()), parseLong(body.unt_bidrem6())),
+                new PriceLevel(parseLong(body.bidho7()), parseLong(body.unt_bidrem7())),
+                new PriceLevel(parseLong(body.bidho8()), parseLong(body.unt_bidrem8())),
+                new PriceLevel(parseLong(body.bidho9()), parseLong(body.unt_bidrem9())),
+                new PriceLevel(parseLong(body.bidho10()), parseLong(body.unt_bidrem10()))
+        );
+
+        return new StockOrderBookResponse(body.shcode(), sellLevels, buyLevels, body.hotime());
+    }
+
+    private static long parseLong(String value) {
+        if (value == null || value.isBlank()) return 0L;
+        return Long.parseLong(value.trim());
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockOrderBookResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockOrderBookResponse.java
@@ -2,7 +2,6 @@ package org.solmate.domain.stock.dto.response;
 
 import java.util.List;
 
-import org.solmate.external.ls.dto.websocket.LsWsOrderBookResponse;
 
 public record StockOrderBookResponse(
         String stockCode,
@@ -13,29 +12,4 @@ public record StockOrderBookResponse(
         String timestamp
 ) {
     public record PriceLevel(long price, long quantity) {}
-
-    public static StockOrderBookResponse from(LsWsOrderBookResponse.Body body, long currentPrice, double changeRate) {
-        List<PriceLevel> sellLevels = List.of(
-                new PriceLevel(parseLong(body.offerho1()), parseLong(body.unt_offerrem1())),
-                new PriceLevel(parseLong(body.offerho2()), parseLong(body.unt_offerrem2())),
-                new PriceLevel(parseLong(body.offerho3()), parseLong(body.unt_offerrem3())),
-                new PriceLevel(parseLong(body.offerho4()), parseLong(body.unt_offerrem4())),
-                new PriceLevel(parseLong(body.offerho5()), parseLong(body.unt_offerrem5()))
-        );
-
-        List<PriceLevel> buyLevels = List.of(
-                new PriceLevel(parseLong(body.bidho1()), parseLong(body.unt_bidrem1())),
-                new PriceLevel(parseLong(body.bidho2()), parseLong(body.unt_bidrem2())),
-                new PriceLevel(parseLong(body.bidho3()), parseLong(body.unt_bidrem3())),
-                new PriceLevel(parseLong(body.bidho4()), parseLong(body.unt_bidrem4())),
-                new PriceLevel(parseLong(body.bidho5()), parseLong(body.unt_bidrem5()))
-        );
-
-        return new StockOrderBookResponse(body.shcode(), currentPrice, changeRate, sellLevels, buyLevels, body.hotime());
-    }
-
-    private static long parseLong(String value) {
-        if (value == null || value.isBlank()) return 0L;
-        return Long.parseLong(value.trim());
-    }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -19,7 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 public class CandleAccumulatorService {
 
     private static final String CANDLE_KEY_PREFIX = "candle:1min:";
-    private static final String PRICE_KEY_PREFIX = "stock:info:";
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final StringRedisTemplate redisTemplate;

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CandleAccumulatorService {
 
     private static final String CANDLE_KEY_PREFIX = "candle:1min:";
+    private static final String PRICE_KEY_PREFIX = "stock:info:";
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final StringRedisTemplate redisTemplate;

--- a/src/main/java/org/solmate/domain/stock/service/OrderBookService.java
+++ b/src/main/java/org/solmate/domain/stock/service/OrderBookService.java
@@ -20,7 +20,7 @@ public class OrderBookService {
 
     private final StringRedisTemplate redisTemplate;
 
-    public StockOrderBookResponse save(LsWsOrderBookResponse.Body body) {
+    public void save(LsWsOrderBookResponse.Body body) {
         String key = INFO_KEY_PREFIX + body.shcode();
         redisTemplate.opsForHash().putAll(key, Map.ofEntries(
                 Map.entry("ask1", trim(body.offerho1())),
@@ -42,10 +42,10 @@ public class OrderBookService {
                 Map.entry("bidVol2", trim(body.unt_bidrem2())),
                 Map.entry("bidVol3", trim(body.unt_bidrem3())),
                 Map.entry("bidVol4", trim(body.unt_bidrem4())),
-                Map.entry("bidVol5", trim(body.unt_bidrem5()))
+                Map.entry("bidVol5", trim(body.unt_bidrem5())),
+                Map.entry("hotime", trim(body.hotime()))
         ));
 
-        return getOrderBook(body.shcode());
     }
 
     public StockOrderBookResponse getOrderBook(String stockCode) {
@@ -71,7 +71,8 @@ public class OrderBookService {
                 new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("bid5")), parseLong((String) info.get("bidVol5")))
         );
 
-        return new StockOrderBookResponse(stockCode, currentPrice, changeRate, sellLevels, buyLevels);
+        String timestamp = (String) info.get("hotime");
+        return new StockOrderBookResponse(stockCode, currentPrice, changeRate, sellLevels, buyLevels, timestamp);
     }
 
     private String trim(String value) {

--- a/src/main/java/org/solmate/domain/stock/service/OrderBookService.java
+++ b/src/main/java/org/solmate/domain/stock/service/OrderBookService.java
@@ -20,7 +20,7 @@ public class OrderBookService {
 
     private final StringRedisTemplate redisTemplate;
 
-    public void save(LsWsOrderBookResponse.Body body) {
+    public StockOrderBookResponse save(LsWsOrderBookResponse.Body body) {
         String key = INFO_KEY_PREFIX + body.shcode();
         redisTemplate.opsForHash().putAll(key, Map.ofEntries(
                 Map.entry("ask1", trim(body.offerho1())),
@@ -44,6 +44,8 @@ public class OrderBookService {
                 Map.entry("bidVol4", trim(body.unt_bidrem4())),
                 Map.entry("bidVol5", trim(body.unt_bidrem5()))
         ));
+
+        return getOrderBook(body.shcode());
     }
 
     public StockOrderBookResponse getOrderBook(String stockCode) {

--- a/src/main/java/org/solmate/domain/stock/service/OrderBookService.java
+++ b/src/main/java/org/solmate/domain/stock/service/OrderBookService.java
@@ -1,0 +1,88 @@
+package org.solmate.domain.stock.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.solmate.domain.stock.dto.response.StockOrderBookResponse;
+import org.solmate.external.ls.dto.websocket.LsWsOrderBookResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderBookService {
+
+    private static final String INFO_KEY_PREFIX = "stock:info:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(LsWsOrderBookResponse.Body body) {
+        String key = INFO_KEY_PREFIX + body.shcode();
+        redisTemplate.opsForHash().putAll(key, Map.ofEntries(
+                Map.entry("ask1", trim(body.offerho1())),
+                Map.entry("ask2", trim(body.offerho2())),
+                Map.entry("ask3", trim(body.offerho3())),
+                Map.entry("ask4", trim(body.offerho4())),
+                Map.entry("ask5", trim(body.offerho5())),
+                Map.entry("askVol1", trim(body.unt_offerrem1())),
+                Map.entry("askVol2", trim(body.unt_offerrem2())),
+                Map.entry("askVol3", trim(body.unt_offerrem3())),
+                Map.entry("askVol4", trim(body.unt_offerrem4())),
+                Map.entry("askVol5", trim(body.unt_offerrem5())),
+                Map.entry("bid1", trim(body.bidho1())),
+                Map.entry("bid2", trim(body.bidho2())),
+                Map.entry("bid3", trim(body.bidho3())),
+                Map.entry("bid4", trim(body.bidho4())),
+                Map.entry("bid5", trim(body.bidho5())),
+                Map.entry("bidVol1", trim(body.unt_bidrem1())),
+                Map.entry("bidVol2", trim(body.unt_bidrem2())),
+                Map.entry("bidVol3", trim(body.unt_bidrem3())),
+                Map.entry("bidVol4", trim(body.unt_bidrem4())),
+                Map.entry("bidVol5", trim(body.unt_bidrem5()))
+        ));
+    }
+
+    public StockOrderBookResponse getOrderBook(String stockCode) {
+        Map<Object, Object> info = redisTemplate.opsForHash().entries(INFO_KEY_PREFIX + stockCode);
+        if (info.isEmpty()) return null;
+
+        long currentPrice = parseLong((String) info.get("cur"));
+        double changeRate = parseDouble((String) info.get("chgRate"));
+
+        List<StockOrderBookResponse.PriceLevel> sellLevels = List.of(
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("ask1")), parseLong((String) info.get("askVol1"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("ask2")), parseLong((String) info.get("askVol2"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("ask3")), parseLong((String) info.get("askVol3"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("ask4")), parseLong((String) info.get("askVol4"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("ask5")), parseLong((String) info.get("askVol5")))
+        );
+
+        List<StockOrderBookResponse.PriceLevel> buyLevels = List.of(
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("bid1")), parseLong((String) info.get("bidVol1"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("bid2")), parseLong((String) info.get("bidVol2"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("bid3")), parseLong((String) info.get("bidVol3"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("bid4")), parseLong((String) info.get("bidVol4"))),
+                new StockOrderBookResponse.PriceLevel(parseLong((String) info.get("bid5")), parseLong((String) info.get("bidVol5")))
+        );
+
+        return new StockOrderBookResponse(stockCode, currentPrice, changeRate, sellLevels, buyLevels);
+    }
+
+    private String trim(String value) {
+        return value == null ? "0" : value.trim();
+    }
+
+    private long parseLong(String value) {
+        if (value == null || value.isBlank()) return 0L;
+        return Long.parseLong(value.trim());
+    }
+
+    private double parseDouble(String value) {
+        if (value == null || value.isBlank()) return 0.0;
+        return Double.parseDouble(value.trim());
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/service/StockInfoService.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockInfoService.java
@@ -1,0 +1,31 @@
+package org.solmate.domain.stock.service;
+
+import java.util.Map;
+
+import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockInfoService {
+
+    private static final String INFO_KEY_PREFIX = "stock:info:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void update(LsWsStockResponse.Body body) {
+        redisTemplate.opsForHash().putAll(INFO_KEY_PREFIX + body.shcode(), Map.of(
+                "cur", body.price() == null ? "0" : body.price().trim(),
+                "open", body.open() == null ? "0" : body.open().trim(),
+                "high", body.high() == null ? "0" : body.high().trim(),
+                "low", body.low() == null ? "0" : body.low().trim(),
+                "vol", body.volume() == null ? "0" : body.volume().trim(),
+                "chgRate", body.drate() == null ? "0" : body.drate().trim()
+        ));
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsOrderBookResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsOrderBookResponse.java
@@ -1,0 +1,24 @@
+package org.solmate.external.ls.dto.websocket;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsWsOrderBookResponse(Header header, Body body) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Header(String tr_cd, String tr_key) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Body(
+            String shcode,
+            String hotime,
+            // 매도호가 1~5
+            String offerho1, String offerho2, String offerho3, String offerho4, String offerho5,
+            // 통합 매도호가잔량 1~5
+            String unt_offerrem1, String unt_offerrem2, String unt_offerrem3, String unt_offerrem4, String unt_offerrem5,
+            // 매수호가 1~5
+            String bidho1, String bidho2, String bidho3, String bidho4, String bidho5,
+            // 통합 매수호가잔량 1~5
+            String unt_bidrem1, String unt_bidrem2, String unt_bidrem3, String unt_bidrem4, String unt_bidrem5
+    ) {}
+}

--- a/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/websocket/LsWsRequest.java
@@ -19,4 +19,18 @@ public record LsWsRequest(Header header, Body body) {
                 new Body("US3", String.format("U%-9s", stockCode))
         );
     }
+
+    public static LsWsRequest subscribeOrderBook(String token, String stockCode) {
+        return new LsWsRequest(
+                new Header(token, "3"),
+                new Body("UH1", String.format("U%-9s", stockCode))
+        );
+    }
+
+    public static LsWsRequest unsubscribeOrderBook(String token, String stockCode) {
+        return new LsWsRequest(
+                new Header(token, "4"),
+                new Body("UH1", String.format("U%-9s", stockCode))
+        );
+    }
 }

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -9,7 +9,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.solmate.domain.stock.dto.response.StockRealtimeResponse;
 import org.solmate.domain.stock.service.CandleAccumulatorService;
+import org.solmate.domain.stock.service.OrderBookService;
 import org.solmate.external.ls.LsProperties;
+import org.solmate.external.ls.dto.websocket.LsWsOrderBookResponse;
 import org.solmate.external.ls.dto.websocket.LsWsRequest;
 import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
 import org.solmate.external.ls.service.LsTokenService;
@@ -21,6 +23,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.PostConstruct;
@@ -36,7 +39,8 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     private final LsTokenService lsTokenService;
     private final SimpMessagingTemplate messagingTemplate;
     private final CandleAccumulatorService candleAccumulatorService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OrderBookService orderBookService;
+    private final ObjectMapper objectMapper;
     private final ScheduledExecutorService reconnectScheduler = Executors.newSingleThreadScheduledExecutor();
 
     private WebSocketSession session;
@@ -75,19 +79,26 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         if (subscribedCodes.isEmpty()) return;
         log.info("LS WebSocket 재구독 시도: {}", subscribedCodes);
         String token = lsTokenService.getToken();
-        subscribedCodes.forEach(code -> sendMessage(LsWsRequest.subscribe(token, code)));
+        subscribedCodes.forEach(code -> {
+            sendMessage(LsWsRequest.subscribe(token, code));
+            sendMessage(LsWsRequest.subscribeOrderBook(token, code));
+        });
     }
 
     public void subscribe(String stockCode) {
         if (subscribedCodes.contains(stockCode)) return;
-        sendMessage(LsWsRequest.subscribe(lsTokenService.getToken(), stockCode));
+        String token = lsTokenService.getToken();
+        sendMessage(LsWsRequest.subscribe(token, stockCode));
+        sendMessage(LsWsRequest.subscribeOrderBook(token, stockCode));
         subscribedCodes.add(stockCode);
         log.info("LS WebSocket 구독: {}", stockCode);
     }
 
     public void unsubscribe(String stockCode) {
         if (!subscribedCodes.contains(stockCode)) return;
-        sendMessage(LsWsRequest.unsubscribe(lsTokenService.getToken(), stockCode));
+        String token = lsTokenService.getToken();
+        sendMessage(LsWsRequest.unsubscribe(token, stockCode));
+        sendMessage(LsWsRequest.unsubscribeOrderBook(token, stockCode));
         subscribedCodes.remove(stockCode);
         log.info("LS WebSocket 구독 해제: {}", stockCode);
     }
@@ -109,13 +120,28 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
-            log.info("LS WebSocket 수신: {}", message.getPayload());
-            LsWsStockResponse response = objectMapper.readValue(message.getPayload(), LsWsStockResponse.class);
-            if (response.header() == null || response.body() == null) return;
+            String payload = message.getPayload();
+            log.info("LS WebSocket 수신: {}", payload);
 
-            String stockCode = response.body().shcode();
-            candleAccumulatorService.accumulate(response.body());
-            messagingTemplate.convertAndSend("/topic/stocks/" + stockCode, StockRealtimeResponse.from(response.body()));
+            // tr_cd로 라우팅
+            JsonNode node = objectMapper.readTree(payload);
+            JsonNode headerNode = node.get("header");
+            if (headerNode == null) return;
+
+            String trCd = headerNode.path("tr_cd").asText();
+
+            if ("US3".equals(trCd)) {
+                LsWsStockResponse response = objectMapper.treeToValue(node, LsWsStockResponse.class);
+                if (response.body() == null) return;
+                candleAccumulatorService.accumulate(response.body());
+                messagingTemplate.convertAndSend("/topic/stocks/" + response.body().shcode(),
+                        StockRealtimeResponse.from(response.body()));
+
+            } else if ("UH1".equals(trCd)) {
+                LsWsOrderBookResponse response = objectMapper.treeToValue(node, LsWsOrderBookResponse.class);
+                if (response.body() == null) return;
+                orderBookService.save(response.body());
+            }
         } catch (Exception e) {
             log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());
         }

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -7,9 +7,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.solmate.domain.stock.dto.response.StockOrderBookResponse;
 import org.solmate.domain.stock.dto.response.StockRealtimeResponse;
 import org.solmate.domain.stock.service.CandleAccumulatorService;
 import org.solmate.domain.stock.service.OrderBookService;
+import org.solmate.domain.stock.service.StockInfoService;
 import org.solmate.external.ls.LsProperties;
 import org.solmate.external.ls.dto.websocket.LsWsOrderBookResponse;
 import org.solmate.external.ls.dto.websocket.LsWsRequest;
@@ -39,6 +41,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     private final LsTokenService lsTokenService;
     private final SimpMessagingTemplate messagingTemplate;
     private final CandleAccumulatorService candleAccumulatorService;
+    private final StockInfoService stockInfoService;
     private final OrderBookService orderBookService;
     private final ObjectMapper objectMapper;
     private final ScheduledExecutorService reconnectScheduler = Executors.newSingleThreadScheduledExecutor();
@@ -134,13 +137,19 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                 LsWsStockResponse response = objectMapper.treeToValue(node, LsWsStockResponse.class);
                 if (response.body() == null) return;
                 candleAccumulatorService.accumulate(response.body());
+                stockInfoService.update(response.body());
                 messagingTemplate.convertAndSend("/topic/stocks/" + response.body().shcode(),
                         StockRealtimeResponse.from(response.body()));
 
             } else if ("UH1".equals(trCd)) {
                 LsWsOrderBookResponse response = objectMapper.treeToValue(node, LsWsOrderBookResponse.class);
                 if (response.body() == null) return;
+                String stockCode = response.body().shcode();
                 orderBookService.save(response.body());
+                StockOrderBookResponse orderBook = orderBookService.getOrderBook(stockCode);
+                if (orderBook != null) {
+                    messagingTemplate.convertAndSend("/topic/orderbook/" + stockCode, orderBook);
+                }
             }
         } catch (Exception e) {
             log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());

--- a/src/main/resources/static/ws-test.html
+++ b/src/main/resources/static/ws-test.html
@@ -8,8 +8,13 @@
     <style>
         body { font-family: monospace; padding: 20px; background: #1a1a1a; color: #00ff00; }
         input, button { padding: 8px; margin: 4px; font-size: 14px; }
-        #log { margin-top: 20px; border: 1px solid #333; padding: 10px; height: 500px; overflow-y: auto; }
+        .section { margin-top: 30px; }
+        h3 { color: #aaffaa; border-bottom: 1px solid #333; padding-bottom: 6px; }
+        #log, #orderlog { border: 1px solid #333; padding: 10px; height: 300px; overflow-y: auto; margin-top: 10px; }
         .msg { border-bottom: 1px solid #333; padding: 4px 0; }
+        .sell { color: #6699ff; }
+        .buy  { color: #ff6666; }
+        #status { margin: 8px 0; }
     </style>
 </head>
 <body>
@@ -17,13 +22,24 @@
     <input id="stockCode" type="text" value="005930" placeholder="종목코드" />
     <button onclick="subscribe()">구독</button>
     <button onclick="unsubscribe()">구독해제</button>
-    <button onclick="clearLog()">초기화</button>
+    <button onclick="clearAll()">초기화</button>
     <div id="status">연결 중...</div>
-    <div id="log"></div>
+
+    <div class="section">
+        <h3>📈 실시간 시세 (/topic/stocks/{code})</h3>
+        <div id="log"></div>
+    </div>
+
+    <div class="section">
+        <h3>📊 실시간 호가 (/topic/orderbook/{code})</h3>
+        <div id="orderbook"></div>
+        <div id="orderlog"></div>
+    </div>
 
     <script>
         let stompClient = null;
-        let subscription = null;
+        let priceSub = null;
+        let orderbookSub = null;
 
         const socket = new SockJS('http://localhost:8080/ws');
         stompClient = Stomp.over(socket);
@@ -38,32 +54,66 @@
         function subscribe() {
             const code = document.getElementById('stockCode').value;
 
-            // 백엔드에 LS WebSocket 구독 요청
             fetch(`http://localhost:8080/api/stocks/${code}/subscribe`, { method: 'POST' });
 
-            // STOMP 토픽 구독
-            subscription = stompClient.subscribe(`/topic/stocks/${code}`, function (msg) {
+            // 실시간 시세
+            priceSub = stompClient.subscribe(`/topic/stocks/${code}`, function (msg) {
                 const data = JSON.parse(msg.body);
-                const now = new Date().toLocaleTimeString();
                 const div = document.createElement('div');
                 div.className = 'msg';
                 div.innerHTML = `[${data.chetime}] ${data.stockCode} | 현재가: <b>${data.currentPrice}</b> | 전일대비: ${data.changePrice} (${data.changeRate}%) | 고가: ${data.highPrice} | 저가: ${data.lowPrice} | 거래량: ${data.volume}`;
-                const log = document.getElementById('log');
-                log.prepend(div);
+                document.getElementById('log').prepend(div);
+            });
+
+            // 실시간 호가
+            orderbookSub = stompClient.subscribe(`/topic/orderbook/${code}`, function (msg) {
+                const data = JSON.parse(msg.body);
+                renderOrderBook(data);
+
+                const div = document.createElement('div');
+                div.className = 'msg';
+                div.innerHTML = `[${data.timestamp}] 호가 업데이트 | 현재가: <b>${data.currentPrice}</b> (${data.changeRate}%)`;
+                document.getElementById('orderlog').prepend(div);
             });
 
             document.getElementById('status').innerText = `✅ ${code} 구독 중`;
         }
 
+        function renderOrderBook(data) {
+            let html = `<table style="width:300px; border-collapse:collapse; font-size:13px;">`;
+            html += `<tr><th>호가</th><th>잔량</th></tr>`;
+
+            [...data.sellLevels].reverse().forEach(level => {
+                html += `<tr class="sell"><td>${level.price.toLocaleString()}</td><td>${level.quantity.toLocaleString()}</td></tr>`;
+            });
+
+            html += `<tr style="background:#333; color:#fff; font-weight:bold;">
+                        <td>${data.currentPrice.toLocaleString()}</td>
+                        <td style="color:${data.changeRate >= 0 ? '#ff6666' : '#6699ff'}">
+                            ${data.changeRate >= 0 ? '+' : ''}${data.changeRate}%
+                        </td>
+                     </tr>`;
+
+            data.buyLevels.forEach(level => {
+                html += `<tr class="buy"><td>${level.price.toLocaleString()}</td><td>${level.quantity.toLocaleString()}</td></tr>`;
+            });
+
+            html += `</table>`;
+            document.getElementById('orderbook').innerHTML = html;
+        }
+
         function unsubscribe() {
             const code = document.getElementById('stockCode').value;
             fetch(`http://localhost:8080/api/stocks/${code}/subscribe`, { method: 'DELETE' });
-            if (subscription) subscription.unsubscribe();
+            if (priceSub) priceSub.unsubscribe();
+            if (orderbookSub) orderbookSub.unsubscribe();
             document.getElementById('status').innerText = '구독 해제됨';
         }
 
-        function clearLog() {
+        function clearAll() {
             document.getElementById('log').innerHTML = '';
+            document.getElementById('orderlog').innerHTML = '';
+            document.getElementById('orderbook').innerHTML = '';
         }
     </script>
 </body>


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #25

## 💡 작업 배경
  LS증권 WebSocket API의 UH1(통합호가잔량) TR을 활용해 실시간 매도/매수 호가 5단계를 클라이언트에 push하는 기능을 구현이 필요했다.

## 🧩 작업 내용

- Redis 구조 통합
  - `stock:info:{stockCode}` Hash 하나에 시세 + 호가 통합 저장
    - US3(체결)  
    - UH1(호가) 

- 코드 변경 부분
  - `LsWsOrderBookResponse` - UH1 WebSocket 응답 DTO (5단계)
  - `StockOrderBookResponse` - 호가 응답 DTO (현재가 + 등락률 + 매도/매수 5단계)
  - `StockInfoService` - US3 tick → stock:info: 실시간 업데이트
  - `OrderBookService` - UH1 → stock:info: 저장 + 호가 조회
  - `LsWsRequest` - UH1 subscribe/unsubscribe 메서드 추가
  - `LsWebSocketClient` - tr_cd 기준 라우팅 (US3 → 캔들+시세, UH1 → 호가)
  - `StockController` - `GET /api/stocks/{stockCode}/orderbook` 추가
  - `ws-test.html` - 실시간 호가 테이블 UI 추가

- WebSocket broadcast
  - `/topic/orderbook/{stockCode}` 로 호가 변경 시 자동 push
  - `GET /api/stocks/{stockCode}/orderbook` 초기 로딩용 REST 유지

## 📸 스크린샷(선택)
<img width="932" height="628" alt="Screenshot 2026-03-20 at 3 43 05 PM" src="https://github.com/user-attachments/assets/264fa8ef-cc17-41f4-bcb5-2ca160418216" />


## 📝 기타
