### PR TITLE
[Fix]: Notification 엔티티 중복 JdbcTypeCode 어노테이션 제거

### DIFF
--- a/src/main/java/org/solmate/domain/notification/entity/Notification.java
+++ b/src/main/java/org/solmate/domain/notification/entity/Notification.java
@@ -50,7 +50,6 @@ public class Notification extends BaseEntity {
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
-    @org.hibernate.annotations.JdbcTypeCode(org.hibernate.type.SqlTypes.JSON)
     private String payload;
 
     @Column(name = "act_url")


### PR DESCRIPTION
## #️⃣관련 이슈
  closed #65

  ## 💡 작업 배경
  develop 브랜치 머지 과정에서 `Notification` 엔티티의 `payload` 필드에 `@JdbcTypeCode` 어노테이션이 중복으로 추가되는 충돌이 발생했습니다.

  ## 🧩 작업 내용
  - `Notification` 엔티티의 `payload` 필드에 중복 선언된 `@org.hibernate.annotations.JdbcTypeCode(org.hibernate.type.SqlTypes.JSON)` 어노테이션 제거

  ## 📸 스크린샷(선택)


  ## 📝 기타
  없음
