### PR TITLE
[Feat] 보유 종목 조회 API 구현

### DIFF
--- a/src/main/java/org/solmate/common/s3/S3Service.java
+++ b/src/main/java/org/solmate/common/s3/S3Service.java
@@ -63,8 +63,8 @@ public class S3Service {
                 .build();
     }
 
-    private String buildFileUrl(String key) {
-        return "https://" + bucket + ".s3.amazonaws.com/" + key;
+    public String buildFileUrl(String key) {
+        return "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + key;
     }
 
     private String extractKey(String fileUrl) {

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -33,7 +33,8 @@ public enum SuccessStatus implements BaseStatus {
      */
     MOCK_DATA_INIT_SUCCESS("TRADE_200", HttpStatus.OK, "Mock 시세 데이터 초기화 성공"),
     BUY_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매수 주문 접수 성공"),
-    SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공");
+    SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
+    HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/solmate/domain/auth/dto/request/LoginRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record LoginRequest(
-        @Schema(example = "somate2026@gmail.com")
+        @Schema(example = "2026solmate@gmail.com")
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         @Size(max = 30, message = "이메일은 30자를 초과할 수 없습니다.")

--- a/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
@@ -1,0 +1,33 @@
+package org.solmate.domain.trade.controller;
+
+import java.util.List;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.trade.dto.response.HoldingsResponse;
+import org.solmate.domain.trade.service.HoldingsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Holdings", description = "보유 종목 API")
+@RestController
+@RequestMapping("/api/holdings")
+@RequiredArgsConstructor
+public class HoldingsController {
+
+    private final HoldingsService holdingsService;
+
+    @Operation(summary = "보유 종목 조회", description = "로그인한 사용자의 보유 종목 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<HoldingsResponse>>> getHoldings(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(SuccessStatus.HOLDINGS_SUCCESS, holdingsService.getHoldings(userId));
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
@@ -9,6 +9,7 @@ import org.solmate.domain.trade.service.HoldingsService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,4 +31,13 @@ public class HoldingsController {
             @AuthenticationPrincipal Long userId) {
         return ApiResponse.success(SuccessStatus.HOLDINGS_SUCCESS, holdingsService.getHoldings(userId));
     }
+
+
+    @Operation(summary = "타인 보유 종목 조회", description = "타인의 보유 종목 목록을 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<List<HoldingsResponse>>> getOtherHoldings(@PathVariable Long userId) {
+        return ApiResponse.success(SuccessStatus.HOLDINGS_SUCCESS, holdingsService.getHoldings(userId));
+    }
+
+
 }

--- a/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
@@ -7,7 +7,7 @@ import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.trade.dto.response.HoldingsResponse;
 import org.solmate.domain.trade.service.HoldingsService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,8 +26,8 @@ public class HoldingsController {
 
     @Operation(summary = "보유 종목 조회", description = "로그인한 사용자의 보유 종목 목록을 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<HoldingsResponse>>> getHoldings(Authentication authentication) {
-        Long userId = (Long) authentication.getPrincipal();
+    public ResponseEntity<ApiResponse<List<HoldingsResponse>>> getHoldings(
+            @AuthenticationPrincipal Long userId) {
         return ApiResponse.success(SuccessStatus.HOLDINGS_SUCCESS, holdingsService.getHoldings(userId));
     }
 }

--- a/src/main/java/org/solmate/domain/trade/controller/TradeController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeController.java
@@ -8,7 +8,6 @@ import org.solmate.domain.trade.dto.response.OrderResponse;
 import org.solmate.domain.trade.dto.response.TradeHistoryResponse;
 import org.solmate.domain.trade.service.TradeService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,15 +30,17 @@ public class TradeController {
 
     @Operation(summary = "매수 주문", description = "시장가/지정가 매수 주문을 접수합니다.")
     @PostMapping("/buy")
-    public ResponseEntity<ApiResponse<OrderResponse>> buyOrder(Authentication authentication, @RequestBody BuyOrderRequest request) {
-        Long userId = (Long) authentication.getPrincipal();
+    public ResponseEntity<ApiResponse<OrderResponse>> buyOrder(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody BuyOrderRequest request) {
         return ApiResponse.success(SuccessStatus.BUY_ORDER_SUCCESS, tradeService.buyOrder(userId, request));
     }
 
     @Operation(summary = "매도 주문", description = "시장가/지정가 매도 주문을 접수합니다.")
     @PostMapping("/sell")
-    public ResponseEntity<ApiResponse<OrderResponse>> sellOrder(Authentication authentication, @RequestBody SellOrderRequest request) {
-        Long userId = (Long) authentication.getPrincipal();
+    public ResponseEntity<ApiResponse<OrderResponse>> sellOrder(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody SellOrderRequest request) {
         return ApiResponse.success(SuccessStatus.SELL_ORDER_SUCCESS, tradeService.sellOrder(userId, request));
     }
 

--- a/src/main/java/org/solmate/domain/trade/controller/TradeOrderController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeOrderController.java
@@ -1,6 +1,5 @@
 package org.solmate.domain.trade.controller;
 
-import org.solmate.common.jwt.CustomUserDetails;
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.trade.service.TradeOrderService;

--- a/src/main/java/org/solmate/domain/trade/controller/TradeOrderController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeOrderController.java
@@ -1,5 +1,6 @@
 package org.solmate.domain.trade.controller;
 
+import org.solmate.common.jwt.CustomUserDetails;
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.trade.service.TradeOrderService;

--- a/src/main/java/org/solmate/domain/trade/dto/response/HoldingsResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/HoldingsResponse.java
@@ -1,0 +1,44 @@
+package org.solmate.domain.trade.dto.response;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.solmate.domain.trade.entity.Holdings;
+
+public record HoldingsResponse(
+        String tickerCode,
+        String stockName,
+        String stockLogo,
+        BigDecimal quantity,
+        BigDecimal avgPrice,
+        BigDecimal currentPrice,
+        BigDecimal evaluation,
+        BigDecimal returnRate,
+        BigDecimal returnAmount
+) {
+    public static HoldingsResponse of(Holdings holdings, BigDecimal currentPrice) {
+        BigDecimal quantity = holdings.getQuantity();
+        BigDecimal avgPrice = holdings.getAvgPrice();
+
+        BigDecimal evaluation = currentPrice.multiply(quantity).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal returnAmount = currentPrice.subtract(avgPrice).multiply(quantity).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal returnRate = avgPrice.compareTo(BigDecimal.ZERO) == 0
+                ? BigDecimal.ZERO
+                : currentPrice.subtract(avgPrice)
+                        .divide(avgPrice, 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(2, RoundingMode.HALF_UP);
+
+        return new HoldingsResponse(
+                holdings.getTickerCode(),
+                holdings.getStock().getStockName(),
+                holdings.getStock().getStockLogo(),
+                quantity,
+                avgPrice,
+                currentPrice,
+                evaluation,
+                returnRate,
+                returnAmount
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/dto/response/HoldingsResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/HoldingsResponse.java
@@ -3,6 +3,7 @@ package org.solmate.domain.trade.dto.response;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import org.solmate.common.s3.S3Service;
 import org.solmate.domain.trade.entity.Holdings;
 
 public record HoldingsResponse(
@@ -16,7 +17,7 @@ public record HoldingsResponse(
         BigDecimal returnRate,
         BigDecimal returnAmount
 ) {
-    public static HoldingsResponse of(Holdings holdings, BigDecimal currentPrice) {
+    public static HoldingsResponse of(Holdings holdings, BigDecimal currentPrice, S3Service s3Service) {
         BigDecimal quantity = holdings.getQuantity();
         BigDecimal avgPrice = holdings.getAvgPrice();
 
@@ -29,10 +30,13 @@ public record HoldingsResponse(
                         .multiply(BigDecimal.valueOf(100))
                         .setScale(2, RoundingMode.HALF_UP);
 
+        String logoKey = holdings.getStock().getStockLogo();
+        String stockLogo = (logoKey != null) ? s3Service.buildFileUrl(logoKey) : null;
+
         return new HoldingsResponse(
                 holdings.getTickerCode(),
                 holdings.getStock().getStockName(),
-                holdings.getStock().getStockLogo(),
+                stockLogo,
                 quantity,
                 avgPrice,
                 currentPrice,

--- a/src/main/java/org/solmate/domain/trade/repository/HoldingsRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/HoldingsRepository.java
@@ -22,4 +22,7 @@ public interface HoldingsRepository extends JpaRepository<Holdings, Long> {
     Optional<Holdings> findByUserAndTickerCodeWithLock(@Param("user") User user, @Param("tickerCode") String tickerCode);
 
     List<Holdings> findByUser(User user);
+
+    @Query("SELECT h FROM Holdings h JOIN FETCH h.stock WHERE h.user.id = :userId")
+    List<Holdings> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
+++ b/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
@@ -1,0 +1,38 @@
+package org.solmate.domain.trade.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.trade.dto.response.HoldingsResponse;
+import org.solmate.domain.trade.entity.Holdings;
+import org.solmate.domain.trade.repository.HoldingsRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HoldingsService {
+
+    private final HoldingsRepository holdingsRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    @Transactional(readOnly = true)
+    public List<HoldingsResponse> getHoldings(Long userId) {
+        List<Holdings> holdings = holdingsRepository.findByUserId(userId);
+
+        return holdings.stream()
+            .map(h -> HoldingsResponse.of(h, getCurrentPrice(h.getTickerCode())))
+            .toList();
+    }
+
+    private BigDecimal getCurrentPrice(String ticker) {
+        String curStr = (String) redisTemplate.opsForHash().get("stock:info:" + ticker, "cur");
+        if (curStr == null) throw new GeneralException(ErrorStatus.STOCK_PRICE_NOT_FOUND);
+        return new BigDecimal(curStr);
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
+++ b/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.solmate.common.exception.GeneralException;
+import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.trade.dto.response.HoldingsResponse;
 import org.solmate.domain.trade.entity.Holdings;
@@ -20,13 +21,14 @@ public class HoldingsService {
 
     private final HoldingsRepository holdingsRepository;
     private final StringRedisTemplate redisTemplate;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public List<HoldingsResponse> getHoldings(Long userId) {
         List<Holdings> holdings = holdingsRepository.findByUserId(userId);
 
         return holdings.stream()
-            .map(h -> HoldingsResponse.of(h, getCurrentPrice(h.getTickerCode())))
+            .map(h -> HoldingsResponse.of(h, getCurrentPrice(h.getTickerCode()), s3Service))
             .toList();
     }
 

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -178,11 +178,11 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                 LsWsStockResponse response = objectMapper.treeToValue(node, LsWsStockResponse.class);
                 if (response.body() == null) return;
                 String stockCode = response.body().shcode();
-                candleAccumulatorService.accumulate(response.body());
                 stockInfoService.update(response.body());
-                orderMatchingService.match(stockCode);
                 messagingTemplate.convertAndSend("/topic/stocks/" + stockCode + "/quote",
                         StockRealtimeResponse.from(response.body()));
+                candleAccumulatorService.accumulate(response.body());
+                orderMatchingService.match(stockCode);
                 broadcastCandle(stockCode, "candle:1min:",  "/topic/stocks/" + stockCode + "/candle/1min");
                 broadcastCandle(stockCode, "candle:5min:",  "/topic/stocks/" + stockCode + "/candle/5min");
                 broadcastCandle(stockCode, "candle:30min:", "/topic/stocks/" + stockCode + "/candle/30min");

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -214,7 +214,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             LocalDateTime candleTime = LocalDateTime.parse(startTime, DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
             messagingTemplate.convertAndSend(topic, CandleResponse.fromRedis(data, candleTime));
         } catch (Exception e) {
-            log.warn("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
+            // log.warn("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
         }
     }
 

--- a/src/main/resources/static/holdings-test.html
+++ b/src/main/resources/static/holdings-test.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>보유 종목 실시간</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body { font-family: monospace; padding: 20px; background: #1a1a1a; color: #00ff00; }
+        input, button { padding: 8px; margin: 4px; font-size: 14px; }
+        h3 { color: #aaffaa; border-bottom: 1px solid #333; padding-bottom: 6px; }
+        table { border-collapse: collapse; width: 100%; margin-top: 10px; font-size: 13px; }
+        th { background: #333; color: #aaffaa; padding: 8px; text-align: left; }
+        td { padding: 8px; border-bottom: 1px solid #333; }
+        .plus { color: #ff6666; }
+        .minus { color: #6699ff; }
+        #status { margin: 8px 0; }
+        img { width: 30px; height: 30px; border-radius: 50%; vertical-align: middle; }
+    </style>
+</head>
+<body>
+    <h2>📦 보유 종목 실시간</h2>
+    <input id="token" type="text" placeholder="JWT 토큰 입력" style="width: 500px;" />
+    <button onclick="start()">실시간 시작</button>
+    <button onclick="stop()">중지</button>
+    <div id="status">대기 중...</div>
+
+    <h3>보유 종목 목록</h3>
+    <table>
+        <thead>
+            <tr>
+                <th>로고</th>
+                <th>종목명</th>
+                <th>종목코드</th>
+                <th>수량</th>
+                <th>평균단가</th>
+                <th>현재가</th>
+                <th>평가금액</th>
+                <th>수익률</th>
+                <th>수익금</th>
+            </tr>
+        </thead>
+        <tbody id="holdings-body"></tbody>
+    </table>
+
+    <script>
+        let stompClient = null;
+        let subs = [];
+        let holdings = {}; // ticker -> { avgPrice, quantity, stockName, stockLogo, currentPrice }
+
+        async function start() {
+            const token = document.getElementById('token').value.trim();
+            if (!token) { document.getElementById('status').innerText = '❌ 토큰을 입력하세요.'; return; }
+
+            // 1. REST API로 초기 보유 종목 로드
+            const res = await fetch('http://localhost:8080/api/holdings', {
+                headers: { 'Authorization': 'Bearer ' + token },
+                cache: 'no-store'
+            });
+            const json = await res.json();
+            if (!json.isSuccess) { document.getElementById('status').innerText = '❌ ' + json.message; return; }
+
+            holdings = {};
+            json.data.forEach(h => {
+                holdings[h.tickerCode] = {
+                    avgPrice: h.avgPrice,
+                    quantity: h.quantity,
+                    stockName: h.stockName,
+                    stockLogo: h.stockLogo,
+                    currentPrice: h.currentPrice
+                };
+            });
+            renderAll();
+
+            // 2. STOMP 연결 (ws-test.html 방식 동일)
+            stop();
+            const socket = new SockJS('http://localhost:8080/ws');
+            stompClient = Stomp.over(socket);
+            stompClient.debug = null;
+
+            stompClient.connect({}, function () {
+                document.getElementById('status').innerText = '🔴 실시간 연결됨 | 종목 수: ' + Object.keys(holdings).length;
+
+                Object.keys(holdings).forEach(ticker => {
+                    const sub = stompClient.subscribe('/topic/stocks/' + ticker + '/quote', function (msg) {
+                        const data = JSON.parse(msg.body);
+                        holdings[ticker].currentPrice = data.currentPrice;
+                        updateRow(ticker);
+                    });
+                    subs.push(sub);
+                });
+            }, function (err) {
+                document.getElementById('status').innerText = '❌ 연결 실패: ' + err;
+            });
+        }
+
+        function stop() {
+            subs.forEach(s => s.unsubscribe());
+            subs = [];
+            if (stompClient) { stompClient.disconnect(); stompClient = null; }
+            document.getElementById('status').innerText = '⏹ 중지됨';
+        }
+
+        function renderAll() {
+            const tbody = document.getElementById('holdings-body');
+            tbody.innerHTML = '';
+            Object.keys(holdings).forEach(ticker => {
+                const tr = document.createElement('tr');
+                tr.id = 'row-' + ticker;
+                tbody.appendChild(tr);
+                updateRow(ticker);
+            });
+        }
+
+        function updateRow(ticker) {
+            const h = holdings[ticker];
+            const cur = h.currentPrice;
+            const avg = h.avgPrice;
+            const qty = h.quantity;
+            const evaluation = cur * qty;
+            const returnAmount = (cur - avg) * qty;
+            const returnRate = ((cur - avg) / avg * 100).toFixed(2);
+            const plus = returnAmount >= 0;
+            const cls = plus ? 'plus' : 'minus';
+            const sign = plus ? '+' : '';
+
+            document.getElementById('row-' + ticker).innerHTML = `
+                <td><img src="${h.stockLogo}" onerror="this.style.display='none'" /></td>
+                <td>${h.stockName}</td>
+                <td>${ticker}</td>
+                <td>${qty.toLocaleString()}</td>
+                <td>${avg.toLocaleString()}</td>
+                <td>${cur.toLocaleString()}</td>
+                <td>${evaluation.toLocaleString()}</td>
+                <td class="${cls}">${sign}${returnRate}%</td>
+                <td class="${cls}">${sign}${returnAmount.toLocaleString()}</td>
+            `;
+        }
+    </script>
+</body>
+</html>

--- a/src/main/resources/static/holdings-test.html
+++ b/src/main/resources/static/holdings-test.html
@@ -20,7 +20,8 @@
 </head>
 <body>
     <h2>📦 보유 종목 실시간</h2>
-    <input id="token" type="text" placeholder="JWT 토큰 입력" style="width: 500px;" />
+    <input id="token" type="text" placeholder="JWT 토큰 입력" style="width: 400px;" />
+    <input id="targetUserId" type="text" placeholder="타인 userId (비우면 내 것)" style="width: 200px;" />
     <button onclick="start()">실시간 시작</button>
     <button onclick="stop()">중지</button>
     <div id="status">대기 중...</div>
@@ -53,7 +54,11 @@
             if (!token) { document.getElementById('status').innerText = '❌ 토큰을 입력하세요.'; return; }
 
             // 1. REST API로 초기 보유 종목 로드
-            const res = await fetch('http://localhost:8080/api/holdings', {
+            const targetUserId = document.getElementById('targetUserId').value.trim();
+            const url = targetUserId
+                ? `http://localhost:8080/api/holdings/${targetUserId}`
+                : 'http://localhost:8080/api/holdings';
+            const res = await fetch(url, {
                 headers: { 'Authorization': 'Bearer ' + token },
                 cache: 'no-store'
             });


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #41

 ## 💡 작업 배경
   모의투자 기능의 핵심인 보유 종목 조회 기능이 필요했다.
   현재가는 실시간으로 변하기 때문에 Redis에서 매번 조회하고, 평가금액/수익률/수익금은 서버에서 계산하여 응한다.

   ## 🧩 작업 내용
   - `GET /api/holdings` - 내 보유 종목 조회
     - DB에서 avgPrice, quantity 등 고정값 조회
     - Redis(`stock:info:{ticker}`)에서 현재가 실시간 조회
     - 평가금액, 수익률, 수익금 계산 후 응답
   - `GET /api/holdings/{userId}` - 타인 보유 종목 조회
   - `fix`: LS WebSocket US3 처리 시 브로드캐스트 순서 변경
     - `accumulate()` 예외 발생 시 STOMP 브로드캐스트가 막히던 문제 수정
     - Redis 업데이트 → 브로드캐스트 → 봉 누적 → 주문 매칭 순서로 변경
   - 실시간 확인용 `holdings-test.html` 구현 (STOMP WebSocket)

## 📸 스크린샷(선택)

- 자신
<img width="1512" height="401" alt="Screenshot 2026-03-23 at 3 55 27 PM" src="https://github.com/user-attachments/assets/faf81442-12fb-4843-8d1a-f79c08b32ec7" />
<img width="1265" height="774" alt="Screenshot 2026-03-23 at 2 24 19 PM" src="https://github.com/user-attachments/assets/e6e844bd-147c-4850-af4f-1510ee9fb387" />

- 타인
<img width="1512" height="296" alt="Screenshot 2026-03-23 at 4 21 19 PM" src="https://github.com/user-attachments/assets/a0f9f8e3-a684-47d1-abb3-017c391c7862" />
<img width="1162" height="756" alt="Screenshot 2026-03-23 at 4 16 31 PM" src="https://github.com/user-attachments/assets/9230aa31-0118-4905-9b6b-0f120a5fbf03" />



## 📝 기타

