### PR TITLE
[Feat] 멘토링 신청/수락/거절 API 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -52,7 +52,24 @@ public enum ErrorStatus implements BaseStatus {
     INSUFFICIENT_CASH("TRADE_400_1", HttpStatus.BAD_REQUEST, "잔액이 부족합니다."),
     STOCK_NOT_FOUND("TRADE_404_2", HttpStatus.NOT_FOUND, "종목을 찾을 수 없습니다."),
     INSUFFICIENT_HOLDINGS("TRADE_400_2", HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다."),
-    STOCK_PRICE_NOT_FOUND("TRADE_404_3", HttpStatus.NOT_FOUND, "Redis에 해당 종목 시세가 없습니다.");
+    STOCK_PRICE_NOT_FOUND("TRADE_404_3", HttpStatus.NOT_FOUND, "Redis에 해당 종목 시세가 없습니다."),
+
+    /**
+     * Mentoring
+     */
+    /**
+     * Notification
+     */
+    NOTIFICATION_NOT_FOUND("NOTIFICATION_404", HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+    NOTIFICATION_UNAUTHORIZED("NOTIFICATION_403", HttpStatus.FORBIDDEN, "해당 알림에 대한 권한이 없습니다."),
+    NOTIFICATION_INVALID_TYPE("NOTIFICATION_400", HttpStatus.BAD_REQUEST, "해당 알림에서 수행할 수 없는 작업입니다."),
+
+    MENTORING_SELF_REQUEST("MENTORING_400_1", HttpStatus.BAD_REQUEST, "자기 자신에게 멘토링을 신청할 수 없습니다."),
+    MENTORING_ALREADY_HAS_MENTOR("MENTORING_400_2", HttpStatus.BAD_REQUEST, "이미 멘토가 있습니다."),
+    MENTORING_ALREADY_REQUESTED("MENTORING_409", HttpStatus.CONFLICT, "이미 멘토링 요청을 보냈습니다."),
+    MENTORING_RELATION_NOT_FOUND("MENTORING_404", HttpStatus.NOT_FOUND, "멘토링 요청을 찾을 수 없습니다."),
+    MENTORING_UNAUTHORIZED("MENTORING_403", HttpStatus.FORBIDDEN, "해당 멘토링 요청에 대한 권한이 없습니다."),
+    MENTORING_ALREADY_RESPONDED("MENTORING_400_3", HttpStatus.BAD_REQUEST, "이미 처리된 멘토링 요청입니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -34,12 +34,7 @@ public enum SuccessStatus implements BaseStatus {
     MOCK_DATA_INIT_SUCCESS("TRADE_200", HttpStatus.OK, "Mock 시세 데이터 초기화 성공"),
     BUY_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매수 주문 접수 성공"),
     SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
-    HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공");
-    SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
-
-    /**
-     * Mentoring
-     */
+    HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공"),
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -33,7 +33,15 @@ public enum SuccessStatus implements BaseStatus {
      */
     MOCK_DATA_INIT_SUCCESS("TRADE_200", HttpStatus.OK, "Mock 시세 데이터 초기화 성공"),
     BUY_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매수 주문 접수 성공"),
-    SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공");
+    SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
+
+    /**
+     * Mentoring
+     */
+    MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
+    MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
+    MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),
+    MENTORING_MY_STATUS_SUCCESS("MENTORING_200_3", HttpStatus.OK, "내 멘토링 신청 현황 조회 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
@@ -1,0 +1,57 @@
+package org.solmate.domain.notification.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.notification.service.NotificationService;
+import org.solmate.domain.social.dto.response.MentoringResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Notification", description = "알림 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    /**
+     * 알림에서 멘토 신청 수락
+     * - 멘토가 MENTORING_REQUEST 알림에서 수락 버튼 클릭 시 호출
+     * - 알림의 payload에서 mentoringRelationId를 꺼내 멘토링 관계를 ACCEPTED로 변경
+     * - 멘티에게 수락 알림 전송
+     */
+    @Operation(summary = "알림에서 멘토 신청 수락")
+    @PostMapping("/{notificationId}/mentor-request/accept")
+    public ResponseEntity<ApiResponse<MentoringResponse>> acceptMentoring(
+            @AuthenticationPrincipal Long mentorId,
+            @PathVariable Long notificationId
+    ) {
+        MentoringResponse response = notificationService.acceptMentoringFromNotification(mentorId, notificationId);
+        return ApiResponse.success(SuccessStatus.MENTORING_ACCEPT_SUCCESS, response);
+    }
+
+    /**
+     * 알림에서 멘토 신청 거절
+     * - 멘토가 MENTORING_REQUEST 알림에서 거절 버튼 클릭 시 호출
+     * - 알림의 payload에서 mentoringRelationId를 꺼내 멘토링 관계를 REJECTED로 변경
+     * - 멘티에게 별도 알림 없음
+     */
+    @Operation(summary = "알림에서 멘토 신청 거절")
+    @PostMapping("/{notificationId}/mentor-request/reject")
+    public ResponseEntity<ApiResponse<MentoringResponse>> rejectMentoring(
+            @AuthenticationPrincipal Long mentorId,
+            @PathVariable Long notificationId
+    ) {
+        MentoringResponse response = notificationService.rejectMentoringFromNotification(mentorId, notificationId);
+        return ApiResponse.success(SuccessStatus.MENTORING_REJECT_SUCCESS, response);
+    }
+}

--- a/src/main/java/org/solmate/domain/notification/entity/Notification.java
+++ b/src/main/java/org/solmate/domain/notification/entity/Notification.java
@@ -5,6 +5,9 @@ import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.enums.NotificationType;
 import org.solmate.domain.user.entity.User;
 
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -45,6 +48,7 @@ public class Notification extends BaseEntity {
     @Column(name = "is_read", nullable = false)
     private boolean isRead = false;
 
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
     private String payload;
 

--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -1,0 +1,125 @@
+package org.solmate.domain.notification.service;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.notification.entity.Notification;
+import org.solmate.domain.notification.enums.NotificationType;
+import org.solmate.domain.notification.repository.NotificationRepository;
+import org.solmate.domain.social.dto.response.MentoringResponse;
+import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.social.service.MentoringService;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MentoringService mentoringService;
+    private final MentoringRepository mentoringRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 알림에서 멘토 신청 수락
+     * - 멘토가 알림 목록에서 수락 버튼을 눌렀을 때 호출됨
+     * - 알림을 검증한 뒤 payload에서 mentoringRelationId를 꺼내 MentoringService에 위임
+     * - relation이 없는 경우 = 다른 멘토가 먼저 수락해서 해당 행이 삭제된 상황
+     *   → payload의 menteeId로 멘티의 멘토 존재 여부를 확인 후 적절한 에러 반환
+     * - 수락 처리 후 해당 알림을 읽음 상태로 변경
+     */
+    @Transactional
+    public MentoringResponse acceptMentoringFromNotification(Long mentorId, Long notificationId) {
+        // 알림 존재 여부, 본인 여부, 타입 검증
+        Notification notification = findAndValidateNotification(mentorId, notificationId, NotificationType.MENTORING_REQUEST);
+
+        // 알림 payload 파싱
+        JsonNode payload = parsePayload(notification);
+        Long mentoringRelationId = payload.get("mentoringRelationId").asLong();
+
+        // relation이 없으면 다른 멘토가 먼저 수락해서 행이 삭제된 상황
+        // payload의 menteeId로 멘티에게 이미 멘토가 있는지 확인 후 에러 반환
+        if (!mentoringRepository.existsById(mentoringRelationId)) {
+            Long menteeId = payload.get("menteeId").asLong();
+            User mentee = userRepository.findById(menteeId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+            if (mentoringRepository.existsByMenteeAndStatus(mentee, MentoringStatus.ACCEPTED)) {
+                throw new GeneralException(ErrorStatus.MENTORING_ALREADY_HAS_MENTOR);
+            }
+            throw new GeneralException(ErrorStatus.MENTORING_RELATION_NOT_FOUND);
+        }
+
+        // 수락 처리하면 알림을 읽음으로 표시
+        notification.markAsRead();
+
+        return mentoringService.acceptMentoring(mentorId, mentoringRelationId);
+    }
+
+    /**
+     * 알림에서 멘토 신청 거절
+     * - 멘토가 알림 목록에서 거절 버튼을 눌렀을 때 호출됨
+     * - 알림을 검증한 뒤 payload에서 mentoringRelationId를 꺼내 MentoringService에 위임
+     * - 거절 시 멘티에게 별도 알림은 전송하지 않음
+     * - 거절 처리 후 해당 알림을 읽음 상태로 변경
+     */
+    @Transactional
+    public MentoringResponse rejectMentoringFromNotification(Long mentorId, Long notificationId) {
+        // 알림 존재 여부, 본인 여부, 타입 검증
+        Notification notification = findAndValidateNotification(mentorId, notificationId, NotificationType.MENTORING_REQUEST);
+
+        // 알림 payload에서 어떤 멘토링 관계인지 식별
+        Long mentoringRelationId = parsePayload(notification).get("mentoringRelationId").asLong();
+
+        // 거절 처리하면 알림을 읽음으로 표시
+        notification.markAsRead();
+
+        return mentoringService.rejectMentoring(mentorId, mentoringRelationId);
+    }
+
+    /**
+     * 알림 조회 및 공통 검증
+     * - notificationId로 알림을 조회하고 아래 세 가지를 검증함
+     *   1. 알림이 존재하는지
+     *   2. 현재 로그인한 사용자가 이 알림의 수신자인지 (다른 사람의 알림에 접근 방지)
+     *   3. 알림 타입이 기대한 타입인지 (예: 멘토링 신청 알림에서만 수락/거절 가능)
+     */
+    private Notification findAndValidateNotification(Long userId, Long notificationId, NotificationType expectedType) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        // 이 알림을 받은 사람이 현재 요청한 사람과 동일한지 확인
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_UNAUTHORIZED);
+        }
+
+        // 멘토링 신청 알림(MENTORING_REQUEST)에서만 수락/거절 가능
+        if (notification.getNotificationType() != expectedType) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_INVALID_TYPE);
+        }
+
+        return notification;
+    }
+
+    /**
+     * 알림 payload 파싱
+     * - 멘토링 신청 시 알림 payload에 저장된 형식: {"mentoringRelationId": 123, "menteeId": 3}
+     * - payload가 없거나 형식이 올바르지 않으면 에러 반환
+     */
+    private JsonNode parsePayload(Notification notification) {
+        try {
+            return objectMapper.readTree(notification.getPayload());
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_INVALID_TYPE);
+        }
+    }
+}

--- a/src/main/java/org/solmate/domain/social/controller/MentoringController.java
+++ b/src/main/java/org/solmate/domain/social/controller/MentoringController.java
@@ -1,0 +1,58 @@
+package org.solmate.domain.social.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.social.dto.request.MentoringRequest;
+import org.solmate.domain.social.dto.response.MentoringResponse;
+import org.solmate.domain.social.dto.response.MyMentoringStatusResponse;
+import org.solmate.domain.social.service.MentoringService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Mentoring", description = "멘토링 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MentoringController {
+
+    private final MentoringService mentoringService;
+
+    /**
+     * 내 멘토링 신청 현황 조회
+     * - 프론트에서 유저 목록의 멘토 신청 버튼 활성화 여부 판단에 사용
+     * - hasAcceptedMentor: 이미 수락된 멘토가 있으면 모든 버튼 비활성화
+     * - pendingMentorIds: 해당 멘토에게 이미 신청 중이면 그 버튼만 비활성화
+     */
+    @Operation(summary = "내 멘토링 신청 현황 조회")
+    @GetMapping("/mentor-requests/my")
+    public ResponseEntity<ApiResponse<MyMentoringStatusResponse>> getMyMentoringStatus(
+            @AuthenticationPrincipal Long menteeId
+    ) {
+        MyMentoringStatusResponse response = mentoringService.getMyMentoringStatus(menteeId);
+        return ApiResponse.success(SuccessStatus.MENTORING_MY_STATUS_SUCCESS, response);
+    }
+
+    /**
+     * 멘토 신청
+     * - 유저 목록에서 멘토 신청 버튼 클릭 시 호출
+     * - 신청 성공 시 멘토에게 알림 전송 (payload에 mentoringRelationId 포함)
+     */
+    @Operation(summary = "멘토 신청")
+    @PostMapping("/mentor-requests")
+    public ResponseEntity<ApiResponse<MentoringResponse>> requestMentoring(
+            @AuthenticationPrincipal Long menteeId,
+            @RequestBody MentoringRequest request
+    ) {
+        MentoringResponse response = mentoringService.requestMentoring(menteeId, request.mentorUserId());
+        return ApiResponse.success(SuccessStatus.MENTORING_REQUEST_SUCCESS, response);
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/request/MentoringRequest.java
+++ b/src/main/java/org/solmate/domain/social/dto/request/MentoringRequest.java
@@ -1,0 +1,4 @@
+package org.solmate.domain.social.dto.request;
+
+public record MentoringRequest(Long mentorUserId) {
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/MentoringResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MentoringResponse.java
@@ -1,0 +1,9 @@
+package org.solmate.domain.social.dto.response;
+
+import org.solmate.domain.social.entity.MentoringRelation;
+
+public record MentoringResponse(String status) {
+    public static MentoringResponse of(MentoringRelation mentoringRelation) {
+        return new MentoringResponse(mentoringRelation.getStatus().name());
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/MyMentoringStatusResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MyMentoringStatusResponse.java
@@ -1,0 +1,9 @@
+package org.solmate.domain.social.dto.response;
+
+import java.util.List;
+
+public record MyMentoringStatusResponse(
+        boolean hasAcceptedMentor,
+        List<Long> pendingMentorIds
+) {
+}

--- a/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
@@ -1,0 +1,24 @@
+package org.solmate.domain.social.repository;
+
+import java.util.List;
+
+import org.solmate.domain.social.entity.MentoringRelation;
+import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoringRepository extends JpaRepository<MentoringRelation, Long> {
+
+    // 멘티가 이미 수락된 멘토가 있는지 확인
+    boolean existsByMenteeAndStatus(User mentee, MentoringStatus status);
+
+    // 동일한 멘토-멘티 간 이미 PENDING 요청이 있는지 확인
+    boolean existsByMentorAndMenteeAndStatus(User mentor, User mentee, MentoringStatus status);
+
+    // 멘티가 보낸 특정 상태의 멘토링 요청 목록 조회
+    List<MentoringRelation> findAllByMenteeAndStatus(User mentee, MentoringStatus status);
+
+    // 멘티의 특정 멘토링 관계를 제외한 나머지 PENDING 요청 삭제
+    // (멘토 수락 시 다른 멘토에게 보낸 PENDING 요청 정리)
+    void deleteAllByMenteeAndStatusAndIdNot(User mentee, MentoringStatus status, Long excludeId);
+}

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -1,0 +1,182 @@
+package org.solmate.domain.social.service;
+
+import java.util.List;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.notification.entity.Notification;
+import org.solmate.domain.notification.enums.NotificationCategory;
+import org.solmate.domain.notification.enums.NotificationType;
+import org.solmate.domain.notification.repository.NotificationRepository;
+import org.solmate.domain.social.dto.response.MentoringResponse;
+import org.solmate.domain.social.dto.response.MyMentoringStatusResponse;
+import org.solmate.domain.social.entity.MentoringRelation;
+import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MentoringService {
+
+    private final MentoringRepository mentoringRepository;
+    private final UserRepository userRepository;
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * 멘토 신청
+     * - 유저 목록에서 특정 유저에게 멘토 신청 버튼을 눌렀을 때 호출됨
+     * - 여러 명에게 동시에 신청 가능하지만, 동일한 멘토에게 중복 신청은 불가
+     * - 신청 성공 시 멘토에게 알림이 전송되며, 알림 payload에 mentoringRelationId가 포함됨
+     *   (멘토가 알림에서 수락/거절 버튼 클릭 시 해당 ID를 사용)
+     */
+    @Transactional
+    public MentoringResponse requestMentoring(Long menteeId, Long mentorId) {
+        // 자기 자신에게는 신청할 수 없음 (프론트에서도 막지만 백엔드에서도 방어)
+        if (menteeId.equals(mentorId)) {
+            throw new GeneralException(ErrorStatus.MENTORING_SELF_REQUEST);
+        }
+
+        User mentee = userRepository.findById(menteeId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User mentor = userRepository.findById(mentorId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 이미 수락된 멘토가 있으면 신청 불가
+        // (프론트에서 버튼 비활성화로 막지만, 직접 API 호출하는 경우 대비)
+        if (mentoringRepository.existsByMenteeAndStatus(mentee, MentoringStatus.ACCEPTED)) {
+            throw new GeneralException(ErrorStatus.MENTORING_ALREADY_HAS_MENTOR);
+        }
+
+        // 같은 멘토에게 이미 대기 중인 요청이 있으면 중복 신청 불가
+        if (mentoringRepository.existsByMentorAndMenteeAndStatus(mentor, mentee, MentoringStatus.PENDING)) {
+            throw new GeneralException(ErrorStatus.MENTORING_ALREADY_REQUESTED);
+        }
+
+        // 멘토링 관계 생성 (초기 상태: PENDING, 요청 시각 자동 기록)
+        MentoringRelation mentoringRelation = MentoringRelation.builder()
+                .mentor(mentor)
+                .mentee(mentee)
+                .build();
+        mentoringRepository.save(mentoringRelation);
+
+        // 멘토에게 알림 전송
+        // payload에 mentoringRelationId와 menteeId를 담음
+        // menteeId는 수락 시 행이 삭제된 경우에도 멘티의 멘토 존재 여부를 확인하기 위해 사용
+        String payload = String.format("{\"mentoringRelationId\":%d,\"menteeId\":%d}",
+                mentoringRelation.getId(), mentee.getId());
+        Notification notification = Notification.builder()
+                .user(mentor)
+                .notificationType(NotificationType.MENTORING_REQUEST)
+                .category(NotificationCategory.MENTORING)
+                .content(mentee.getNickname() + "님이 멘토 신청을 보냈습니다.")
+                .payload(payload)
+                .build();
+        notificationRepository.save(notification);
+
+        return MentoringResponse.of(mentoringRelation);
+    }
+
+    /**
+     * 멘토 신청 수락
+     * - NotificationService에서 알림의 payload를 파싱한 후 호출됨
+     * - 멘티가 여러 멘토에게 신청을 보낸 경우, 다른 멘토가 먼저 수락했을 수 있으므로
+     *   수락 시점에 멘티의 멘토 존재 여부를 다시 한번 확인함
+     * - 수락 성공 시 멘티에게 수락 알림 전송
+     */
+    @Transactional
+    public MentoringResponse acceptMentoring(Long mentorId, Long relationId) {
+        MentoringRelation relation = mentoringRepository.findById(relationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MENTORING_RELATION_NOT_FOUND));
+
+        // 해당 멘토링 요청의 수신자(멘토) 본인인지 확인
+        if (!relation.getMentor().getId().equals(mentorId)) {
+            throw new GeneralException(ErrorStatus.MENTORING_UNAUTHORIZED);
+        }
+
+        // 이미 수락 또는 거절된 요청인지 확인 (PENDING 상태만 처리 가능)
+        if (relation.getStatus() != MentoringStatus.PENDING) {
+            throw new GeneralException(ErrorStatus.MENTORING_ALREADY_RESPONDED);
+        }
+
+        // 멘티가 이미 다른 멘토에게 수락된 상태인지 확인
+        // (A, B 두 멘토에게 신청했을 때 A가 먼저 수락하면 B가 수락하려 할 때 막음)
+        if (mentoringRepository.existsByMenteeAndStatus(relation.getMentee(), MentoringStatus.ACCEPTED)) {
+            throw new GeneralException(ErrorStatus.MENTORING_ALREADY_HAS_MENTOR);
+        }
+
+        // 멘토링 관계를 수락 상태로 변경 (ACCEPTED, 응답 시각 자동 기록)
+        relation.accept();
+
+        // 멘티가 다른 멘토에게 보낸 나머지 PENDING 요청 삭제
+        // (멘토는 1명만 가질 수 있으므로 수락된 관계 외 나머지는 불필요)
+        mentoringRepository.deleteAllByMenteeAndStatusAndIdNot(
+                relation.getMentee(), MentoringStatus.PENDING, relation.getId());
+
+        // 멘티에게 수락 알림 전송 (거절과 달리 수락 시에만 알림 발송)
+        Notification notification = Notification.builder()
+                .user(relation.getMentee())
+                .notificationType(NotificationType.MENTORING_ACCEPTED)
+                .category(NotificationCategory.MENTORING)
+                .content(relation.getMentor().getNickname() + "님이 멘토 신청을 수락하셨습니다.")
+                .build();
+        notificationRepository.save(notification);
+
+        return MentoringResponse.of(relation);
+    }
+
+    /**
+     * 내 멘토링 신청 현황 조회
+     * - 유저 목록 진입 시 프론트에서 호출하여 멘토 신청 버튼 활성화 여부를 판단하는 데 사용
+     * - hasAcceptedMentor가 true이면 모든 버튼 비활성화
+     * - pendingMentorIds에 포함된 유저 ID의 버튼만 개별 비활성화
+     */
+    public MyMentoringStatusResponse getMyMentoringStatus(Long menteeId) {
+        User mentee = userRepository.findById(menteeId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 이미 수락된 멘토가 있는지 여부
+        boolean hasAcceptedMentor = mentoringRepository.existsByMenteeAndStatus(mentee, MentoringStatus.ACCEPTED);
+
+        // 현재 대기 중인(PENDING) 신청을 보낸 멘토들의 ID 목록
+        List<Long> pendingMentorIds = mentoringRepository.findAllByMenteeAndStatus(mentee, MentoringStatus.PENDING)
+                .stream()
+                .map(relation -> relation.getMentor().getId())
+                .toList();
+
+        return new MyMentoringStatusResponse(hasAcceptedMentor, pendingMentorIds);
+    }
+
+    /**
+     * 멘토 신청 거절
+     * - NotificationService에서 알림의 payload를 파싱한 후 호출됨
+     * - 거절 시 멘티에게 별도 알림은 전송하지 않음
+     */
+    @Transactional
+    public MentoringResponse rejectMentoring(Long mentorId, Long relationId) {
+        MentoringRelation relation = mentoringRepository.findById(relationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MENTORING_RELATION_NOT_FOUND));
+
+        // 해당 멘토링 요청의 수신자(멘토) 본인인지 확인
+        if (!relation.getMentor().getId().equals(mentorId)) {
+            throw new GeneralException(ErrorStatus.MENTORING_UNAUTHORIZED);
+        }
+
+        // 이미 수락 또는 거절된 요청인지 확인 (PENDING 상태만 처리 가능)
+        if (relation.getStatus() != MentoringStatus.PENDING) {
+            throw new GeneralException(ErrorStatus.MENTORING_ALREADY_RESPONDED);
+        }
+
+        // 멘토링 관계를 거절 상태로 변경 (REJECTED, 응답 시각 자동 기록)
+        relation.reject();
+
+        return MentoringResponse.of(relation);
+    }
+}


### PR DESCRIPTION
## #️⃣  관련 이슈
  closed #53

  ## 💡 작업 배경
  멘토-멘티 관계 기능 구현을 위해 멘토링 신청/수락/거절 API가 필요했습니다.

  ## 🧩 작업 내용
  - 멘토 신청 API (`POST /api/v1/mentor-requests`)
    - 자기 자신 신청 방지
    - 이미 수락된 멘토가 있을 경우 신청 불가
    - 동일 멘토에게 중복 신청 방지
    - 신청 성공 시 멘토에게 알림 전송 (payload에 mentoringRelationId, menteeId 포함)

  - 내 멘토링 신청 현황 조회 API (`GET /api/v1/mentor-requests/my`)
    - 프론트 유저 목록에서 멘토 신청 버튼 활성화/비활성화 판단용

  - 알림에서 멘토 신청 수락 API (`POST /api/v1/notifications/{notificationId}/mentor-request/accept`)
    - 수락 시 멘티에게 수락 알림 전송
    - 수락 시 해당 멘티의 나머지 PENDING 요청 삭제
    - 이미 다른 멘토가 수락한 경우 적절한 에러 반환

  - 알림에서 멘토 신청 거절 API (`POST /api/v1/notifications/{notificationId}/mentor-request/reject`)
    - 거절 시 멘티에게 별도 알림 없음

  ## 📸 스크린샷(선택)

  ## 📝 기타
  - 멘토는 여러 명의 멘티를 가질 수 있으나, 멘티는 멘토 1명만 가질 수 있습니다.
  - 수락/거절은 알림 도메인에서 처리하며, 알림 payload의 mentoringRelationId를 통해 멘토링 관계를 식별합니다.