### PR TITLE
[Feat] 캔들데이터 수동 적재 api 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'

--- a/src/main/java/org/solmate/common/config/SecurityConfig.java
+++ b/src/main/java/org/solmate/common/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
 				.requestMatchers("/ws/**").permitAll()
 				.requestMatchers("/static/**", "/*.html").permitAll()
 				.requestMatchers("/api/stocks/**").permitAll()
+				.requestMatchers("/api/admin/**").permitAll()
 				.anyRequest().authenticated()
 			)
 			.sessionManagement(session ->

--- a/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
+++ b/src/main/java/org/solmate/domain/market/service/MarketIndicatorService.java
@@ -50,7 +50,7 @@ public class MarketIndicatorService {
             );
 
             stringRedisTemplate.opsForValue().set(redisKey, json);
-            log.info("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
+            log.debug("시장 지표 Redis 저장 완료 - {}: {}", redisKey, json);
 
         } catch (Exception e) {
             log.error("시장 지표 Redis 저장 실패: {}", e.getMessage());
@@ -74,7 +74,7 @@ public class MarketIndicatorService {
             );
 
             stringRedisTemplate.opsForValue().set(USD_KRW_KEY, json);
-            log.info("환율 Redis 저장 완료 - {}: {}", USD_KRW_KEY, json);
+            log.debug("환율 Redis 저장 완료 - {}: {}", USD_KRW_KEY, json);
 
         } catch (Exception e) {
             log.error("환율 Redis 저장 실패: {}", e.getMessage());
@@ -85,7 +85,7 @@ public class MarketIndicatorService {
         try {
             String json = stringRedisTemplate.opsForValue().get(redisKey);
             if (json == null) {
-                log.warn("Redis에 데이터 없음 - {}", redisKey);
+                log.debug("Redis에 데이터 없음 - {}", redisKey);
                 return null;
             }
 

--- a/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
@@ -10,6 +10,7 @@ import org.solmate.domain.stock.repository.StockRepository;
 import org.solmate.domain.stock.service.CandleLoadService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,18 +44,68 @@ public class CandleLoadController {
             @RequestParam(defaultValue = "3650") int dailyDays
     ) {
         List<String> codes = stockRepository.findAllTickerCodes();
-        log.info("[캔들 일괄 적재 요청] 종목 수={}, 분봉={}일, 일봉={}일", codes.size(), minuteDays, dailyDays);
+        int total = codes.size();
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [캔들 일괄 적재 시작] 종목={}개, 분봉={}일, 일봉={}일", total, minuteDays, dailyDays);
+        log.info("└─────────────────────────────────────────────");
 
         String today      = LocalDate.now().format(DATE_FMT);
         String minuteFrom = LocalDate.now().minusDays(minuteDays).format(DATE_FMT);
         String dailyFrom  = LocalDate.now().minusDays(dailyDays).format(DATE_FMT);
 
-        for (String code : codes) {
-            candleLoadService.loadMinuteCandles(code, minuteFrom, today);
-            candleLoadService.loadDailyCandles(code, dailyFrom, today);
+        int minuteSuccess = 0, minuteFail = 0, dailySuccess = 0, dailyFail = 0;
+
+        for (int i = 0; i < codes.size(); i++) {
+            String code = codes.get(i);
+            log.info("[{}/{}] 적재 중: {}", i + 1, total, code);
+            if (candleLoadService.loadMinuteCandles(code, minuteFrom, today)) minuteSuccess++;
+            else minuteFail++;
+            if (candleLoadService.loadDailyCandles(code, dailyFrom, today)) dailySuccess++;
+            else dailyFail++;
         }
 
-        log.info("[캔들 일괄 적재 완료]");
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [캔들 일괄 적재 완료]");
+        log.info("│ 분봉: 성공 {}건 / 실패 {}건", minuteSuccess, minuteFail);
+        log.info("│ 일봉: 성공 {}건 / 실패 {}건", dailySuccess, dailyFail);
+        log.info("└─────────────────────────────────────────────");
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+
+    @Operation(
+            summary = "특정 종목 캔들 재적재",
+            description = "실패한 종목 코드 목록을 받아 분봉/일봉을 재시도합니다."
+    )
+    @PostMapping("/retry")
+    public ResponseEntity<ApiResponse<Void>> retry(
+            @RequestBody List<String> stockCodes,
+            @RequestParam(defaultValue = "30") int minuteDays,
+            @RequestParam(defaultValue = "3650") int dailyDays
+    ) {
+        String today      = LocalDate.now().format(DATE_FMT);
+        String minuteFrom = LocalDate.now().minusDays(minuteDays).format(DATE_FMT);
+        String dailyFrom  = LocalDate.now().minusDays(dailyDays).format(DATE_FMT);
+
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [캔들 재적재 시작] 종목={}개", stockCodes.size());
+        log.info("└─────────────────────────────────────────────");
+
+        int minuteSuccess = 0, minuteFail = 0, dailySuccess = 0, dailyFail = 0;
+
+        for (int i = 0; i < stockCodes.size(); i++) {
+            String code = stockCodes.get(i);
+            log.info("[{}/{}] 재적재 중: {}", i + 1, stockCodes.size(), code);
+            if (candleLoadService.loadMinuteCandles(code, minuteFrom, today)) minuteSuccess++;
+            else minuteFail++;
+            if (candleLoadService.loadDailyCandles(code, dailyFrom, today)) dailySuccess++;
+            else dailyFail++;
+        }
+
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [캔들 재적재 완료]");
+        log.info("│ 분봉: 성공 {}건 / 실패 {}건", minuteSuccess, minuteFail);
+        log.info("│ 일봉: 성공 {}건 / 실패 {}건", dailySuccess, dailyFail);
+        log.info("└─────────────────────────────────────────────");
         return ApiResponse.success(SuccessStatus.SUCCESS_200);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
@@ -1,0 +1,60 @@
+package org.solmate.domain.stock.controller;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.stock.repository.StockRepository;
+import org.solmate.domain.stock.service.CandleLoadService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Tag(name = "Admin", description = "관리자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/candles")
+public class CandleLoadController {
+
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final CandleLoadService candleLoadService;
+    private final StockRepository stockRepository;
+
+    @Operation(
+            summary = "과거 캔들 데이터 일괄 적재",
+            description = "전체 종목의 분봉(최근 minuteDays일)과 일봉(최근 dailyDays일)을 LS API로 적재합니다. "
+                        + "최초 1회 수동 호출용이며, 이미 DB에 존재하는 데이터는 자동으로 스킵됩니다. "
+                        + "200종목 기준 약 20분 소요됩니다."
+    )
+    @PostMapping("/load")
+    public ResponseEntity<ApiResponse<Void>> loadAll(
+            @RequestParam(defaultValue = "30") int minuteDays,
+            @RequestParam(defaultValue = "3650") int dailyDays
+    ) {
+        List<String> codes = stockRepository.findAllTickerCodes();
+        log.info("[캔들 일괄 적재 요청] 종목 수={}, 분봉={}일, 일봉={}일", codes.size(), minuteDays, dailyDays);
+
+        String today      = LocalDate.now().format(DATE_FMT);
+        String minuteFrom = LocalDate.now().minusDays(minuteDays).format(DATE_FMT);
+        String dailyFrom  = LocalDate.now().minusDays(dailyDays).format(DATE_FMT);
+
+        for (String code : codes) {
+            candleLoadService.loadMinuteCandles(code, minuteFrom, today);
+            candleLoadService.loadDailyCandles(code, dailyFrom, today);
+        }
+
+        log.info("[캔들 일괄 적재 완료]");
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -8,7 +8,6 @@ import org.solmate.domain.stock.dto.response.CandleResponse;
 import org.solmate.domain.stock.dto.response.StockQuoteResponse;
 import org.solmate.domain.stock.service.CandleService;
 import org.solmate.domain.stock.dto.response.StockOrderBookResponse;
-import org.solmate.domain.stock.dto.response.StockQuoteResponse;
 import org.solmate.domain.stock.service.OrderBookService;
 import org.solmate.domain.stock.service.StockService;
 import org.solmate.external.ls.websocket.LsWebSocketClient;

--- a/src/main/java/org/solmate/domain/stock/entity/DailyCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/DailyCandle.java
@@ -21,7 +21,7 @@ import lombok.experimental.SuperBuilder;
 	name = "daily_candle",
 	uniqueConstraints = {
 		@UniqueConstraint(
-			name = "uk_minute_candle_stock_code_candle_time",
+			name = "uk_daily_candle_stock_code_candle_time",
 			columnNames = {"stock_code", "candle_time"}
 		)
 	},

--- a/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
@@ -10,5 +10,4 @@ public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> 
 
     List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
-
 }

--- a/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
 
-    // 특정 종목의 시간 범위 내 일봉 조회 (오름차순)
     List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
+
 }

--- a/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
@@ -24,7 +24,7 @@ public class CandleScheduler {
     @Scheduled(cron = "0 * * * * MON-FRI")
     public void flushMinuteCandles() {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.info("1분봉 스케줄러 실행 - 구독 종목 수: {}", codes.size());
+        log.debug("1분봉 스케줄러 실행 - 구독 종목 수: {}", codes.size());
         codes.forEach(candleAccumulatorService::flushMinuteCandle);
     }
 
@@ -32,7 +32,7 @@ public class CandleScheduler {
     @Scheduled(cron = "0 */5 * * * MON-FRI")
     public void flush5MinCandles() {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.info("5분봉 스케줄러 실행");
+        log.debug("5분봉 스케줄러 실행");
         codes.forEach(candleAccumulatorService::flush5MinCandle);
     }
 
@@ -40,7 +40,7 @@ public class CandleScheduler {
     @Scheduled(cron = "0 */30 * * * MON-FRI")
     public void flush30MinCandles() {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.info("30분봉 스케줄러 실행");
+        log.debug("30분봉 스케줄러 실행");
         codes.forEach(candleAccumulatorService::flush30MinCandle);
     }
 
@@ -48,7 +48,7 @@ public class CandleScheduler {
     @Scheduled(cron = "0 0 * * * MON-FRI")
     public void flush60MinCandles() {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.info("60분봉 스케줄러 실행");
+        log.debug("60분봉 스케줄러 실행");
         codes.forEach(candleAccumulatorService::flush60MinCandle);
     }
 
@@ -56,7 +56,7 @@ public class CandleScheduler {
     @Scheduled(cron = "0 30 15 * * MON-FRI")
     public void flushDailyCandles() {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.info("일봉 스케줄러 실행");
+        log.debug("일봉 스케줄러 실행");
         codes.forEach(candleAccumulatorService::flushDailyCandle);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -93,19 +93,19 @@ public class CandleAccumulatorService {
     // 5분봉 Redis 초기화 (매 5분)
     public void flush5MinCandle(String stockCode) {
         redisTemplate.delete(KEY_5MIN + stockCode);
-        log.info("5분봉 초기화: {}", stockCode);
+        log.debug("5분봉 초기화: {}", stockCode);
     }
 
     // 30분봉 Redis 초기화 (매 30분)
     public void flush30MinCandle(String stockCode) {
         redisTemplate.delete(KEY_30MIN + stockCode);
-        log.info("30분봉 초기화: {}", stockCode);
+        log.debug("30분봉 초기화: {}", stockCode);
     }
 
     // 60분봉 Redis 초기화 (매 60분)
     public void flush60MinCandle(String stockCode) {
         redisTemplate.delete(KEY_60MIN + stockCode);
-        log.info("60분봉 초기화: {}", stockCode);
+        log.debug("60분봉 초기화: {}", stockCode);
     }
 
     // 일봉 DB 저장 (장 마감 15:30)
@@ -148,7 +148,9 @@ public class CandleAccumulatorService {
 
         try {
             String startTime = (String) data.get("startTime");
-            LocalDateTime candleTime = LocalDateTime.parse(startTime, TIME_FORMATTER);
+            LocalDateTime candleTime = (startTime != null)
+                    ? LocalDateTime.parse(startTime, TIME_FORMATTER)
+                    : LocalDateTime.now().withSecond(0).withNano(0);
 
             MinuteCandle candle = MinuteCandle.builder()
                     .stockCode(stockCode)

--- a/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
@@ -1,19 +1,22 @@
 package org.solmate.domain.stock.service;
 
+import java.io.StringReader;
+import java.sql.Connection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.sql.DataSource;
+
+import org.postgresql.copy.CopyManager;
+import org.postgresql.core.BaseConnection;
 import org.solmate.domain.stock.entity.DailyCandle;
 import org.solmate.domain.stock.entity.MinuteCandle;
-import org.solmate.domain.stock.repository.DailyCandleRepository;
-import org.solmate.domain.stock.repository.MinuteCandleRepository;
 import org.solmate.external.ls.client.LsApiClient;
 import org.solmate.external.ls.dto.response.LsDailyCandleResponse;
 import org.solmate.external.ls.dto.response.LsMinuteCandleResponse;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -28,8 +31,7 @@ public class CandleLoadService {
     private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     private final LsApiClient lsApiClient;
-    private final MinuteCandleRepository minuteCandleRepository;
-    private final DailyCandleRepository dailyCandleRepository;
+    private final DataSource dataSource;
 
     /**
      * 1분봉 과거 데이터 적재
@@ -37,8 +39,7 @@ public class CandleLoadService {
      * - 연속조회로 전체 데이터 수집
      * - 호출 후 200ms 대기 (LS API 초당 1건 rate limit 준수)
      */
-    public void loadMinuteCandles(String stockCode, String sdate, String edate) {
-        log.info("[분봉 적재 시작] stockCode={}, {}~{}", stockCode, sdate, edate);
+    public boolean loadMinuteCandles(String stockCode, String sdate, String edate) {
         List<MinuteCandle> candles = new ArrayList<>();
 
         try {
@@ -46,7 +47,7 @@ public class CandleLoadService {
             collectMinuteCandles(response, stockCode, candles);
 
             while (response.hasNext()) {
-                sleep(); // 연속조회 사이에도 rate limit 준수
+                sleep();
                 String ctsDate = response.t8412OutBlock().cts_date();
                 String ctsTime = response.t8412OutBlock().cts_time();
                 response = lsApiClient.getMinuteCandlesContinue(stockCode, sdate, edate, ctsDate, ctsTime);
@@ -54,9 +55,11 @@ public class CandleLoadService {
             }
 
             saveMinuteCandles(candles, stockCode);
-            sleep(); // 다음 종목 호출 전 대기
+            sleep();
+            return true;
         } catch (Exception e) {
-            log.error("[분봉 적재 실패] stockCode={}", stockCode, e);
+            log.error("  ✗ [분봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            return false;
         }
     }
 
@@ -66,8 +69,7 @@ public class CandleLoadService {
      * - 연속조회로 전체 데이터 수집
      * - 호출 후 200ms 대기 (LS API 초당 1건 rate limit 준수)
      */
-    public void loadDailyCandles(String stockCode, String sdate, String edate) {
-        log.info("[일봉 적재 시작] stockCode={}, {}~{}", stockCode, sdate, edate);
+    public boolean loadDailyCandles(String stockCode, String sdate, String edate) {
         List<DailyCandle> candles = new ArrayList<>();
 
         try {
@@ -75,23 +77,25 @@ public class CandleLoadService {
             collectDailyCandles(response, stockCode, candles);
 
             while (response.hasNext()) {
-                sleep(); // 연속조회 사이에도 rate limit 준수
+                sleep();
                 String ctsDate = response.t8410OutBlock().cts_date();
                 response = lsApiClient.getDailyCandlesContinue(stockCode, sdate, edate, ctsDate);
                 collectDailyCandles(response, stockCode, candles);
             }
 
             saveDailyCandles(candles, stockCode);
-            sleep(); // 다음 종목 호출 전 대기
+            sleep();
+            return true;
         } catch (Exception e) {
-            log.error("[일봉 적재 실패] stockCode={}", stockCode, e);
+            log.error("  ✗ [일봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            return false;
         }
     }
 
-    /** LS API 초당 1건 rate limit 준수를 위한 대기 (200ms = 초당 최대 5건) */
+    /** LS API rate limit 준수를 위한 대기 (2000ms, WebSocket 호출과 합산 고려) */
     private void sleep() {
         try {
-            Thread.sleep(200);
+            Thread.sleep(2000);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -145,29 +149,68 @@ public class CandleLoadService {
         }
     }
 
+    private static final DateTimeFormatter COPY_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     private void saveMinuteCandles(List<MinuteCandle> candles, String stockCode) {
-        int saved = 0;
-        for (MinuteCandle candle : candles) {
-            try {
-                minuteCandleRepository.save(candle);
-                saved++;
-            } catch (DataIntegrityViolationException e) {
-                // unique constraint 위반 = 이미 존재하는 데이터 → 스킵
+        if (candles.isEmpty()) return;
+        try {
+            StringBuilder csv = new StringBuilder();
+            for (MinuteCandle c : candles) {
+                csv.append(c.getStockCode()).append(',')
+                   .append(c.getOpenPrice()).append(',')
+                   .append(c.getHighPrice()).append(',')
+                   .append(c.getLowPrice()).append(',')
+                   .append(c.getClosePrice()).append(',')
+                   .append(c.getVolume()).append(',')
+                   .append(c.getCandleTime().format(COPY_FMT)).append('\n');
             }
+            bulkCopy("minute_candle", csv.toString());
+            log.info("  ✓ [분봉] stockCode={}, {}건 적재 완료", stockCode, candles.size());
+        } catch (Exception e) {
+            log.error("  ✗ [분봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
         }
-        log.info("[분봉 적재 완료] stockCode={}, {}건 저장 (총 {}건 중)", stockCode, saved, candles.size());
     }
 
     private void saveDailyCandles(List<DailyCandle> candles, String stockCode) {
-        int saved = 0;
-        for (DailyCandle candle : candles) {
-            try {
-                dailyCandleRepository.save(candle);
-                saved++;
-            } catch (DataIntegrityViolationException e) {
-                // unique constraint 위반 = 이미 존재하는 데이터 → 스킵
+        if (candles.isEmpty()) return;
+        try {
+            StringBuilder csv = new StringBuilder();
+            for (DailyCandle c : candles) {
+                csv.append(c.getStockCode()).append(',')
+                   .append(c.getOpenPrice()).append(',')
+                   .append(c.getHighPrice()).append(',')
+                   .append(c.getLowPrice()).append(',')
+                   .append(c.getClosePrice()).append(',')
+                   .append(c.getVolume()).append(',')
+                   .append(c.getCandleTime().format(COPY_FMT)).append('\n');
             }
+            bulkCopy("daily_candle", csv.toString());
+            log.info("  ✓ [일봉] stockCode={}, {}건 적재 완료", stockCode, candles.size());
+        } catch (Exception e) {
+            log.error("  ✗ [일봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
         }
-        log.info("[일봉 적재 완료] stockCode={}, {}건 저장 (총 {}건 중)", stockCode, saved, candles.size());
+    }
+
+    private void bulkCopy(String table, String csv) throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(false);
+            String cols = "stock_code, open_price, high_price, low_price, close_price, volume, candle_time";
+            conn.createStatement().execute(
+                "CREATE TEMP TABLE tmp_" + table + " " +
+                "(stock_code varchar(12), open_price bigint, high_price bigint, " +
+                " low_price bigint, close_price bigint, volume bigint, candle_time timestamp) " +
+                "ON COMMIT DROP"
+            );
+            CopyManager copyManager = new CopyManager(conn.unwrap(BaseConnection.class));
+            copyManager.copyIn(
+                "COPY tmp_" + table + " (" + cols + ") FROM STDIN WITH (FORMAT csv)",
+                new StringReader(csv)
+            );
+            conn.createStatement().execute(
+                "INSERT INTO " + table + " (" + cols + ") " +
+                "SELECT " + cols + " FROM tmp_" + table + " ON CONFLICT DO NOTHING"
+            );
+            conn.commit();
+        }
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
@@ -1,0 +1,173 @@
+package org.solmate.domain.stock.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.MinuteCandle;
+import org.solmate.domain.stock.repository.DailyCandleRepository;
+import org.solmate.domain.stock.repository.MinuteCandleRepository;
+import org.solmate.external.ls.client.LsApiClient;
+import org.solmate.external.ls.dto.response.LsDailyCandleResponse;
+import org.solmate.external.ls.dto.response.LsMinuteCandleResponse;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CandleLoadService {
+
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    private final LsApiClient lsApiClient;
+    private final MinuteCandleRepository minuteCandleRepository;
+    private final DailyCandleRepository dailyCandleRepository;
+
+    /**
+     * 1분봉 과거 데이터 적재
+     * - sdate ~ edate 범위 (최근 3영업일 기준으로 호출)
+     * - 연속조회로 전체 데이터 수집
+     * - 호출 후 200ms 대기 (LS API 초당 1건 rate limit 준수)
+     */
+    public void loadMinuteCandles(String stockCode, String sdate, String edate) {
+        log.info("[분봉 적재 시작] stockCode={}, {}~{}", stockCode, sdate, edate);
+        List<MinuteCandle> candles = new ArrayList<>();
+
+        try {
+            LsMinuteCandleResponse response = lsApiClient.getMinuteCandles(stockCode, sdate, edate);
+            collectMinuteCandles(response, stockCode, candles);
+
+            while (response.hasNext()) {
+                sleep(); // 연속조회 사이에도 rate limit 준수
+                String ctsDate = response.t8412OutBlock().cts_date();
+                String ctsTime = response.t8412OutBlock().cts_time();
+                response = lsApiClient.getMinuteCandlesContinue(stockCode, sdate, edate, ctsDate, ctsTime);
+                collectMinuteCandles(response, stockCode, candles);
+            }
+
+            saveMinuteCandles(candles, stockCode);
+            sleep(); // 다음 종목 호출 전 대기
+        } catch (Exception e) {
+            log.error("[분봉 적재 실패] stockCode={}", stockCode, e);
+        }
+    }
+
+    /**
+     * 일봉 과거 데이터 적재
+     * - sdate ~ edate 범위 (최근 365일 기준으로 호출)
+     * - 연속조회로 전체 데이터 수집
+     * - 호출 후 200ms 대기 (LS API 초당 1건 rate limit 준수)
+     */
+    public void loadDailyCandles(String stockCode, String sdate, String edate) {
+        log.info("[일봉 적재 시작] stockCode={}, {}~{}", stockCode, sdate, edate);
+        List<DailyCandle> candles = new ArrayList<>();
+
+        try {
+            LsDailyCandleResponse response = lsApiClient.getDailyCandles(stockCode, sdate, edate);
+            collectDailyCandles(response, stockCode, candles);
+
+            while (response.hasNext()) {
+                sleep(); // 연속조회 사이에도 rate limit 준수
+                String ctsDate = response.t8410OutBlock().cts_date();
+                response = lsApiClient.getDailyCandlesContinue(stockCode, sdate, edate, ctsDate);
+                collectDailyCandles(response, stockCode, candles);
+            }
+
+            saveDailyCandles(candles, stockCode);
+            sleep(); // 다음 종목 호출 전 대기
+        } catch (Exception e) {
+            log.error("[일봉 적재 실패] stockCode={}", stockCode, e);
+        }
+    }
+
+    /** LS API 초당 1건 rate limit 준수를 위한 대기 (200ms = 초당 최대 5건) */
+    private void sleep() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void collectMinuteCandles(LsMinuteCandleResponse response, String stockCode,
+                                       List<MinuteCandle> candles) {
+        if (response.t8412OutBlock1() == null) return;
+
+        for (LsMinuteCandleResponse.OutBlock1 item : response.t8412OutBlock1()) {
+            try {
+                // time 필드: HHMMSS 형식 (6자리) → 앞 4자리만 사용(HHMM)
+                String timeStr = item.time().length() >= 6 ? item.time().substring(0, 6) : item.time();
+                LocalDateTime candleTime = LocalDateTime.parse(item.date() + timeStr, DATETIME_FMT);
+
+                candles.add(MinuteCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                log.warn("[분봉 파싱 실패] stockCode={}, date={}, time={}", stockCode, item.date(), item.time());
+            }
+        }
+    }
+
+    private void collectDailyCandles(LsDailyCandleResponse response, String stockCode,
+                                      List<DailyCandle> candles) {
+        if (response.t8410OutBlock1() == null) return;
+
+        for (LsDailyCandleResponse.OutBlock1 item : response.t8410OutBlock1()) {
+            try {
+                LocalDateTime candleTime = LocalDate.parse(item.date(), DATE_FMT).atStartOfDay();
+
+                candles.add(DailyCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                log.warn("[일봉 파싱 실패] stockCode={}, date={}", stockCode, item.date());
+            }
+        }
+    }
+
+    private void saveMinuteCandles(List<MinuteCandle> candles, String stockCode) {
+        int saved = 0;
+        for (MinuteCandle candle : candles) {
+            try {
+                minuteCandleRepository.save(candle);
+                saved++;
+            } catch (DataIntegrityViolationException e) {
+                // unique constraint 위반 = 이미 존재하는 데이터 → 스킵
+            }
+        }
+        log.info("[분봉 적재 완료] stockCode={}, {}건 저장 (총 {}건 중)", stockCode, saved, candles.size());
+    }
+
+    private void saveDailyCandles(List<DailyCandle> candles, String stockCode) {
+        int saved = 0;
+        for (DailyCandle candle : candles) {
+            try {
+                dailyCandleRepository.save(candle);
+                saved++;
+            } catch (DataIntegrityViolationException e) {
+                // unique constraint 위반 = 이미 존재하는 데이터 → 스킵
+            }
+        }
+        log.info("[일봉 적재 완료] stockCode={}, {}건 저장 (총 {}건 중)", stockCode, saved, candles.size());
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/service/CandleService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleService.java
@@ -49,7 +49,7 @@ public class CandleService {
     // 특정 기간 일봉 조회 (DB + 오늘 진행 중인 봉 포함)
     public List<CandleResponse> getDailyCandles(String stockCode, int days) {
         LocalDateTime from = LocalDate.now().minusDays(days).atStartOfDay();
-        LocalDateTime to   = LocalDate.now().atStartOfDay();
+        LocalDateTime to   = LocalDate.now().plusDays(1).atStartOfDay();
 
         List<DailyCandle> candles = dailyCandleRepository
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);

--- a/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
@@ -22,10 +22,10 @@ public class StockAutoSubscriber {
     @EventListener(ApplicationReadyEvent.class)
     public void autoSubscribe() {
         List<String> codes = stockRepository.findAllTickerCodes();
-        log.info("자동 구독 시작: 총 {}개 종목", codes.size());
-        codes.stream()
-                .limit(200)
-                .forEach(lsWebSocketClient::subscribe);
-        log.info("자동 구독 등록 완료: {}개 종목", Math.min(codes.size(), 200));
+        List<String> targets = codes.stream().limit(200).toList();
+        log.info("자동 구독 시작: 총 {}개 종목", targets.size());
+
+        targets.forEach(lsWebSocketClient::subscribe);
+        log.info("자동 구독 등록 완료: {}개 종목", targets.size());
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockAutoSubscriber.java
@@ -28,7 +28,7 @@ public class StockAutoSubscriber {
         List<String> targets = codes.stream().limit(200).toList();
         for (int i = 0; i < targets.size(); i++) {
             lsWebSocketClient.subscribe(targets.get(i));
-            log.info("자동 구독 진행: {}/{} - {}", i + 1, targets.size(), targets.get(i));
+            log.debug("자동 구독 진행: {}/{} - {}", i + 1, targets.size(), targets.get(i));
             try {
                 Thread.sleep(50); // 50ms 간격으로 전송
             } catch (InterruptedException e) {

--- a/src/main/java/org/solmate/external/ls/client/LsApiClient.java
+++ b/src/main/java/org/solmate/external/ls/client/LsApiClient.java
@@ -1,7 +1,11 @@
 package org.solmate.external.ls.client;
 
 import org.solmate.external.ls.LsProperties;
+import org.solmate.external.ls.dto.request.LsDailyCandleRequest;
+import org.solmate.external.ls.dto.request.LsMinuteCandleRequest;
 import org.solmate.external.ls.dto.request.LsQuoteRequest;
+import org.solmate.external.ls.dto.response.LsDailyCandleResponse;
+import org.solmate.external.ls.dto.response.LsMinuteCandleResponse;
 import org.solmate.external.ls.dto.response.LsQuoteResponse;
 import org.solmate.external.ls.service.LsTokenService;
 import org.springframework.http.MediaType;
@@ -28,5 +32,61 @@ public class LsApiClient {
                 .body(LsQuoteRequest.of(stockCode))
                 .retrieve()
                 .body(LsQuoteResponse.class);
+    }
+
+    /** t8412: 1분봉 조회 (처음 조회) */
+    public LsMinuteCandleResponse getMinuteCandles(String stockCode, String sdate, String edate) {
+        return restClient.post()
+                .uri(lsProperties.getBaseUrl() + "/stock/chart")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", "Bearer " + lsTokenService.getToken())
+                .header("tr_cd", "t8412")
+                .header("tr_cont", "N")
+                .body(LsMinuteCandleRequest.of(stockCode, sdate, edate))
+                .retrieve()
+                .body(LsMinuteCandleResponse.class);
+    }
+
+    /** t8412: 1분봉 연속 조회 */
+    public LsMinuteCandleResponse getMinuteCandlesContinue(String stockCode, String sdate, String edate,
+                                                            String ctsDate, String ctsTime) {
+        return restClient.post()
+                .uri(lsProperties.getBaseUrl() + "/stock/chart")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", "Bearer " + lsTokenService.getToken())
+                .header("tr_cd", "t8412")
+                .header("tr_cont", "Y")
+                .header("tr_cont_key", ctsDate + ctsTime)
+                .body(LsMinuteCandleRequest.ofContinue(stockCode, sdate, edate, ctsDate, ctsTime))
+                .retrieve()
+                .body(LsMinuteCandleResponse.class);
+    }
+
+    /** t8410: 일봉 조회 (처음 조회) */
+    public LsDailyCandleResponse getDailyCandles(String stockCode, String sdate, String edate) {
+        return restClient.post()
+                .uri(lsProperties.getBaseUrl() + "/stock/chart")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", "Bearer " + lsTokenService.getToken())
+                .header("tr_cd", "t8410")
+                .header("tr_cont", "N")
+                .body(LsDailyCandleRequest.of(stockCode, sdate, edate))
+                .retrieve()
+                .body(LsDailyCandleResponse.class);
+    }
+
+    /** t8410: 일봉 연속 조회 */
+    public LsDailyCandleResponse getDailyCandlesContinue(String stockCode, String sdate, String edate,
+                                                          String ctsDate) {
+        return restClient.post()
+                .uri(lsProperties.getBaseUrl() + "/stock/chart")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", "Bearer " + lsTokenService.getToken())
+                .header("tr_cd", "t8410")
+                .header("tr_cont", "Y")
+                .header("tr_cont_key", ctsDate)
+                .body(LsDailyCandleRequest.ofContinue(stockCode, sdate, edate, ctsDate))
+                .retrieve()
+                .body(LsDailyCandleResponse.class);
     }
 }

--- a/src/main/java/org/solmate/external/ls/dto/request/LsDailyCandleRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/request/LsDailyCandleRequest.java
@@ -1,0 +1,46 @@
+package org.solmate.external.ls.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LsDailyCandleRequest(
+        @JsonProperty("t8410InBlock") InBlock t8410InBlock
+) {
+    public record InBlock(
+            String shcode,
+            String gubun,
+            int qrycnt,
+            String sdate,
+            String edate,
+            String cts_date,
+            String comp_yn,
+            String sujung
+    ) {}
+
+    public static LsDailyCandleRequest of(String shcode, String sdate, String edate) {
+        return new LsDailyCandleRequest(new InBlock(
+                shcode,
+                "2",     // 일봉
+                500,     // 비압축 최대
+                sdate,
+                edate,
+                " ",
+                "N",     // 비압축 (OPENAPI 압축 미제공)
+                "Y"      // 수정주가 적용
+        ));
+    }
+
+    /** 연속조회용 */
+    public static LsDailyCandleRequest ofContinue(String shcode, String sdate, String edate,
+                                                   String ctsDate) {
+        return new LsDailyCandleRequest(new InBlock(
+                shcode,
+                "2",
+                500,
+                sdate,
+                edate,
+                ctsDate,
+                "N",
+                "Y"
+        ));
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/request/LsMinuteCandleRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/request/LsMinuteCandleRequest.java
@@ -1,0 +1,55 @@
+package org.solmate.external.ls.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LsMinuteCandleRequest(
+        @JsonProperty("t8412InBlock") InBlock t8412InBlock
+) {
+    public record InBlock(
+            String shcode,
+            int ncnt,
+            int qrycnt,
+            String nday,
+            String sdate,
+            String stime,
+            String edate,
+            String etime,
+            String cts_date,
+            String cts_time,
+            String comp_yn
+    ) {}
+
+    public static LsMinuteCandleRequest of(String shcode, String sdate, String edate) {
+        return new LsMinuteCandleRequest(new InBlock(
+                shcode,
+                1,       // 1분봉
+                500,     // 비압축 최대
+                "0",     // nday 미사용
+                sdate,
+                "000000",
+                edate,
+                "235959",
+                " ",
+                " ",
+                "N"      // 비압축
+        ));
+    }
+
+    /** 연속조회용 */
+    public static LsMinuteCandleRequest ofContinue(String shcode, String sdate, String edate,
+                                                    String ctsDate, String ctsTime) {
+        return new LsMinuteCandleRequest(new InBlock(
+                shcode,
+                1,
+                500,
+                "0",
+                sdate,
+                "000000",
+                edate,
+                "235959",
+                ctsDate,
+                ctsTime,
+                "N"
+        ));
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/response/LsDailyCandleResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/response/LsDailyCandleResponse.java
@@ -1,0 +1,33 @@
+package org.solmate.external.ls.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsDailyCandleResponse(
+        @JsonProperty("t8410OutBlock") OutBlock t8410OutBlock,
+        @JsonProperty("t8410OutBlock1") List<OutBlock1> t8410OutBlock1
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutBlock(
+            String cts_date
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutBlock1(
+            String date,        // 날짜 (YYYYMMDD)
+            long open,          // 시가
+            long high,          // 고가
+            long low,           // 저가
+            long close,         // 종가
+            long jdiff_vol      // 거래량
+    ) {}
+
+    public boolean hasNext() {
+        return t8410OutBlock != null
+                && t8410OutBlock.cts_date() != null
+                && !t8410OutBlock.cts_date().isBlank();
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/response/LsMinuteCandleResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/response/LsMinuteCandleResponse.java
@@ -1,0 +1,35 @@
+package org.solmate.external.ls.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsMinuteCandleResponse(
+        @JsonProperty("t8412OutBlock") OutBlock t8412OutBlock,
+        @JsonProperty("t8412OutBlock1") List<OutBlock1> t8412OutBlock1
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutBlock(
+            String cts_date,
+            String cts_time
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutBlock1(
+            String date,        // 날짜 (YYYYMMDD)
+            String time,        // 시간 (HHMMSS)
+            long open,          // 시가
+            long high,          // 고가
+            long low,           // 저가
+            long close,         // 종가
+            long jdiff_vol      // 거래량
+    ) {}
+
+    public boolean hasNext() {
+        return t8412OutBlock != null
+                && t8412OutBlock.cts_date() != null
+                && !t8412OutBlock.cts_date().isBlank();
+    }
+}

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -113,13 +113,13 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     // 재연결 후 기존 구독 종목 전체 재구독
     private void resubscribeAll() {
         if (subscribedCodes.isEmpty()) return;
-        log.info("LS WebSocket 재구독 시작: {}개 종목", subscribedCodes.size());
+        log.debug("LS WebSocket 재구독 시작: {}개 종목", subscribedCodes.size());
         String token = lsTokenService.getToken();
         subscribedCodes.forEach(code -> {
             sendMessage(LsWsRequest.subscribe(token, code));
             sendMessage(LsWsRequest.subscribeOrderBook(token, code));
         });
-        log.info("LS WebSocket 재구독 완료: {}개 종목 - {}", subscribedCodes.size(), subscribedCodes);
+        log.debug("LS WebSocket 재구독 완료: {}개 종목 - {}", subscribedCodes.size(), subscribedCodes);
     }
 
     // LS WebSocket에 종목 실시간 체결 구독 요청
@@ -129,7 +129,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         sendMessage(LsWsRequest.subscribe(token, stockCode));
         sendMessage(LsWsRequest.subscribeOrderBook(token, stockCode));
         subscribedCodes.add(stockCode);
-        log.info("LS WebSocket 구독: {}", stockCode);
+        log.debug("LS WebSocket 구독: {}", stockCode);
     }
 
     public void unsubscribe(String stockCode) {
@@ -138,7 +138,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
         sendMessage(LsWsRequest.unsubscribe(token, stockCode));
         sendMessage(LsWsRequest.unsubscribeOrderBook(token, stockCode));
         subscribedCodes.remove(stockCode);
-        log.info("LS WebSocket 구독 해제: {}", stockCode);
+        log.debug("LS WebSocket 구독 해제: {}", stockCode);
     }
 
     // LS WebSocket 세션으로 JSON 메시지 전송
@@ -214,7 +214,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             LocalDateTime candleTime = LocalDateTime.parse(startTime, DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
             messagingTemplate.convertAndSend(topic, CandleResponse.fromRedis(data, candleTime));
         } catch (Exception e) {
-            log.warn("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
+            log.debug("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
         }
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #13

## 💡 작업 배경
  
LS증권 REST API(t8412/t8410)를 활용해 과거 캔들 데이터를 DB에 적재하고, 이후 차트 조회 시 DB에서만 데이터를 꺼내오는 구조를 완성하기 위해 작업했습니다. 
기존에는 실시간 WebSocket 데이터만 누적하는 구조였으나, 과거 데이터 부재로 차트 조회가 불가능한 상태였습니다.

## 🧩 작업 내용

버그 수정
  • DailyCandle unique constraint 이름 오타 수정
    (uk_minute_candle_... → uk_daily_candle_...)
  • CandleAccumulatorService 실시간 1분봉 저장 시
    startTime null로 인한 NPE 수정 — 매 분 경계에서
    스케줄러와 WebSocket 체결 수신 사이 race
    condition으로 startTime이 설정되기 전에 flush가
    실행되는 경우, 현재 시각을 fallback으로 사용하도록
    처리

과거 캔들 적재 기능 구현
  • CandleLoadService — LS API 연속조회로 전체 수집 후
    PostgreSQL COPY + 임시 테이블 방식으로 벌크 적재, ON
     CONFLICT DO NOTHING으로 중복 자동 스킵, rate limit
    대응 2000ms sleep
  • POST /api/admin/candles/load — 전체 200종목
    분봉(최근 30일) + 일봉(최근 10년) 일괄 적재
  • POST /api/admin/candles/retry — 실패 종목 코드
    목록을 받아 재시도

로그 노이즈 정리
  • 체결마다 반복되는 지수/환율 저장, 스케줄러 실행,
    종목별 구독/해제 로그를 DEBUG로 조정
  • org.hibernate.orm.jdbc.error OFF — 중복 insert 시
    Hibernate WARN 로그 억제

## 📸 스크린샷(선택)


## 📝 기타
