### PR TITLE
[Feat] 지수데이터 실시간 브로드캐스트

### DIFF
--- a/src/main/java/org/solmate/domain/market/controller/MarketIndicatorController.java
+++ b/src/main/java/org/solmate/domain/market/controller/MarketIndicatorController.java
@@ -1,7 +1,10 @@
 package org.solmate.domain.market.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.market.dto.response.MarketIndicatorResponse;
 import org.solmate.domain.market.service.MarketIndicatorService;
 import org.springframework.http.ResponseEntity;
@@ -17,8 +20,9 @@ public class MarketIndicatorController {
 
     private final MarketIndicatorService marketIndicatorService;
 
+    @Operation(summary = "시장 지표 조회 (KOSPI, KOSDAQ, USD/KRW)")
     @GetMapping("/market-indicators")
-    public ResponseEntity<MarketIndicatorResponse> getMarketIndicators() {
-        return ResponseEntity.ok(marketIndicatorService.getMarketIndicators());
+    public ResponseEntity<ApiResponse<MarketIndicatorResponse>> getMarketIndicators() {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, marketIndicatorService.getMarketIndicators());
     }
 }

--- a/src/main/java/org/solmate/domain/market/dto/response/MarketIndicatorRealtimeResponse.java
+++ b/src/main/java/org/solmate/domain/market/dto/response/MarketIndicatorRealtimeResponse.java
@@ -1,0 +1,44 @@
+package org.solmate.domain.market.dto.response;
+
+import org.solmate.external.ls.dto.websocket.LsWsCurrencyResponse;
+import org.solmate.external.ls.dto.websocket.LsWsIndexResponse;
+
+public record MarketIndicatorRealtimeResponse(
+        String type,        // "KOSPI", "KOSDAQ", "USD_KRW"
+        double current,     // 현재 지수/환율
+        double change,      // 전일 대비
+        double changeRate,  // 등락률
+        String sign,        // 전일대비구분 (1=상한, 2=상승, 3=보합, 4=하한, 5=하락)
+        double high,        // 당일 고가
+        double low,         // 당일 저가
+        String asOf         // 시간 (HHMMSS)
+) {
+    public static MarketIndicatorRealtimeResponse fromIndex(LsWsIndexResponse response) {
+        String type = "001".equals(response.header().tr_key()) ? "KOSPI" : "KOSDAQ";
+        LsWsIndexResponse.Body body = response.body();
+        return new MarketIndicatorRealtimeResponse(
+                type,
+                Double.parseDouble(body.jisu().trim()),
+                Double.parseDouble(body.change().trim()),
+                Double.parseDouble(body.drate().trim()),
+                body.sign(),
+                Double.parseDouble(body.highjisu().trim()),
+                Double.parseDouble(body.lowjisu().trim()),
+                body.time()
+        );
+    }
+
+    public static MarketIndicatorRealtimeResponse fromCurrency(LsWsCurrencyResponse response) {
+        LsWsCurrencyResponse.Body body = response.body();
+        return new MarketIndicatorRealtimeResponse(
+                "USD_KRW",
+                Double.parseDouble(body.price().trim()),
+                Double.parseDouble(body.change().trim()),
+                Double.parseDouble(body.drate().trim()),
+                body.sign(),
+                Double.parseDouble(body.high().trim()),
+                Double.parseDouble(body.low().trim()),
+                body.time()
+        );
+    }
+}

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -10,8 +10,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.solmate.domain.stock.dto.response.CandleResponse;
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.market.dto.response.MarketIndicatorRealtimeResponse;
 import org.solmate.domain.market.service.MarketIndicatorService;
+import org.solmate.domain.stock.dto.response.CandleResponse;
 import org.solmate.domain.stock.dto.response.StockOrderBookResponse;
 import org.solmate.domain.stock.dto.response.StockRealtimeResponse;
 import org.solmate.domain.stock.service.CandleAccumulatorService;
@@ -169,10 +172,14 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             if ("IJ_".equals(trCd)) {
                 LsWsIndexResponse response = objectMapper.treeToValue(node, LsWsIndexResponse.class);
                 marketIndicatorService.saveIndex(response);
+                messagingTemplate.convertAndSend("/topic/market/indicators",
+                        new ApiResponse<>(true, SuccessStatus.SUCCESS_200.getCode(), SuccessStatus.SUCCESS_200.getMessage(), MarketIndicatorRealtimeResponse.fromIndex(response)));
 
             } else if ("CUR".equals(trCd)) {
                 LsWsCurrencyResponse response = objectMapper.treeToValue(node, LsWsCurrencyResponse.class);
                 marketIndicatorService.saveCurrency(response);
+                messagingTemplate.convertAndSend("/topic/market/indicators",
+                        new ApiResponse<>(true, SuccessStatus.SUCCESS_200.getCode(), SuccessStatus.SUCCESS_200.getMessage(), MarketIndicatorRealtimeResponse.fromCurrency(response)));
 
             } else if ("US3".equals(trCd)) {
                 LsWsStockResponse response = objectMapper.treeToValue(node, LsWsStockResponse.class);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #58 

## 💡 작업 배경
LS WebSocket에서 받은 지수/환율 데이터를 Redis에 저장하는 것에 그치지 않고, 프론트엔드로 실시간 브로드캐스트 

## 🧩 작업 내용
1. MarketIndicatorRealtimeResponse.java (신규 생성)
  - 경로: domain/market/dto/response/                                                                                                             
  - STOMP 브로드캐스트 전용 record                                                                                                                
  - 기존 StockRealtimeResponse와 동일한 패턴 (record + from() 팩토리)
  - fromIndex(), fromCurrency() 팩토리 메서드로 LS WebSocket 응답을 변환                                                                          
                                                                                                                                                  
  2. LsWebSocketClient.java (수정)                                                                                                                
  - IJ_ (지수) 수신 시 Redis 저장 후 /topic/market/indicators로 브로드캐스트 추가                                                                 
  - CUR (환율) 수신 시 Redis 저장 후 /topic/market/indicators로 브로드캐스트 추가                                                                 
  - US3, UH1, candle 등 기존 로직 변경 없음                                      
                                                                                                                                                  
  3. MarketIndicatorController.java (수정)                                                                                                        
  - 응답 형식을 다른 API와 동일하게 ApiResponse 래핑으로 통일                                                                                     
  - @Operation Swagger 어노테이션 추가 

## 📸 스크린샷(선택)


## 📝 기타
{               
    "isSuccess": true,
    "code": "SOLMATE_200",                                                                                                                        
    "message": "성공입니다.",
    "data": {                                                                                                                                     
      "type": "KOSPI",
      "current": 2543.21,                                                                                                                         
      "change": 12.34,
      "changeRate": 0.49,                                                                                                                         
      "sign": "2",                                                                                                                                
      "high": 2550.0,
      "low": 2530.0,                                                                                                                              
      "asOf": "133045"
    }
  }   