### PR TITLE
[Fix] StockAutoSubscriber에서 addSubscribedCode를 subscribe로 변경

### DIFF
--- a/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
@@ -25,7 +25,7 @@ public class StockAutoSubscriber {
         log.info("자동 구독 시작: 총 {}개 종목", codes.size());
         codes.stream()
                 .limit(200)
-                .forEach(lsWebSocketClient::addSubscribedCode);
-        log.info("자동 구독 등록 완료 (WebSocket 연결 시 구독 시작)");
+                .forEach(lsWebSocketClient::subscribe);
+        log.info("자동 구독 등록 완료: {}개 종목", Math.min(codes.size(), 200));
     }
 }

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -113,12 +113,13 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     // 재연결 후 기존 구독 종목 전체 재구독
     private void resubscribeAll() {
         if (subscribedCodes.isEmpty()) return;
-        log.info("LS WebSocket 재구독 시도: {}", subscribedCodes);
+        log.info("LS WebSocket 재구독 시작: {}개 종목", subscribedCodes.size());
         String token = lsTokenService.getToken();
         subscribedCodes.forEach(code -> {
             sendMessage(LsWsRequest.subscribe(token, code));
             sendMessage(LsWsRequest.subscribeOrderBook(token, code));
         });
+        log.info("LS WebSocket 재구독 완료: {}개 종목 - {}", subscribedCodes.size(), subscribedCodes);
     }
 
     // LS WebSocket에 종목 실시간 체결 구독 요청


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #46 

## 💡 작업 배경
  앱 시작 시 StockAutoSubscriber에서 addSubscribedCode()만 호출해 in-memory Set에만 종목을 추가하고 실제 LS WebSocket 구독 메시지는 전송하지 않는 버그가 생기고 있다.
WebSocket 연결 완료 시점에는 Set이 비어있고, Set에 코드가 채워지는 시점에는 이미 연결이 완료된 후라 resubscribeAll()이 재실행되지 않아 200개 종목의 실시간 시세를 수신하지 못하는 상태이다.

## 🧩 작업 내용
  - addSubscribedCode() → subscribe() 로 변경
    - WebSocket 연결된 경우: 즉시 구독 메시지 전송
    - 미연결 상태: Set에 추가 후 resubscribeAll()이 재연결 시 처리
  - resubscribeAll() 로그 개선: 구독 시작/완료 시점에 종목 수 및 목록 출력

## 📸 스크린샷(선택)
<img width="782" height="285" alt="Screenshot 2026-03-23 at 8 56 41 AM" src="https://github.com/user-attachments/assets/e60ed617-641b-42bd-a03d-09997877f533" />


## 📝 기타
