### PR TITLE
[Feat] 종목별 매매내역 조회 API 구현

### DIFF
--- a/src/main/java/org/solmate/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/solmate/domain/auth/dto/request/LoginRequest.java
@@ -1,15 +1,18 @@
 package org.solmate.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
+        @Schema(example = "somate2026@gmail.com")
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         @Size(max = 30, message = "이메일은 30자를 초과할 수 없습니다.")
         String email,
 
+        @Schema(example = "string1234")
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 8, message = "비밀번호는 최소 8자 이상입니다.")
         String password

--- a/src/main/java/org/solmate/domain/trade/controller/TradeController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeController.java
@@ -1,0 +1,33 @@
+package org.solmate.domain.trade.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.trade.dto.response.TradeHistoryResponse;
+import org.solmate.domain.trade.service.TradeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Trade", description = "매매 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trades")
+public class TradeController {
+
+    private final TradeService tradeService;
+
+    @Operation(summary = "종목별 매매내역 리스트 조회")
+    @GetMapping("/{tickerCode}")
+    public ResponseEntity<ApiResponse<TradeHistoryResponse>> getTradeHistories(
+            @PathVariable String tickerCode,
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeService.getTradeHistories(userId, tickerCode));
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
@@ -25,40 +25,27 @@ public record TradeHistoryResponse(
             boolean cancelable
     ) {
         public static OrderItem from(TradeHistory trade) {
-            String side = trade.getTradeType().name();
-            String sideLabel = side.equals("BUY") ? "매수" : "매도";
-
-            String orderType = trade.getOrderType().name();
-            String orderTypeLabel = orderType.equals("LIMIT") ? "지정가" : "시장가";
-
-            String status;
-            String statusLabel;
-            switch (trade.getTradeStatus()) {
-                case EXECUTED -> { status = "FILLED";    statusLabel = "체결"; }
-                case CANCELLED -> { status = "CANCELLED"; statusLabel = "취소"; }
-                default ->        { status = "PENDING";   statusLabel = "대기"; }
-            }
-
-            boolean cancelable = trade.getTradeStatus() == TradeStatus.PENDING;
-            BigDecimal orderAmount = trade.getPrice().multiply(trade.getQuantity());
-
             return new OrderItem(
                     trade.getId(),
-                    side, sideLabel,
-                    orderType, orderTypeLabel,
+                    trade.getTradeType().name(),
+                    trade.getTradeType().getLabel(),
+                    trade.getOrderType().name(),
+                    trade.getOrderType().getLabel(),
                     trade.getPrice(),
                     trade.getQuantity(),
-                    orderAmount,
-                    status, statusLabel,
-                    cancelable
+                    trade.getPrice().multiply(trade.getQuantity()),
+                    trade.getTradeStatus().name(),
+                    trade.getTradeStatus().getLabel(),
+                    trade.getTradeStatus() == TradeStatus.PENDING
             );
         }
     }
 
     public static TradeHistoryResponse of(String stockCode, String stockName, List<TradeHistory> trades) {
-        List<OrderItem> orders = trades.stream()
-                .map(OrderItem::from)
-                .toList();
-        return new TradeHistoryResponse(stockCode, stockName, orders);
+        return new TradeHistoryResponse(
+                stockCode,
+                stockName,
+                trades.stream().map(OrderItem::from).toList()
+        );
     }
 }

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
@@ -1,0 +1,64 @@
+package org.solmate.domain.trade.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.solmate.domain.trade.entity.TradeHistory;
+import org.solmate.domain.trade.enums.TradeStatus;
+
+public record TradeHistoryResponse(
+        String stockCode,
+        String stockName,
+        List<OrderItem> orders
+) {
+    public record OrderItem(
+            Long orderId,
+            String side,
+            String sideLabel,
+            String orderType,
+            String orderTypeLabel,
+            BigDecimal orderPrice,
+            BigDecimal quantity,
+            BigDecimal orderAmount,
+            String status,
+            String statusLabel,
+            boolean cancelable
+    ) {
+        public static OrderItem from(TradeHistory trade) {
+            String side = trade.getTradeType().name();
+            String sideLabel = side.equals("BUY") ? "매수" : "매도";
+
+            String orderType = trade.getOrderType().name();
+            String orderTypeLabel = orderType.equals("LIMIT") ? "지정가" : "시장가";
+
+            String status;
+            String statusLabel;
+            switch (trade.getTradeStatus()) {
+                case EXECUTED -> { status = "FILLED";    statusLabel = "체결"; }
+                case CANCELLED -> { status = "CANCELLED"; statusLabel = "취소"; }
+                default ->        { status = "PENDING";   statusLabel = "대기"; }
+            }
+
+            boolean cancelable = trade.getTradeStatus() == TradeStatus.PENDING;
+            BigDecimal orderAmount = trade.getPrice().multiply(trade.getQuantity());
+
+            return new OrderItem(
+                    trade.getId(),
+                    side, sideLabel,
+                    orderType, orderTypeLabel,
+                    trade.getPrice(),
+                    trade.getQuantity(),
+                    orderAmount,
+                    status, statusLabel,
+                    cancelable
+            );
+        }
+    }
+
+    public static TradeHistoryResponse of(String stockCode, String stockName, List<TradeHistory> trades) {
+        List<OrderItem> orders = trades.stream()
+                .map(OrderItem::from)
+                .toList();
+        return new TradeHistoryResponse(stockCode, stockName, orders);
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/enums/OrderType.java
+++ b/src/main/java/org/solmate/domain/trade/enums/OrderType.java
@@ -1,6 +1,13 @@
 package org.solmate.domain.trade.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OrderType {
-    MARKET,  // 시장가
-    LIMIT    // 지정가
+    MARKET("시장가"),
+    LIMIT("지정가");
+
+    private final String label;
 }

--- a/src/main/java/org/solmate/domain/trade/enums/TradeStatus.java
+++ b/src/main/java/org/solmate/domain/trade/enums/TradeStatus.java
@@ -1,7 +1,14 @@
 package org.solmate.domain.trade.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum TradeStatus {
-    PENDING,
-    EXECUTED,
-    CANCELLED
+    PENDING("대기"),
+    FILLED("체결"),
+    CANCELLED("취소");
+
+    private final String label;
 }

--- a/src/main/java/org/solmate/domain/trade/enums/TradeType.java
+++ b/src/main/java/org/solmate/domain/trade/enums/TradeType.java
@@ -1,6 +1,13 @@
 package org.solmate.domain.trade.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum TradeType {
-    BUY,
-    SELL
+    BUY("매수"),
+    SELL("매도");
+
+    private final String label;
 }

--- a/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
@@ -6,8 +6,13 @@ import org.solmate.domain.trade.entity.TradeHistory;
 import org.solmate.domain.trade.enums.TradeStatus;
 import org.solmate.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TradeHistoryRepository extends JpaRepository<TradeHistory, Long> {
 
     List<TradeHistory> findByUserAndTradeStatus(User user, TradeStatus tradeStatus);
+
+    @Query("SELECT t FROM TradeHistory t JOIN FETCH t.stock WHERE t.user.id = :userId AND t.stock.tickerCode = :tickerCode ORDER BY t.createdAt DESC")
+    List<TradeHistory> findByUserIdAndTickerCode(@Param("userId") Long userId, @Param("tickerCode") String tickerCode);
 }

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -1,0 +1,34 @@
+package org.solmate.domain.trade.service;
+
+import java.util.List;
+
+import org.solmate.domain.stock.entity.Stock;
+import org.solmate.domain.stock.repository.StockRepository;
+import org.solmate.domain.trade.dto.response.TradeHistoryResponse;
+import org.solmate.domain.trade.entity.TradeHistory;
+import org.solmate.domain.trade.repository.TradeHistoryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TradeService {
+
+    private final TradeHistoryRepository tradeHistoryRepository;
+    private final StockRepository stockRepository;
+
+    public TradeHistoryResponse getTradeHistories(Long userId, String tickerCode) {
+        List<TradeHistory> trades = tradeHistoryRepository.findByUserIdAndTickerCode(userId, tickerCode);
+
+        String stockName = trades.isEmpty()
+                ? stockRepository.findByTickerCode(tickerCode)
+                        .map(Stock::getStockName)
+                        .orElse("")
+                : trades.get(0).getStock().getStockName();
+
+        return TradeHistoryResponse.of(tickerCode, stockName, trades);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #34 

## 💡 작업 배경
종목별 매매내역을 조회하는 API가 없어 프론트엔드에서 사용자의 거래 이력을 표시할 수 없었다.
또한 TradeStatus enum 값이 EXECUTED로 되어 있어 금융 도메인 표준 용어인 FILLED와 혼용될 여지가 있어 통일이 필요했다.

## 🧩 작업 내용
  - GET /api/trades/{tickerCode} 엔드포인트 구현                                
    - JWT 인증된 유저의 특정 종목 매매내역 리스트 반환
    - 종목명, 매수/매도 구분, 주문 유형, 체결 금액, 상태, 취소 가능 여부 포함   
  - TradeStatus.EXECUTED → FILLED 로 변경 (DB 마이그레이션 포함)                
  - TradeStatus, TradeType, OrderType enum에 한글 라벨 필드 추가                
  - 로그인 Request DTO 스웨거 예시값 설정


## 📸 스크린샷(선택)
<img width="1191" height="741" alt="Screenshot 2026-03-21 at 2 25 43 PM" src="https://github.com/user-attachments/assets/ed83568f-de16-4c3f-a65c-878a730fad89" />


## 📝 기타
