### PR TITLE
[Fix] 앱 시작 시 LS WebSocket 대량 구독 메시지 드롭 현상 수정

### DIFF
--- a/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
@@ -23,9 +23,19 @@ public class StockAutoSubscriber {
     public void autoSubscribe() {
         List<String> codes = stockRepository.findAllTickerCodes();
         log.info("자동 구독 시작: 총 {}개 종목", codes.size());
-        codes.stream()
-                .limit(200)
-                .forEach(lsWebSocketClient::subscribe);
-        log.info("자동 구독 등록 완료: {}개 종목", Math.min(codes.size(), 200));
+
+        List<String> targets = codes.stream().limit(200).toList();
+        for (int i = 0; i < targets.size(); i++) {
+            lsWebSocketClient.subscribe(targets.get(i));
+            log.info("자동 구독 진행: {}/{} - {}", i + 1, targets.size(), targets.get(i));
+            try {
+                Thread.sleep(50); // 50ms 간격으로 전송
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        log.info("자동 구독 등록 완료: {}개 종목", targets.size());
     }
 }

--- a/src/main/java/org/solmate/domain/trade/dto/response/HoldingsResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/HoldingsResponse.java
@@ -1,0 +1,44 @@
+package org.solmate.domain.trade.dto.response;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.solmate.domain.trade.entity.Holdings;
+
+public record HoldingsResponse(
+        String tickerCode,
+        String stockName,
+        String stockLogo,
+        BigDecimal quantity,
+        BigDecimal avgPrice,
+        BigDecimal currentPrice,
+        BigDecimal evaluation,
+        BigDecimal returnRate,
+        BigDecimal returnAmount
+) {
+    public static HoldingsResponse of(Holdings holdings, BigDecimal currentPrice) {
+        BigDecimal quantity = holdings.getQuantity();
+        BigDecimal avgPrice = holdings.getAvgPrice();
+
+        BigDecimal evaluation = currentPrice.multiply(quantity).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal returnAmount = currentPrice.subtract(avgPrice).multiply(quantity).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal returnRate = avgPrice.compareTo(BigDecimal.ZERO) == 0
+                ? BigDecimal.ZERO
+                : currentPrice.subtract(avgPrice)
+                        .divide(avgPrice, 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(2, RoundingMode.HALF_UP);
+
+        return new HoldingsResponse(
+                holdings.getTickerCode(),
+                holdings.getStock().getStockName(),
+                holdings.getStock().getStockLogo(),
+                quantity,
+                avgPrice,
+                currentPrice,
+                evaluation,
+                returnRate,
+                returnAmount
+        );
+    }
+}

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -203,7 +203,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                 }
             }
         } catch (Exception e) {
-            log.warn("LS WebSocket 메시지 파싱 실패: {}", message.getPayload());
+            log.warn("LS WebSocket 메시지 파싱 실패: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -149,7 +149,6 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                 return;
             }
             String json = objectMapper.writeValueAsString(request);
-            log.info("LS WebSocket 전송: {}", json);
             session.sendMessage(new TextMessage(json));
         } catch (IOException e) {
             log.error("LS WebSocket 메시지 전송 실패", e);
@@ -161,8 +160,6 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
             String payload = message.getPayload();
-            log.info("LS WebSocket 수신: {}", payload);
-
             JsonNode node = objectMapper.readTree(payload);
             JsonNode headerNode = node.get("header");
             if (headerNode == null || node.get("body") == null || node.get("body").isNull()) return;


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #51

## 💡 작업 배경

앱 시작 시 200개 종목 구독 메시지를 한꺼번에 전송하면 LS 서버에서 일부  메시지를 드롭하는 현상 발견이 되었다. 
특정 종목이 subscribedCodes Set에는 등록되어있으나 실제 실시간 시세 데이터가 수신되지 않았으며, 수동으로 구독 해제 후  재구독 시 정상 동작하는 것으로 원인이 확인되었다.
                                      
## 🧩 작업 내용
  - 200개 종목 구독 시 종목당 50ms 딜레이 추가로 LS 서버 메시지 드롭 방지       
  - 구독 진행 상황 로그 추가 (자동 구독 진행: 1/200 - 005930)                   
  - WebSocket 파싱 실패 로그에 payload 대신 실제 에러 메시지 출력하도록 수정
  - HoldingsResponse DTO 추가 (보유 종목 조회 API용)  
  - 로그 레벨 조정

## 📸 스크린샷(선택)


## 📝 기타

  - LS 서버의 정확한 rate limit 기준 미확인, 딜레이 조정 필요 시  Thread.sleep(50) 값 변경                                                      
  - 200개 × 50ms = 앱 시작 후 약 10초 뒤 전체 구독 완료  
