### PR TITLE
[Fix] 체결 알림 payload jsonb 타입 오류 수정 및 체결 정보 추가

### DIFF
--- a/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
+++ b/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
@@ -50,7 +50,7 @@ public class MarketIndicatorService {
             );
 
             stringRedisTemplate.opsForValue().set(redisKey, json);
-            log.info("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
+            log.debug("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
 
         } catch (Exception e) {
             log.error("시장 지표 Redis 저장 실패: {}", e.getMessage());
@@ -74,7 +74,7 @@ public class MarketIndicatorService {
             );
 
             stringRedisTemplate.opsForValue().set(USD_KRW_KEY, json);
-            log.info("환율 Redis 저장 완료 - {}: {}", USD_KRW_KEY, json);
+            log.debug("환율 Redis 저장 완료 - {}: {}", USD_KRW_KEY, json);
 
         } catch (Exception e) {
             log.error("환율 Redis 저장 실패: {}", e.getMessage());

--- a/src/main/java/org/solmate/domain/notification/entity/Notification.java
+++ b/src/main/java/org/solmate/domain/notification/entity/Notification.java
@@ -45,7 +45,8 @@ public class Notification extends BaseEntity {
     @Column(name = "is_read", nullable = false)
     private boolean isRead = false;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "jsonb")
+    @org.hibernate.annotations.JdbcTypeCode(org.hibernate.type.SqlTypes.JSON)
     private String payload;
 
     @Column(name = "act_url")

--- a/src/main/java/org/solmate/domain/notification/entity/Notification.java
+++ b/src/main/java/org/solmate/domain/notification/entity/Notification.java
@@ -45,7 +45,7 @@ public class Notification extends BaseEntity {
     @Column(name = "is_read", nullable = false)
     private boolean isRead = false;
 
-    @Column(columnDefinition = "jsonb")
+    @Column(columnDefinition = "TEXT")
     private String payload;
 
     @Column(name = "act_url")

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -162,7 +162,7 @@ public class CandleAccumulatorService {
 
             minuteCandleRepository.save(candle);
             redisTemplate.delete(key);
-            log.info("1분봉 저장 완료: {} {}", stockCode, candleTime);
+            log.debug("1분봉 저장 완료: {} {}", stockCode, candleTime);
         } catch (Exception e) {
             log.error("1분봉 저장 실패: {}", stockCode, e);
         }

--- a/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
@@ -27,7 +27,7 @@ public class StockAutoSubscriber {
         List<String> targets = codes.stream().limit(200).toList();
         for (int i = 0; i < targets.size(); i++) {
             lsWebSocketClient.subscribe(targets.get(i));
-            log.info("자동 구독 진행: {}/{} - {}", i + 1, targets.size(), targets.get(i));
+            log.debug("자동 구독 진행: {}/{} - {}", i + 1, targets.size(), targets.get(i));
             try {
                 Thread.sleep(50); // 50ms 간격으로 전송
             } catch (InterruptedException e) {

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -2,6 +2,7 @@ package org.solmate.domain.trade.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -181,15 +182,32 @@ public class OrderMatchingService {
     // 체결 알림 저장
     private void saveNotification(User user, TradeHistory tradeHistory, BigDecimal currentPrice, BigDecimal quantity) {
         String stockName = tradeHistory.getStock().getStockName();
+        String ticker = tradeHistory.getStock().getTickerCode();
+        String side = tradeHistory.getTradeType() == TradeType.BUY ? "BUY" : "SELL";
         String tradeTypeStr = tradeHistory.getTradeType() == TradeType.BUY ? "매수" : "매도";
         String content = String.format("[%s] %s %s주가 %s원에 체결되었습니다.",
             stockName, tradeTypeStr, quantity.toPlainString(), currentPrice.toPlainString());
+
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsString(Map.of(
+                "orderId", tradeHistory.getId(),
+                "stockCode", ticker,
+                "stockName", stockName,
+                "side", side,
+                "filledPrice", currentPrice,
+                "filledQuantity", quantity
+            ));
+        } catch (Exception e) {
+            payload = null;
+        }
 
         Notification notification = Notification.builder()
             .user(user)
             .notificationType(NotificationType.TRADE)
             .category(NotificationCategory.TRADING)
             .content(content)
+            .payload(payload)
             .build();
 
         notificationRepository.save(notification);

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -129,7 +129,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         sendMessage(LsWsRequest.subscribe(token, stockCode));
         sendMessage(LsWsRequest.subscribeOrderBook(token, stockCode));
         subscribedCodes.add(stockCode);
-        log.info("LS WebSocket 구독: {}", stockCode);
+        log.debug("LS WebSocket 구독: {}", stockCode);
     }
 
     public void unsubscribe(String stockCode) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #54 

## 💡 작업 배경
  notification 테이블의 payload 컬럼이 jsonb 타입인데 Hibernate가 String을
  그대로 insert 시도하면서 타입 불일치 오류 발생 → 체결 시 전체 트랜잭션 롤백 


## 🧩 작업 내용
  - `Notification.java` - `@JdbcTypeCode(SqlTypes.JSON)` 추가로 jsonb 타입 변환 처리                                                                                                
  - `OrderMatchingService.java` - 체결 알림 payload에 체결 정보 JSON 추가 
  - payload 예시
   {                                                                                                                                                                                 
    "orderId": 6, 
    "stockCode": "005930",
    "stockName": "삼성전자", 
    "side": "BUY",
    "filledPrice": 73400,                                                                                                                                                           
    "filledQuantity": 10                                                                                                                                                              
}


## 📸 스크린샷(선택)


## 📝 기타
