### PR TITLE
[Fix] 체결 시 TradeDiary status PENDING → FILLED 업데이트 추가

### DIFF
--- a/src/main/java/org/solmate/domain/trade/entity/TradeDiary.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeDiary.java
@@ -46,6 +46,10 @@ public class TradeDiary extends BaseEntity {
     @Column(nullable = false)
     private TradeDiaryStatus status;
 
+    public void updateStatus(TradeDiaryStatus status) {
+        this.status = status;
+    }
+
     @Builder
     public TradeDiary(User user, TradeHistory tradeHistory, String content, TradeDiaryStatus status) {
         this.user = user;

--- a/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
@@ -1,9 +1,13 @@
 package org.solmate.domain.trade.repository;
 
+import java.util.Optional;
+
 import org.solmate.domain.trade.entity.TradeDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TradeDiaryRepository extends JpaRepository<TradeDiary, Long> {
 
     void deleteByTradeHistoryId(Long tradeHistoryId);
+
+    Optional<TradeDiary> findByTradeHistoryId(Long tradeHistoryId);
 }

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -16,7 +16,10 @@ import org.solmate.domain.trade.entity.Holdings;
 import org.solmate.domain.trade.entity.TradeHistory;
 import org.solmate.domain.trade.enums.TradeStatus;
 import org.solmate.domain.trade.enums.TradeType;
+import org.solmate.domain.trade.entity.TradeDiary;
+import org.solmate.domain.trade.enums.TradeDiaryStatus;
 import org.solmate.domain.trade.repository.HoldingsRepository;
+import org.solmate.domain.trade.repository.TradeDiaryRepository;
 import org.solmate.domain.trade.repository.TradeHistoryRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
@@ -36,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderMatchingService {
 
     private final TradeHistoryRepository tradeHistoryRepository;
+    private final TradeDiaryRepository tradeDiaryRepository;
     private final HoldingsRepository holdingsRepository;
     private final AccountRepository accountRepository;
     private final UserRepository userRepository;
@@ -103,6 +107,10 @@ public class OrderMatchingService {
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
 
+                    // TradeDiary 상태 업데이트
+                    tradeDiaryRepository.findByTradeHistoryId(orderId)
+                        .ifPresent(diary -> diary.updateStatus(TradeDiaryStatus.FILLED));
+
                     // 알림 저장
                     saveNotification(user, tradeHistory, currentPrice, quantity);
 
@@ -159,6 +167,10 @@ public class OrderMatchingService {
 
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
+
+                    // TradeDiary 상태 업데이트
+                    tradeDiaryRepository.findByTradeHistoryId(orderId)
+                        .ifPresent(diary -> diary.updateStatus(TradeDiaryStatus.FILLED));
 
                     // 알림 저장
                     saveNotification(user, tradeHistory, currentPrice, quantity);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #56 

## 💡 작업 배경
매수 체결 시에 TradeDiary 가 체결로 수정이 안되는 이슈가 발생하였다. 

## 🧩 작업 내용
TradeDiary 의 status를 업데이트 할 수 있게 변경


