### PR TITLE
[Feat] 차트 데이터 호출 api 구현

### DIFF
--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -1,8 +1,12 @@
 package org.solmate.domain.stock.controller;
 
+import java.util.List;
+
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.stock.dto.response.CandleResponse;
 import org.solmate.domain.stock.dto.response.StockQuoteResponse;
+import org.solmate.domain.stock.service.CandleService;
 import org.solmate.domain.stock.service.StockService;
 import org.solmate.external.ls.websocket.LsWebSocketClient;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class StockController {
 
     private final StockService stockService;
+    private final CandleService candleService;
     private final LsWebSocketClient lsWebSocketClient;
 
     @Operation(summary = "주식 현재가 조회")
@@ -31,6 +37,20 @@ public class StockController {
     public ResponseEntity<ApiResponse<StockQuoteResponse>> getQuote(@PathVariable String stockCode) {
         StockQuoteResponse response = stockService.getQuote(stockCode);
         return ApiResponse.success(SuccessStatus.SUCCESS_200, response);
+    }
+
+    @Operation(summary = "1분봉 조회 (오늘 장 시작부터 현재까지)")
+    @GetMapping("/{stockCode}/candles/minute")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getMinuteCandles(@PathVariable String stockCode) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMinuteCandles(stockCode));
+    }
+
+    @Operation(summary = "일봉 조회", description = "days 파라미터로 조회 기간 지정 (주: 5, 월: 30, 년: 365)")
+    @GetMapping("/{stockCode}/candles/day")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getDailyCandles(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "30") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getDailyCandles(stockCode, days));
     }
 
     @Operation(summary = "주식 실시간 시세 구독")

--- a/src/main/java/org/solmate/domain/stock/dto/response/CandleResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/CandleResponse.java
@@ -1,0 +1,42 @@
+package org.solmate.domain.stock.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import org.solmate.domain.stock.entity.BaseCandle;
+
+public record CandleResponse(
+        long time,
+        long open,
+        long high,
+        long low,
+        long close,
+        long volume
+) {
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    /** DB에서 조회한 MinuteCandle / DailyCandle 변환용 */
+    public static CandleResponse from(BaseCandle candle, LocalDateTime candleTime) {
+        return new CandleResponse(
+                candleTime.toEpochSecond(KST),
+                candle.getOpenPrice(),
+                candle.getHighPrice(),
+                candle.getLowPrice(),
+                candle.getClosePrice(),
+                candle.getVolume()
+        );
+    }
+
+    /** Redis에서 꺼낸 현재 진행 중인 봉 변환용 */
+    public static CandleResponse fromRedis(Map<Object, Object> data, LocalDateTime candleTime) {
+        return new CandleResponse(
+                candleTime.toEpochSecond(KST),
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume"))
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
@@ -1,0 +1,7 @@
+package org.solmate.domain.stock.repository;
+
+import org.solmate.domain.stock.entity.DailyCandle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
+}

--- a/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
@@ -1,7 +1,14 @@
 package org.solmate.domain.stock.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.solmate.domain.stock.entity.DailyCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
+
+    // 특정 종목의 시간 범위 내 일봉 조회 (오름차순)
+    List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
+            String stockCode, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/org/solmate/domain/stock/repository/MinuteCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/MinuteCandleRepository.java
@@ -1,7 +1,14 @@
 package org.solmate.domain.stock.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.solmate.domain.stock.entity.MinuteCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MinuteCandleRepository extends JpaRepository<MinuteCandle, Long> {
+
+    // 특정 종목의 시간 범위 내 1분봉 조회 (오름차순)
+    List<MinuteCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
+            String stockCode, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
@@ -20,11 +20,43 @@ public class CandleScheduler {
     private final CandleAccumulatorService candleAccumulatorService;
     private final LsWebSocketClient lsWebSocketClient;
 
-    // 매 분 00초에 실행
-    @Scheduled(cron = "0 * * * * *")
+    // 매 분 00초 - 1분봉 DB 저장
+    @Scheduled(cron = "0 * * * * MON-FRI")
     public void flushMinuteCandles() {
-        Set<String> subscribedCodes = lsWebSocketClient.getSubscribedCodes();
-        log.info("1분봉 스케줄러 실행 - 구독 종목 수: {}", subscribedCodes.size());
-        subscribedCodes.forEach(candleAccumulatorService::flushToDb);
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        log.info("1분봉 스케줄러 실행 - 구독 종목 수: {}", codes.size());
+        codes.forEach(candleAccumulatorService::flushMinuteCandle);
+    }
+
+    // 매 5분 - 5분봉 Redis 초기화
+    @Scheduled(cron = "0 */5 * * * MON-FRI")
+    public void flush5MinCandles() {
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        log.info("5분봉 스케줄러 실행");
+        codes.forEach(candleAccumulatorService::flush5MinCandle);
+    }
+
+    // 매 30분 - 30분봉 Redis 초기화
+    @Scheduled(cron = "0 */30 * * * MON-FRI")
+    public void flush30MinCandles() {
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        log.info("30분봉 스케줄러 실행");
+        codes.forEach(candleAccumulatorService::flush30MinCandle);
+    }
+
+    // 매 정시 - 60분봉 Redis 초기화
+    @Scheduled(cron = "0 0 * * * MON-FRI")
+    public void flush60MinCandles() {
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        log.info("60분봉 스케줄러 실행");
+        codes.forEach(candleAccumulatorService::flush60MinCandle);
+    }
+
+    // 장 마감 15:30 - 일봉 DB 저장
+    @Scheduled(cron = "0 30 15 * * MON-FRI")
+    public void flushDailyCandles() {
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        log.info("일봉 스케줄러 실행");
+        codes.forEach(candleAccumulatorService::flushDailyCandle);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -1,10 +1,15 @@
 package org.solmate.domain.stock.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 
+import org.solmate.domain.stock.entity.DailyCandle;
 import org.solmate.domain.stock.entity.MinuteCandle;
+import org.solmate.domain.stock.repository.DailyCandleRepository;
 import org.solmate.domain.stock.repository.MinuteCandleRepository;
 import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -18,46 +23,126 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class CandleAccumulatorService {
 
-    private static final String CANDLE_KEY_PREFIX = "candle:1min:";
+    private static final LocalTime MARKET_OPEN  = LocalTime.of(9, 0);
+    private static final LocalTime MARKET_CLOSE = LocalTime.of(15, 30);
+
+    private static final String KEY_1MIN  = "candle:1min:";
+    private static final String KEY_5MIN  = "candle:5min:";
+    private static final String KEY_30MIN = "candle:30min:";
+    private static final String KEY_60MIN = "candle:60min:";
+    private static final String KEY_1DAY  = "candle:1day:";
+
+    private static final List<String> ALL_PREFIXES = List.of(
+            KEY_1MIN, KEY_5MIN, KEY_30MIN, KEY_60MIN, KEY_1DAY
+    );
+
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final StringRedisTemplate redisTemplate;
     private final MinuteCandleRepository minuteCandleRepository;
+    private final DailyCandleRepository dailyCandleRepository;
 
+    // 체결 수신 시 정규장 여부 확인 후 모든 봉 Redis 키 동시 업데이트
     public void accumulate(LsWsStockResponse.Body body) {
-        String stockCode = body.shcode();
-        long price = Long.parseLong(body.price().trim());
-        long cvolume = Long.parseLong(body.cvolume().trim());
-        String key = CANDLE_KEY_PREFIX + stockCode;
+        LocalTime now = LocalTime.now();
+        if (now.isBefore(MARKET_OPEN) || now.isAfter(MARKET_CLOSE)) return;
 
+        String stockCode = body.shcode();
+        long price   = Long.parseLong(body.price().trim());
+        long cvolume = Long.parseLong(body.cvolume().trim());
+
+        accumulateKey(KEY_1MIN  + stockCode, price, cvolume);
+        accumulateKey(KEY_5MIN  + stockCode, price, cvolume);
+        accumulateKey(KEY_30MIN + stockCode, price, cvolume);
+        accumulateKey(KEY_60MIN + stockCode, price, cvolume);
+        accumulateKey(KEY_1DAY  + stockCode, price, cvolume);
+    }
+
+    // Redis 키에 체결가/거래량 누적 (첫 체결이면 open 세팅, 이후엔 high/low/close/volume 갱신)
+    private void accumulateKey(String key, long price, long cvolume) {
         Map<Object, Object> current = redisTemplate.opsForHash().entries(key);
 
         if (current.isEmpty()) {
-
             redisTemplate.opsForHash().putAll(key, Map.of(
-                    "open", String.valueOf(price),
-                    "high", String.valueOf(price),
-                    "low", String.valueOf(price),
-                    "close", String.valueOf(price),
-                    "volume", String.valueOf(cvolume),
+                    "open",      String.valueOf(price),
+                    "high",      String.valueOf(price),
+                    "low",       String.valueOf(price),
+                    "close",     String.valueOf(price),
+                    "volume",    String.valueOf(cvolume),
                     "startTime", LocalDateTime.now().format(TIME_FORMATTER)
             ));
         } else {
-            long high = Math.max(price, Long.parseLong((String) current.get("high")));
-            long low = Math.min(price, Long.parseLong((String) current.get("low")));
+            long high   = Math.max(price, Long.parseLong((String) current.get("high")));
+            long low    = Math.min(price, Long.parseLong((String) current.get("low")));
             long volume = Long.parseLong((String) current.get("volume")) + cvolume;
 
             redisTemplate.opsForHash().putAll(key, Map.of(
-                    "high", String.valueOf(high),
-                    "low", String.valueOf(low),
-                    "close", String.valueOf(price),
+                    "high",   String.valueOf(high),
+                    "low",    String.valueOf(low),
+                    "close",  String.valueOf(price),
                     "volume", String.valueOf(volume)
             ));
         }
     }
 
-    public void flushToDb(String stockCode) {
-        String key = CANDLE_KEY_PREFIX + stockCode;
+    // 1분봉 DB 저장 (매 분 00초)
+    public void flushMinuteCandle(String stockCode) {
+        flushToMinuteDb(stockCode);
+    }
+
+    // 5분봉 Redis 초기화 (매 5분)
+    public void flush5MinCandle(String stockCode) {
+        redisTemplate.delete(KEY_5MIN + stockCode);
+        log.info("5분봉 초기화: {}", stockCode);
+    }
+
+    // 30분봉 Redis 초기화 (매 30분)
+    public void flush30MinCandle(String stockCode) {
+        redisTemplate.delete(KEY_30MIN + stockCode);
+        log.info("30분봉 초기화: {}", stockCode);
+    }
+
+    // 60분봉 Redis 초기화 (매 60분)
+    public void flush60MinCandle(String stockCode) {
+        redisTemplate.delete(KEY_60MIN + stockCode);
+        log.info("60분봉 초기화: {}", stockCode);
+    }
+
+    // 일봉 DB 저장 (장 마감 15:30)
+    public void flushDailyCandle(String stockCode) {
+        String key = KEY_1DAY + stockCode;
+        Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
+        if (data.isEmpty()) return;
+
+        try {
+            LocalDateTime candleTime = LocalDate.now().atStartOfDay();
+
+            DailyCandle candle = DailyCandle.builder()
+                    .stockCode(stockCode)
+                    .openPrice(Long.parseLong((String) data.get("open")))
+                    .highPrice(Long.parseLong((String) data.get("high")))
+                    .lowPrice(Long.parseLong((String) data.get("low")))
+                    .closePrice(Long.parseLong((String) data.get("close")))
+                    .volume(Long.parseLong((String) data.get("volume")))
+                    .candleTime(candleTime)
+                    .build();
+
+            dailyCandleRepository.save(candle);
+            redisTemplate.delete(key);
+            log.info("일봉 저장 완료: {}", stockCode);
+        } catch (Exception e) {
+            log.error("일봉 저장 실패: {}", stockCode, e);
+        }
+    }
+
+    // 현재 진행 중인 봉 Redis 데이터 조회 (API 응답용)
+    public Map<Object, Object> getCurrentCandle(String stockCode, String prefix) {
+        return redisTemplate.opsForHash().entries(prefix + stockCode);
+    }
+
+    // 1분봉 Redis 데이터를 DB에 저장하고 키 삭제
+    private void flushToMinuteDb(String stockCode) {
+        String key = KEY_1MIN + stockCode;
         Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
         if (data.isEmpty()) return;
 

--- a/src/main/java/org/solmate/domain/stock/service/CandleService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleService.java
@@ -1,0 +1,77 @@
+package org.solmate.domain.stock.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.solmate.domain.stock.dto.response.CandleResponse;
+import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.MinuteCandle;
+import org.solmate.domain.stock.repository.DailyCandleRepository;
+import org.solmate.domain.stock.repository.MinuteCandleRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CandleService {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+
+    private final MinuteCandleRepository minuteCandleRepository;
+    private final DailyCandleRepository dailyCandleRepository;
+    private final CandleAccumulatorService candleAccumulatorService;
+
+    // 오늘 날짜 기준 1분봉 조회 (DB + 현재 진행 중인 봉 포함)
+    public List<CandleResponse> getMinuteCandles(String stockCode) {
+        LocalDateTime from = LocalDate.now().atTime(LocalTime.of(9, 0));
+        LocalDateTime to   = LocalDate.now().atTime(LocalTime.of(15, 30));
+
+        List<MinuteCandle> candles = minuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+
+        List<CandleResponse> result = new ArrayList<>(
+                candles.stream()
+                        .map(c -> CandleResponse.from(c, c.getCandleTime()))
+                        .toList()
+        );
+
+        // 현재 진행 중인 봉 Redis에서 추가
+        appendCurrentCandle(result, stockCode, "candle:1min:");
+        return result;
+    }
+
+    // 특정 기간 일봉 조회 (DB + 오늘 진행 중인 봉 포함)
+    public List<CandleResponse> getDailyCandles(String stockCode, int days) {
+        LocalDateTime from = LocalDate.now().minusDays(days).atStartOfDay();
+        LocalDateTime to   = LocalDate.now().atStartOfDay();
+
+        List<DailyCandle> candles = dailyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+
+        List<CandleResponse> result = new ArrayList<>(
+                candles.stream()
+                        .map(c -> CandleResponse.from(c, c.getCandleTime()))
+                        .toList()
+        );
+
+        // 오늘 진행 중인 일봉 Redis에서 추가
+        appendCurrentCandle(result, stockCode, "candle:1day:");
+        return result;
+    }
+
+    // Redis에서 현재 진행 중인 봉을 꺼내 리스트 끝에 추가
+    private void appendCurrentCandle(List<CandleResponse> result, String stockCode, String prefix) {
+        Map<Object, Object> current = candleAccumulatorService.getCurrentCandle(stockCode, prefix);
+        if (current.isEmpty()) return;
+
+        String startTime = (String) current.get("startTime");
+        LocalDateTime candleTime = LocalDateTime.parse(startTime, TIME_FORMATTER);
+        result.add(CandleResponse.fromRedis(current, candleTime));
+    }
+}

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -1,12 +1,16 @@
 package org.solmate.external.ls.websocket;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.solmate.domain.stock.dto.response.CandleResponse;
 import org.solmate.domain.stock.dto.response.StockRealtimeResponse;
 import org.solmate.domain.stock.service.CandleAccumulatorService;
 import org.solmate.external.ls.LsProperties;
@@ -42,10 +46,12 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     private WebSocketSession session;
     private final Set<String> subscribedCodes = ConcurrentHashMap.newKeySet();
 
+    // 현재 구독 중인 종목 코드 목록 반환 (스케줄러에서 사용)
     public Set<String> getSubscribedCodes() {
         return subscribedCodes;
     }
 
+    // 앱 시작 시 LS WebSocket 서버에 자동 연결
     @PostConstruct
     public void connect() {
         try {
@@ -66,11 +72,13 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         }
     }
 
+    // 연결 실패 또는 종료 시 5초 후 재연결 예약
     private void scheduleReconnect() {
         log.info("LS WebSocket 5초 후 재연결 시도");
         reconnectScheduler.schedule(this::connect, 5, TimeUnit.SECONDS);
     }
 
+    // 재연결 후 기존 구독 종목 전체 재구독
     private void resubscribeAll() {
         if (subscribedCodes.isEmpty()) return;
         log.info("LS WebSocket 재구독 시도: {}", subscribedCodes);
@@ -78,6 +86,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         subscribedCodes.forEach(code -> sendMessage(LsWsRequest.subscribe(token, code)));
     }
 
+    // LS WebSocket에 종목 실시간 체결 구독 요청
     public void subscribe(String stockCode) {
         if (subscribedCodes.contains(stockCode)) return;
         sendMessage(LsWsRequest.subscribe(lsTokenService.getToken(), stockCode));
@@ -85,6 +94,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         log.info("LS WebSocket 구독: {}", stockCode);
     }
 
+    // LS WebSocket에 종목 구독 해제 요청
     public void unsubscribe(String stockCode) {
         if (!subscribedCodes.contains(stockCode)) return;
         sendMessage(LsWsRequest.unsubscribe(lsTokenService.getToken(), stockCode));
@@ -92,6 +102,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         log.info("LS WebSocket 구독 해제: {}", stockCode);
     }
 
+    // LS WebSocket 세션으로 JSON 메시지 전송
     private void sendMessage(LsWsRequest request) {
         try {
             if (session == null || !session.isOpen()) {
@@ -106,6 +117,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         }
     }
 
+    // LS WebSocket으로부터 체결 데이터 수신 시 봉 누적 및 STOMP 브로드캐스트
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
@@ -114,13 +126,43 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             if (response.header() == null || response.body() == null) return;
 
             String stockCode = response.body().shcode();
+
+            // 모든 봉 Redis 누적
             candleAccumulatorService.accumulate(response.body());
-            messagingTemplate.convertAndSend("/topic/stocks/" + stockCode, StockRealtimeResponse.from(response.body()));
+
+            // 현재가/등락 정보 브로드캐스트 (종목 상단 현재가 표시용)
+            messagingTemplate.convertAndSend(
+                    "/topic/stocks/" + stockCode + "/quote",
+                    StockRealtimeResponse.from(response.body())
+            );
+
+            // 봉별 토픽으로 현재 진행 중인 캔들 브로드캐스트
+            broadcastCandle(stockCode, "candle:1min:",  "/topic/stocks/" + stockCode + "/candle/1min");
+            broadcastCandle(stockCode, "candle:5min:",  "/topic/stocks/" + stockCode + "/candle/5min");
+            broadcastCandle(stockCode, "candle:30min:", "/topic/stocks/" + stockCode + "/candle/30min");
+            broadcastCandle(stockCode, "candle:60min:", "/topic/stocks/" + stockCode + "/candle/60min");
+            broadcastCandle(stockCode, "candle:1day:",  "/topic/stocks/" + stockCode + "/candle/1day");
+
         } catch (Exception e) {
             log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());
         }
     }
 
+    // Redis에서 해당 봉 데이터를 읽어 STOMP 토픽으로 브로드캐스트
+    private void broadcastCandle(String stockCode, String redisPrefix, String topic) {
+        try {
+            Map<Object, Object> data = candleAccumulatorService.getCurrentCandle(stockCode, redisPrefix);
+            if (data.isEmpty()) return;
+
+            String startTime = (String) data.get("startTime");
+            LocalDateTime candleTime = LocalDateTime.parse(startTime, DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+            messagingTemplate.convertAndSend(topic, CandleResponse.fromRedis(data, candleTime));
+        } catch (Exception e) {
+            log.warn("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
+        }
+    }
+
+    // LS WebSocket 연결 종료 시 세션 초기화 후 재연결 시도
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         log.warn("LS WebSocket 연결 종료: {}", status);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #13 

## 💡 작업 배경
종목 상세 페이지에서 캔들 차트를 구현하기 위해 실시간 봉 데이터 생성 및 조회 기능이 필요했습니다. 
기존에는 1분봉 Redis 누적과 DB 저장만 구현된 상태였으며, 차트 렌더링에 필요한 다양한 봉 단위와 프론트 전달 구조가 없었습니다.


## 🧩 작업 내용

캔들 데이터 응답 DTO 생성
  • TradingView lightweight-charts에 맞춘 CandleResponse
     DTO 생성
  • time 필드를 KST 기준 Unix timestamp(초)로 변환
  • DB 엔티티(BaseCandle)와 Redis 데이터 두 가지 모두
    변환 가능하도록 팩토리 메서드 구현

다중 봉 단위 Redis 누적 및 스케줄러 추가
  • 기존 1분봉 외 5분/30분/60분/일봉 Redis 누적 로직
    추가
  • 정규장 시간(09:00~15:30) 외 체결 데이터 필터링
  • 봉 완성 시점별 스케줄러 추가 (5분/30분/매 정시/장
    마감 15:30)
  • DailyCandleRepository 추가 및 일봉 DB 저장 로직 구현

STOMP 브로드캐스트 봉별 토픽 분리
  • 기존 단일 토픽(/topic/stocks/{stockCode})에서 봉별
    토픽으로 분리
  • /topic/stocks/{stockCode}/quote — 현재가/등락
  • /topic/stocks/{stockCode}/candle/1min ~ 1day — 봉별
    실시간 캔들

분봉/일봉 조회 API 구현
  • GET /api/stocks/{stockCode}/candles/minute — 오늘
    1분봉 (DB + 진행 중인 봉)
  • GET /api/stocks/{stockCode}/candles/day?days=N — N일
     일봉 (주/월/년 탭 공용)
  • DB 저장된 과거 봉 + Redis 현재 진행 중인 봉을 합쳐서
     반환

## 📸 스크린샷(선택)


## 📝 기타
