### PR TITLE
[Feat] LS 토큰 7시 자동 갱신 및 WebSocket 재연결 구현

### DIFF
--- a/src/main/java/org/solmate/SolmateApplication.java
+++ b/src/main/java/org/solmate/SolmateApplication.java
@@ -3,9 +3,11 @@ package org.solmate;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class SolmateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/solmate/external/ls/scheduler/LsTokenScheduler.java
+++ b/src/main/java/org/solmate/external/ls/scheduler/LsTokenScheduler.java
@@ -1,0 +1,22 @@
+package org.solmate.external.ls.scheduler;
+
+import org.solmate.external.ls.websocket.LsWebSocketClient;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LsTokenScheduler {
+
+    private final LsWebSocketClient lsWebSocketClient;
+
+    @Scheduled(cron = "0 0 7 * * *")
+    public void refreshToken() {
+        log.info("LS 토큰 만료 예정 - WebSocket 재연결 시작");
+        lsWebSocketClient.reconnect();
+    }
+}

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -82,6 +82,16 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         }
     }
 
+    public void reconnect() {
+        try {
+            if (session != null && session.isOpen()) {
+                session.close();
+            }
+        } catch (Exception e) {
+            log.error("LS WebSocket 세션 종료 실패", e);
+        }
+    }
+
     private void scheduleReconnect() {
         log.info("LS WebSocket 5초 후 재연결 시도");
         reconnectScheduler.schedule(this::connect, 5, TimeUnit.SECONDS);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #36 

## 💡 작업 배경
 LS증권 토큰은 매일 갱신이 필요했다. 그래서 매일 오전 7시(장 시작 전)에 자동으로 토큰을 갱신하고 WebSocket을 재연결하여 실시간 데이터 수신을 유지하도록 구현이 필요했다.

## 🧩 작업 내용
LsTokenScheduler 파일에서 스케줄러 등록을 통하여 매일 자동 갱신하도록 구현을 하였다.

## 📸 스크린샷(선택)
<img width="964" height="385" alt="Screenshot 2026-03-20 at 4 49 10 PM" src="https://github.com/user-attachments/assets/7e755405-ce66-43ee-872a-400b89991062" />


## 📝 기타
스크린샷은 테스트용으로 1분마다 스케줄러가 돌아가도록 구현 후 스크린샷한 사진입니다. 실제로는 오전 7시마다 돌아갑니다!