### PR TITLE
[Refactor] 주문 취소 시 Redis ZSet에서 해당 주문 제거

### DIFF
--- a/src/main/java/org/solmate/domain/trade/service/TradeOrderService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeOrderService.java
@@ -1,5 +1,7 @@
 package org.solmate.domain.trade.service;
 
+import java.util.Set;
+
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.account.entity.Account;
@@ -12,11 +14,17 @@ import org.solmate.domain.trade.repository.HoldingsRepository;
 import org.solmate.domain.trade.repository.TradeDiaryRepository;
 import org.solmate.domain.trade.repository.TradeHistoryRepository;
 import org.solmate.domain.user.entity.User;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,6 +34,8 @@ public class TradeOrderService {
     private final TradeDiaryRepository tradeDiaryRepository;
     private final AccountRepository accountRepository;
     private final HoldingsRepository holdingsRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
     public void cancelOrder(Long userId, Long orderId) {
@@ -66,5 +76,28 @@ public class TradeOrderService {
 
         // 해당 주문에 연결된 매매일지 삭제
         tradeDiaryRepository.deleteByTradeHistoryId(orderId);
+
+        // Redis ZSet에서 해당 주문 제거
+        removeOrderFromRedis(tradeHistory);
+    }
+
+    private void removeOrderFromRedis(TradeHistory tradeHistory) {
+        String type = tradeHistory.getTradeType() == TradeType.BUY ? "buy" : "sell";
+        String key = "orders:" + type + ":" + tradeHistory.getStock().getTickerCode();
+
+        Set<String> orders = redisTemplate.opsForZSet().range(key, 0, -1);
+        if (orders == null) return;
+
+        for (String json : orders) {
+            try {
+                JsonNode node = objectMapper.readTree(json);
+                if (node.get("orderId").asLong() == tradeHistory.getId()) {
+                    redisTemplate.opsForZSet().remove(key, json);
+                    return;
+                }
+            } catch (Exception e) {
+                log.error("Redis 주문 제거 실패 - orderId: {}", tradeHistory.getId(), e);
+            }
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
 closed #48 

## 💡 작업 배경
 주문 취소 시 DB 상태만 CANCELLED로 변경하고 Redis ZSet에서 해당 주문을 제거하지 않아, 취소된 주문이 Redis에 계속 남아있는 문제가 있었습니다.
이로 인해 실시간 시세가 수신될 때마다 체결 로직이 취소된 주문을 조회하여 불필요한 DB 조회가 반복적으로 발생했습니다.

## 🧩 작업 내용
 - TradeOrderService.cancelOrder() 에 removeOrderFromRedis() 메서드 추가                                                                                                     
  - 주문 취소 완료 시 orders:buy:{ticker} 또는 orders:sell:{ticker} ZSet에서 해당 주문 제거
  - 취소된 주문이 체결 사이클에서 불필요하게 처리되는 오버헤드 제거  

## 📸 스크린샷(선택)


## 📝 기타
