### PR TITLE
[Feat] 매매일지 관련 API 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -53,6 +53,7 @@ public enum ErrorStatus implements BaseStatus {
     STOCK_NOT_FOUND("TRADE_404_2", HttpStatus.NOT_FOUND, "종목을 찾을 수 없습니다."),
     INSUFFICIENT_HOLDINGS("TRADE_400_2", HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다."),
     STOCK_PRICE_NOT_FOUND("TRADE_404_3", HttpStatus.NOT_FOUND, "Redis에 해당 종목 시세가 없습니다."),
+    TRADE_DIARY_NOT_FOUND("TRADE_404_4", HttpStatus.NOT_FOUND, "매매일지를 찾을 수 없습니다."),
 
     /**
      * Mentoring

--- a/src/main/java/org/solmate/domain/social/repository/CommentRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package org.solmate.domain.social.repository;
+
+import org.solmate.domain.social.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    long countByTradeDiaryIdAndIsDeletedFalse(Long tradeDiaryId);
+}

--- a/src/main/java/org/solmate/domain/social/repository/CommentRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/CommentRepository.java
@@ -1,9 +1,13 @@
 package org.solmate.domain.social.repository;
 
+import java.util.List;
+
 import org.solmate.domain.social.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     long countByTradeDiaryIdAndIsDeletedFalse(Long tradeDiaryId);
+
+    List<Comment> findAllByTradeDiaryIdAndIsDeletedFalseOrderByCreatedAtAsc(Long tradeDiaryId);
 }

--- a/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
@@ -21,4 +21,7 @@ public interface MentoringRepository extends JpaRepository<MentoringRelation, Lo
     // 멘티의 특정 멘토링 관계를 제외한 나머지 PENDING 요청 삭제
     // (멘토 수락 시 다른 멘토에게 보낸 PENDING 요청 정리)
     void deleteAllByMenteeAndStatusAndIdNot(User mentee, MentoringStatus status, Long excludeId);
+
+    // 댓글 작성자가 나의 멘토인지 확인 (mentor=댓글작성자, mentee=나, status=ACCEPTED)
+    boolean existsByMentorIdAndMenteeIdAndStatus(Long mentorId, Long menteeId, MentoringStatus status);
 }

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,10 +25,12 @@ public class TradeDiaryController {
 
     private final TradeDiaryService tradeDiaryService;
 
-    @Operation(summary = "내 매매일지 목록 조회", description = "내 매매일지 목록을 최신순으로 조회합니다.")
+    @Operation(summary = "내 매매일지 목록 조회", description = "내 매매일지 목록을 최신순으로 조회합니다. stockName으로 종목명 검색 가능합니다.")
     @GetMapping("/my")
-    public ResponseEntity<ApiResponse<List<TradeDiaryListResponse>>> getMyDiaries(Authentication authentication) {
+    public ResponseEntity<ApiResponse<List<TradeDiaryListResponse>>> getMyDiaries(
+            Authentication authentication,
+            @RequestParam(required = false) String stockName) {
         Long userId = (Long) authentication.getPrincipal();
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getMyDiaries(userId));
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getMyDiaries(userId, stockName));
     }
 }

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -1,0 +1,33 @@
+package org.solmate.domain.trade.controller;
+
+import java.util.List;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.trade.dto.response.TradeDiaryListResponse;
+import org.solmate.domain.trade.service.TradeDiaryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "TradeDiary", description = "매매일지 API")
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+public class TradeDiaryController {
+
+    private final TradeDiaryService tradeDiaryService;
+
+    @Operation(summary = "내 매매일지 목록 조회", description = "내 매매일지 목록을 최신순으로 조회합니다.")
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<TradeDiaryListResponse>>> getMyDiaries(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getMyDiaries(userId));
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -39,7 +39,7 @@ public class TradeDiaryController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getMyDiaries(userId, stockName));
     }
 
-    @Operation(summary = "특정 유저 매매일지 목록 조회", description = "특정 유저의 매매일지 목록을 조회합니다. 멘토/멘티 관계일 경우 댓글 수 포함.")
+    @Operation(summary = "유저 프로필 매매일지 목록 조회 - 멘토/멘티 탭에서 호출 가능", description = "특정 유저의 매매일지 목록을 조회합니다. 멘토/멘티 관계일 경우 댓글 수 포함.")
     @GetMapping("/users/{userId}")
     public ResponseEntity<ApiResponse<List<TradeDiaryListResponse>>> getUserDiaries(
             @PathVariable Long userId,

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -50,12 +50,11 @@ public class TradeDiaryController {
 
     @Operation(summary = "매매일지 수정", description = "매매일지 내용을 수정합니다.")
     @PatchMapping("/{diaryId}")
-    public ResponseEntity<ApiResponse<Void>> updateDiary(
+    public ResponseEntity<ApiResponse<TradeDiaryDetailResponse>> updateDiary(
             @PathVariable Long diaryId,
             Authentication authentication,
             @RequestBody UpdateTradeDiaryRequest request) {
         Long userId = (Long) authentication.getPrincipal();
-        tradeDiaryService.updateDiary(diaryId, userId, request);
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, null);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.updateDiary(diaryId, userId, request));
     }
 }

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -4,13 +4,16 @@ import java.util.List;
 
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.trade.dto.request.UpdateTradeDiaryRequest;
 import org.solmate.domain.trade.dto.response.TradeDiaryDetailResponse;
 import org.solmate.domain.trade.dto.response.TradeDiaryListResponse;
 import org.solmate.domain.trade.service.TradeDiaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,5 +46,16 @@ public class TradeDiaryController {
             Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getDiaryDetail(diaryId, userId));
+    }
+
+    @Operation(summary = "매매일지 수정", description = "매매일지 내용을 수정합니다.")
+    @PatchMapping("/{diaryId}")
+    public ResponseEntity<ApiResponse<Void>> updateDiary(
+            @PathVariable Long diaryId,
+            Authentication authentication,
+            @RequestBody UpdateTradeDiaryRequest request) {
+        Long userId = (Long) authentication.getPrincipal();
+        tradeDiaryService.updateDiary(diaryId, userId, request);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, null);
     }
 }

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.trade.dto.response.TradeDiaryDetailResponse;
 import org.solmate.domain.trade.dto.response.TradeDiaryListResponse;
 import org.solmate.domain.trade.service.TradeDiaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +34,14 @@ public class TradeDiaryController {
             @RequestParam(required = false) String stockName) {
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getMyDiaries(userId, stockName));
+    }
+
+    @Operation(summary = "매매일지 상세 조회", description = "매매일지 상세 정보와 댓글 목록을 조회합니다.")
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<ApiResponse<TradeDiaryDetailResponse>> getDiaryDetail(
+            @PathVariable Long diaryId,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getDiaryDetail(diaryId, userId));
     }
 }

--- a/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeDiaryController.java
@@ -39,6 +39,15 @@ public class TradeDiaryController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getMyDiaries(userId, stockName));
     }
 
+    @Operation(summary = "특정 유저 매매일지 목록 조회", description = "특정 유저의 매매일지 목록을 조회합니다. 멘토/멘티 관계일 경우 댓글 수 포함.")
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<ApiResponse<List<TradeDiaryListResponse>>> getUserDiaries(
+            @PathVariable Long userId,
+            Authentication authentication) {
+        Long currentUserId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, tradeDiaryService.getUserDiaries(userId, currentUserId));
+    }
+
     @Operation(summary = "매매일지 상세 조회", description = "매매일지 상세 정보와 댓글 목록을 조회합니다.")
     @GetMapping("/{diaryId}")
     public ResponseEntity<ApiResponse<TradeDiaryDetailResponse>> getDiaryDetail(

--- a/src/main/java/org/solmate/domain/trade/dto/request/UpdateTradeDiaryRequest.java
+++ b/src/main/java/org/solmate/domain/trade/dto/request/UpdateTradeDiaryRequest.java
@@ -1,0 +1,5 @@
+package org.solmate.domain.trade.dto.request;
+
+public record UpdateTradeDiaryRequest(
+    String content
+) {}

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryDetailResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryDetailResponse.java
@@ -1,0 +1,80 @@
+package org.solmate.domain.trade.dto.response;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.solmate.domain.social.entity.Comment;
+import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.trade.entity.TradeDiary;
+import org.solmate.domain.trade.enums.TradeType;
+
+public record TradeDiaryDetailResponse(
+    Long diaryId,
+    String tradeType,
+    String stockName,
+    String tickerCode,
+    BigDecimal filledPrice,     // 체결가
+    BigDecimal quantity,        // 수량
+    BigDecimal profit,          // 수익금 (매도일 때만, 매수는 null)
+    BigDecimal profitRate,      // 수익률 % (매도일 때만, 매수는 null)
+    String content,             // 매매일지 내용
+    LocalDateTime createdAt,
+    List<CommentInfo> comments
+) {
+    public record CommentInfo(
+        Long commentId,
+        String nickname,
+        boolean isMentor,       // 댓글 작성자가 나의 멘토인지
+        String content
+    ) {}
+
+    public static TradeDiaryDetailResponse of(TradeDiary diary, List<Comment> comments,
+                                               MentoringRepository mentoringRepository, Long currentUserId) {
+        var tradeHistory = diary.getTradeHistory();
+        boolean isSell = tradeHistory.getTradeType() == TradeType.SELL;
+
+        // 수익금 = (체결가 - avgPriceSnapshot) * 수량 (매도일 때만)
+        BigDecimal profit = null;
+        BigDecimal profitRate = null;
+        if (isSell && tradeHistory.getAvgPriceSnapshot() != null) {
+            profit = tradeHistory.getPrice()
+                .subtract(tradeHistory.getAvgPriceSnapshot())
+                .multiply(tradeHistory.getQuantity());
+
+            // 수익률 = (체결가 - avgPriceSnapshot) / avgPriceSnapshot * 100
+            profitRate = tradeHistory.getPrice()
+                .subtract(tradeHistory.getAvgPriceSnapshot())
+                .divide(tradeHistory.getAvgPriceSnapshot(), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+        }
+
+        // 댓글 목록 변환 (댓글 작성자가 나의 멘토인지 확인)
+        List<CommentInfo> commentInfos = comments.stream()
+            .map(comment -> new CommentInfo(
+                comment.getId(),
+                comment.getUser().getNickname(),
+                mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(
+                    comment.getUser().getId(), currentUserId, MentoringStatus.ACCEPTED),
+                comment.getContent()
+            ))
+            .toList();
+
+        return new TradeDiaryDetailResponse(
+            diary.getId(),
+            tradeHistory.getTradeType().name(),
+            tradeHistory.getStock().getStockName(),
+            tradeHistory.getStock().getTickerCode(),
+            tradeHistory.getPrice(),
+            tradeHistory.getQuantity(),
+            profit,
+            profitRate,
+            diary.getContent(),
+            diary.getCreatedAt(),
+            commentInfos
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryListResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryListResponse.java
@@ -15,10 +15,10 @@ public record TradeDiaryListResponse(
     BigDecimal quantity,
     BigDecimal profit,       // 수익금 (매도일 때만, 매수는 null)
     String content,
-    long commentCount,
+    Long commentCount,       // 멘토/멘티 관계일 때만, 아니면 null
     LocalDateTime createdAt
 ) {
-    public static TradeDiaryListResponse of(TradeDiary diary, CommentRepository commentRepository) {
+    public static TradeDiaryListResponse of(TradeDiary diary, CommentRepository commentRepository, boolean includeCommentCount) {
         var tradeHistory = diary.getTradeHistory();
         boolean isSell = tradeHistory.getTradeType() == TradeType.SELL;
 
@@ -30,6 +30,10 @@ public record TradeDiaryListResponse(
                 .multiply(tradeHistory.getQuantity());
         }
 
+        Long commentCount = includeCommentCount
+            ? commentRepository.countByTradeDiaryIdAndIsDeletedFalse(diary.getId())
+            : null;
+
         return new TradeDiaryListResponse(
             diary.getId(),
             tradeHistory.getTradeType().name(),
@@ -38,7 +42,7 @@ public record TradeDiaryListResponse(
             tradeHistory.getQuantity(),
             profit,
             diary.getContent(),
-            commentRepository.countByTradeDiaryIdAndIsDeletedFalse(diary.getId()),
+            commentCount,
             diary.getCreatedAt()
         );
     }

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryListResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryListResponse.java
@@ -1,0 +1,37 @@
+package org.solmate.domain.trade.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.solmate.domain.social.repository.CommentRepository;
+import org.solmate.domain.trade.entity.TradeDiary;
+import org.solmate.domain.trade.enums.TradeType;
+
+public record TradeDiaryListResponse(
+    Long diaryId,
+    String tradeType,
+    String stockName,
+    BigDecimal filledPrice,
+    BigDecimal quantity,
+    BigDecimal profit,       // 수익금 (매도일 때만, 매수는 null)
+    String content,
+    long commentCount,
+    LocalDateTime createdAt
+) {
+    public static TradeDiaryListResponse of(TradeDiary diary, CommentRepository commentRepository) {
+        var tradeHistory = diary.getTradeHistory();
+        boolean isSell = tradeHistory.getTradeType() == TradeType.SELL;
+
+        return new TradeDiaryListResponse(
+            diary.getId(),
+            tradeHistory.getTradeType().name(),
+            tradeHistory.getStock().getStockName(),
+            tradeHistory.getPrice(),
+            tradeHistory.getQuantity(),
+            isSell ? tradeHistory.getProfit() : null,
+            diary.getContent(),
+            commentRepository.countByTradeDiaryIdAndIsDeletedFalse(diary.getId()),
+            diary.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryListResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryListResponse.java
@@ -22,13 +22,21 @@ public record TradeDiaryListResponse(
         var tradeHistory = diary.getTradeHistory();
         boolean isSell = tradeHistory.getTradeType() == TradeType.SELL;
 
+        // 수익금 = (체결가 - avgPriceSnapshot) * 수량 (매도일 때만)
+        BigDecimal profit = null;
+        if (isSell && tradeHistory.getAvgPriceSnapshot() != null) {
+            profit = tradeHistory.getPrice()
+                .subtract(tradeHistory.getAvgPriceSnapshot())
+                .multiply(tradeHistory.getQuantity());
+        }
+
         return new TradeDiaryListResponse(
             diary.getId(),
             tradeHistory.getTradeType().name(),
             tradeHistory.getStock().getStockName(),
             tradeHistory.getPrice(),
             tradeHistory.getQuantity(),
-            isSell ? tradeHistory.getProfit() : null,
+            profit,
             diary.getContent(),
             commentRepository.countByTradeDiaryIdAndIsDeletedFalse(diary.getId()),
             diary.getCreatedAt()

--- a/src/main/java/org/solmate/domain/trade/entity/TradeDiary.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeDiary.java
@@ -50,6 +50,10 @@ public class TradeDiary extends BaseEntity {
         this.status = status;
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
     @Builder
     public TradeDiary(User user, TradeHistory tradeHistory, String content, TradeDiaryStatus status) {
         this.user = user;

--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -62,17 +62,20 @@ public class TradeHistory extends BaseEntity {
     private OrderType orderType;
 
     /**
-     * 매도 체결 시 확정된 수익금 (매도일 때만 저장)
-     * - 체결 시점에 (체결가 - 매수평균단가) * 수량 으로 계산
-     * - 양수: 수익, 음수: 손실
+     * 매도 주문 접수 시점의 평균단가 스냅샷 (매도일 때만 저장)
+     * - 매도 후 추가 매수하면 Holdings.avgPrice가 바뀌기 때문에
+     *   매도 시점의 평균단가를 여기에 저장해두고 수익 계산에 사용
+     * - 수익금 = (체결가 - avgPriceSnapshot) * 수량
+     * - 수익률 = (체결가 - avgPriceSnapshot) / avgPriceSnapshot * 100
      * - 매수 주문의 경우 null
      */
-    @Column(name = "profit", precision = 19, scale = 4)
-    private BigDecimal profit;
+    @Column(name = "avg_price_snapshot", precision = 19, scale = 4)
+    private BigDecimal avgPriceSnapshot;
 
     @Builder
     public TradeHistory(User user, Stock stock, BigDecimal price, BigDecimal quantity,
-                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType) {
+                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType,
+                        BigDecimal avgPriceSnapshot) {
         this.user = user;
         this.stock = stock;
         this.price = price;
@@ -80,10 +83,7 @@ public class TradeHistory extends BaseEntity {
         this.tradeType = tradeType;
         this.tradeStatus = tradeStatus;
         this.orderType = orderType;
-    }
-
-    public void updateProfit(BigDecimal profit) {
-        this.profit = profit;
+        this.avgPriceSnapshot = avgPriceSnapshot;
     }
 
     public void updateStatus(TradeStatus tradeStatus) {

--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -61,9 +61,20 @@ public class TradeHistory extends BaseEntity {
     @Column(name = "order_type", nullable = false)
     private OrderType orderType;
 
+    /**
+     * 매도 주문 접수 시점의 평균단가 스냅샷 (매도일 때만 저장)
+     * - 매도 후 추가 매수하면 Holdings.avgPrice가 바뀌기 때문에
+     *   매도 시점의 평균단가를 여기에 저장해두고 수익 계산에 사용
+     * - 수익 = (price - avgPriceSnapshot) * quantity
+     * - 매수 주문의 경우 null
+     */
+    @Column(name = "avg_price_snapshot", precision = 19, scale = 4)
+    private BigDecimal avgPriceSnapshot;
+
     @Builder
     public TradeHistory(User user, Stock stock, BigDecimal price, BigDecimal quantity,
-                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType) {
+                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType,
+                        BigDecimal avgPriceSnapshot) {
         this.user = user;
         this.stock = stock;
         this.price = price;
@@ -71,6 +82,7 @@ public class TradeHistory extends BaseEntity {
         this.tradeType = tradeType;
         this.tradeStatus = tradeStatus;
         this.orderType = orderType;
+        this.avgPriceSnapshot = avgPriceSnapshot;
     }
 
     public void updateStatus(TradeStatus tradeStatus) {

--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -62,19 +62,17 @@ public class TradeHistory extends BaseEntity {
     private OrderType orderType;
 
     /**
-     * 매도 주문 접수 시점의 평균단가 스냅샷 (매도일 때만 저장)
-     * - 매도 후 추가 매수하면 Holdings.avgPrice가 바뀌기 때문에
-     *   매도 시점의 평균단가를 여기에 저장해두고 수익 계산에 사용
-     * - 수익 = (price - avgPriceSnapshot) * quantity
+     * 매도 체결 시 확정된 수익금 (매도일 때만 저장)
+     * - 체결 시점에 (체결가 - 매수평균단가) * 수량 으로 계산
+     * - 양수: 수익, 음수: 손실
      * - 매수 주문의 경우 null
      */
-    @Column(name = "avg_price_snapshot", precision = 19, scale = 4)
-    private BigDecimal avgPriceSnapshot;
+    @Column(name = "profit", precision = 19, scale = 4)
+    private BigDecimal profit;
 
     @Builder
     public TradeHistory(User user, Stock stock, BigDecimal price, BigDecimal quantity,
-                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType,
-                        BigDecimal avgPriceSnapshot) {
+                        TradeType tradeType, TradeStatus tradeStatus, OrderType orderType) {
         this.user = user;
         this.stock = stock;
         this.price = price;
@@ -82,7 +80,10 @@ public class TradeHistory extends BaseEntity {
         this.tradeType = tradeType;
         this.tradeStatus = tradeStatus;
         this.orderType = orderType;
-        this.avgPriceSnapshot = avgPriceSnapshot;
+    }
+
+    public void updateProfit(BigDecimal profit) {
+        this.profit = profit;
     }
 
     public void updateStatus(TradeStatus tradeStatus) {

--- a/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
@@ -14,7 +14,7 @@ public interface TradeDiaryRepository extends JpaRepository<TradeDiary, Long> {
 
     Optional<TradeDiary> findByTradeHistoryId(Long tradeHistoryId);
 
-    // 내 매매일지 목록 조회 (최신순)
-    @Query("SELECT td FROM TradeDiary td JOIN FETCH td.tradeHistory th JOIN FETCH th.stock WHERE td.user.id = :userId ORDER BY td.createdAt DESC")
+    // 내 매매일지 목록 조회 (최신순, 체결된 것만)
+    @Query("SELECT td FROM TradeDiary td JOIN FETCH td.tradeHistory th JOIN FETCH th.stock WHERE td.user.id = :userId AND td.status = 'FILLED' ORDER BY td.createdAt DESC")
     List<TradeDiary> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 }

--- a/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
@@ -1,13 +1,20 @@
 package org.solmate.domain.trade.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.solmate.domain.trade.entity.TradeDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TradeDiaryRepository extends JpaRepository<TradeDiary, Long> {
 
     void deleteByTradeHistoryId(Long tradeHistoryId);
 
     Optional<TradeDiary> findByTradeHistoryId(Long tradeHistoryId);
+
+    // 내 매매일지 목록 조회 (최신순)
+    @Query("SELECT td FROM TradeDiary td JOIN FETCH td.tradeHistory th JOIN FETCH th.stock WHERE td.user.id = :userId ORDER BY td.createdAt DESC")
+    List<TradeDiary> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 }

--- a/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeDiaryRepository.java
@@ -17,4 +17,8 @@ public interface TradeDiaryRepository extends JpaRepository<TradeDiary, Long> {
     // 내 매매일지 목록 조회 (최신순, 체결된 것만)
     @Query("SELECT td FROM TradeDiary td JOIN FETCH td.tradeHistory th JOIN FETCH th.stock WHERE td.user.id = :userId AND td.status = 'FILLED' ORDER BY td.createdAt DESC")
     List<TradeDiary> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+
+    // 종목명 검색 (최신순, 체결된 것만)
+    @Query("SELECT td FROM TradeDiary td JOIN FETCH td.tradeHistory th JOIN FETCH th.stock s WHERE td.user.id = :userId AND td.status = 'FILLED' AND s.stockName LIKE %:stockName% ORDER BY td.createdAt DESC")
+    List<TradeDiary> findAllByUserIdAndStockNameContaining(@Param("userId") Long userId, @Param("stockName") String stockName);
 }

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -165,15 +165,6 @@ public class OrderMatchingService {
                         account.addCash(currentPrice.multiply(quantity));
                     }
 
-                    // 수익 계산: (체결가 - 매수평균단가) * 수량
-                    // Holdings.avgPrice는 매도 주문 접수 시점의 평균단가
-                    String sellTicker = tradeHistory.getStock().getTickerCode();
-                    Holdings holdings = holdingsRepository.findByUserAndTickerCode(user, sellTicker).orElse(null);
-                    if (holdings != null) {
-                        BigDecimal profit = currentPrice.subtract(holdings.getAvgPrice()).multiply(quantity);
-                        tradeHistory.updateProfit(profit);
-                    }
-
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
 

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -165,6 +165,15 @@ public class OrderMatchingService {
                         account.addCash(currentPrice.multiply(quantity));
                     }
 
+                    // 수익 계산: (체결가 - 매수평균단가) * 수량
+                    // Holdings.avgPrice는 매도 주문 접수 시점의 평균단가
+                    String sellTicker = tradeHistory.getStock().getTickerCode();
+                    Holdings holdings = holdingsRepository.findByUserAndTickerCode(user, sellTicker).orElse(null);
+                    if (holdings != null) {
+                        BigDecimal profit = currentPrice.subtract(holdings.getAvgPrice()).multiply(quantity);
+                        tradeHistory.updateProfit(profit);
+                    }
+
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
 

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -18,9 +18,12 @@ public class TradeDiaryService {
     private final CommentRepository commentRepository;
 
     @Transactional(readOnly = true)
-    public List<TradeDiaryListResponse> getMyDiaries(Long userId) {
-        return tradeDiaryRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
-            .stream()
+    public List<TradeDiaryListResponse> getMyDiaries(Long userId, String stockName) {
+        var diaries = (stockName != null && !stockName.isBlank())
+            ? tradeDiaryRepository.findAllByUserIdAndStockNameContaining(userId, stockName)
+            : tradeDiaryRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+
+        return diaries.stream()
             .map(diary -> TradeDiaryListResponse.of(diary, commentRepository))
             .toList();
     }

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -61,7 +61,7 @@ public class TradeDiaryService {
     }
 
     @Transactional
-    public void updateDiary(Long diaryId, Long currentUserId, UpdateTradeDiaryRequest request) {
+    public TradeDiaryDetailResponse updateDiary(Long diaryId, Long currentUserId, UpdateTradeDiaryRequest request) {
         var diary = tradeDiaryRepository.findById(diaryId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.TRADE_DIARY_NOT_FOUND));
 
@@ -71,5 +71,8 @@ public class TradeDiaryService {
         }
 
         diary.updateContent(request.content());
+
+        var comments = commentRepository.findAllByTradeDiaryIdAndIsDeletedFalseOrderByCreatedAtAsc(diaryId);
+        return TradeDiaryDetailResponse.of(diary, comments, mentoringRepository, currentUserId);
     }
 }

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -31,7 +31,7 @@ public class TradeDiaryService {
             : tradeDiaryRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
 
         return diaries.stream()
-            .map(diary -> TradeDiaryListResponse.of(diary, commentRepository))
+            .map(diary -> TradeDiaryListResponse.of(diary, commentRepository, true))
             .toList();
     }
 

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -2,7 +2,11 @@ package org.solmate.domain.trade.service;
 
 import java.util.List;
 
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.social.repository.CommentRepository;
+import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.trade.dto.response.TradeDiaryDetailResponse;
 import org.solmate.domain.trade.dto.response.TradeDiaryListResponse;
 import org.solmate.domain.trade.repository.TradeDiaryRepository;
 import org.springframework.stereotype.Service;
@@ -16,6 +20,7 @@ public class TradeDiaryService {
 
     private final TradeDiaryRepository tradeDiaryRepository;
     private final CommentRepository commentRepository;
+    private final MentoringRepository mentoringRepository;
 
     @Transactional(readOnly = true)
     public List<TradeDiaryListResponse> getMyDiaries(Long userId, String stockName) {
@@ -26,5 +31,15 @@ public class TradeDiaryService {
         return diaries.stream()
             .map(diary -> TradeDiaryListResponse.of(diary, commentRepository))
             .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public TradeDiaryDetailResponse getDiaryDetail(Long diaryId, Long currentUserId) {
+        var diary = tradeDiaryRepository.findById(diaryId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.TRADE_DIARY_NOT_FOUND));
+
+        var comments = commentRepository.findAllByTradeDiaryIdAndIsDeletedFalseOrderByCreatedAtAsc(diaryId);
+
+        return TradeDiaryDetailResponse.of(diary, comments, mentoringRepository, currentUserId);
     }
 }

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -1,0 +1,27 @@
+package org.solmate.domain.trade.service;
+
+import java.util.List;
+
+import org.solmate.domain.social.repository.CommentRepository;
+import org.solmate.domain.trade.dto.response.TradeDiaryListResponse;
+import org.solmate.domain.trade.repository.TradeDiaryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TradeDiaryService {
+
+    private final TradeDiaryRepository tradeDiaryRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public List<TradeDiaryListResponse> getMyDiaries(Long userId) {
+        return tradeDiaryRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
+            .stream()
+            .map(diary -> TradeDiaryListResponse.of(diary, commentRepository))
+            .toList();
+    }
+}

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -36,6 +36,19 @@ public class TradeDiaryService {
     }
 
     @Transactional(readOnly = true)
+    public List<TradeDiaryListResponse> getUserDiaries(Long targetUserId, Long currentUserId) {
+        // 멘토/멘티 관계이면 댓글 수 포함, 아니면 null
+        boolean isMentoringRelation =
+            mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(currentUserId, targetUserId, MentoringStatus.ACCEPTED)
+            || mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(targetUserId, currentUserId, MentoringStatus.ACCEPTED);
+
+        return tradeDiaryRepository.findAllByUserIdOrderByCreatedAtDesc(targetUserId)
+            .stream()
+            .map(diary -> TradeDiaryListResponse.of(diary, commentRepository, isMentoringRelation))
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
     public TradeDiaryDetailResponse getDiaryDetail(Long diaryId, Long currentUserId) {
         var diary = tradeDiaryRepository.findById(diaryId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.TRADE_DIARY_NOT_FOUND));

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.social.enums.MentoringStatus;
 import org.solmate.domain.social.repository.CommentRepository;
 import org.solmate.domain.social.repository.MentoringRepository;
 import org.solmate.domain.trade.dto.response.TradeDiaryDetailResponse;
@@ -37,6 +38,21 @@ public class TradeDiaryService {
     public TradeDiaryDetailResponse getDiaryDetail(Long diaryId, Long currentUserId) {
         var diary = tradeDiaryRepository.findById(diaryId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.TRADE_DIARY_NOT_FOUND));
+
+        Long diaryOwnerId = diary.getUser().getId();
+
+        // 내 매매일지가 아닌 경우 멘토/멘티 관계 확인
+        if (!diaryOwnerId.equals(currentUserId)) {
+            boolean isMentoringRelation =
+                // 내가 일지 주인의 멘토인 경우
+                mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(currentUserId, diaryOwnerId, MentoringStatus.ACCEPTED)
+                // 내가 일지 주인의 멘티인 경우
+                || mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(diaryOwnerId, currentUserId, MentoringStatus.ACCEPTED);
+
+            if (!isMentoringRelation) {
+                throw new GeneralException(ErrorStatus.FORBIDDEN);
+            }
+        }
 
         var comments = commentRepository.findAllByTradeDiaryIdAndIsDeletedFalseOrderByCreatedAtAsc(diaryId);
 

--- a/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeDiaryService.java
@@ -7,6 +7,7 @@ import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.social.enums.MentoringStatus;
 import org.solmate.domain.social.repository.CommentRepository;
 import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.trade.dto.request.UpdateTradeDiaryRequest;
 import org.solmate.domain.trade.dto.response.TradeDiaryDetailResponse;
 import org.solmate.domain.trade.dto.response.TradeDiaryListResponse;
 import org.solmate.domain.trade.repository.TradeDiaryRepository;
@@ -57,5 +58,18 @@ public class TradeDiaryService {
         var comments = commentRepository.findAllByTradeDiaryIdAndIsDeletedFalseOrderByCreatedAtAsc(diaryId);
 
         return TradeDiaryDetailResponse.of(diary, comments, mentoringRepository, currentUserId);
+    }
+
+    @Transactional
+    public void updateDiary(Long diaryId, Long currentUserId, UpdateTradeDiaryRequest request) {
+        var diary = tradeDiaryRepository.findById(diaryId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.TRADE_DIARY_NOT_FOUND));
+
+        // 본인 매매일지만 수정 가능
+        if (!diary.getUser().getId().equals(currentUserId)) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN);
+        }
+
+        diary.updateContent(request.content());
     }
 }

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -146,7 +146,6 @@ public class TradeService {
         holdings.subtractQuantity(request.quantity());
 
         // TradeHistory 저장
-        // avgPriceSnapshot: 매도 시점의 평균단가 스냅샷 저장 (이후 추가 매수 시 avgPrice가 바뀌어도 수익 계산 가능)
         TradeHistory tradeHistory = TradeHistory.builder()
             .user(user)
             .stock(stock)
@@ -155,7 +154,6 @@ public class TradeService {
             .tradeType(TradeType.SELL)
             .tradeStatus(TradeStatus.PENDING)
             .orderType(request.orderType())
-            .avgPriceSnapshot(holdings.getAvgPrice())
             .build();
         tradeHistoryRepository.saveAndFlush(tradeHistory);
 

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -146,6 +146,7 @@ public class TradeService {
         holdings.subtractQuantity(request.quantity());
 
         // TradeHistory 저장
+        // avgPriceSnapshot: 매도 시점의 평균단가 스냅샷 저장 (이후 추가 매수 시 avgPrice가 바뀌어도 수익 계산 가능)
         TradeHistory tradeHistory = TradeHistory.builder()
             .user(user)
             .stock(stock)
@@ -154,6 +155,7 @@ public class TradeService {
             .tradeType(TradeType.SELL)
             .tradeStatus(TradeStatus.PENDING)
             .orderType(request.orderType())
+            .avgPriceSnapshot(holdings.getAvgPrice())
             .build();
         tradeHistoryRepository.saveAndFlush(tradeHistory);
 

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -221,7 +221,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
             LocalDateTime candleTime = LocalDateTime.parse(startTime, DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
             messagingTemplate.convertAndSend(topic, CandleResponse.fromRedis(data, candleTime));
         } catch (Exception e) {
-            log.warn("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
+            log.debug("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);
         }
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #49 

## 💡 작업 배경
매매일지 조회 시 진입 경로(매매일지 탭 / 멘토·멘티 탭 / 프로필)에 따라 노출 범위가 달라야 하는 요구사항이 있어 API를 설계하고 구현했습니다.

## 🧩 작업 내용
  진입 경로별 노출 범위

  | 진입 경로 | 댓글 수 | 상세 조회 | 댓글 작성 |
  |---|---|---|---|
  | 매매일지 탭 (내 것) | ✓ | ✓ | ✓ |                                                                                                                                               
  | 멘토/멘티 탭 (상대방 것) | ✓ | ✓ | ✓ |                                                                                                                                          
  | 프로필 (나 포함 누구든) | ❌ | ❌ | ❌ | 

  API 설계

  - GET /api/diaries/my - 매매일지 탭용, 댓글 수 항상 포함
  - GET /api/diaries/users/{userId} - 프로필/멘토·멘티 탭 공용
    - 멘토/멘티 관계(ACCEPTED)이면 댓글 수 포함
    - 관계 없으면 댓글 수 null 반환
    - 프론트에서 진입 경로에 따라 댓글 수 노출 여부 결정
  - GET /api/diaries/{diaryId} - 상세 조회 (멘토/멘티 관계 또는 본인만 접근 가능)
  - PATCH /api/diaries/{diaryId} - 매매일지 내용 수정 (본인만 가능)

  수익 계산

  - 매도 주문 접수 시 avgPriceSnapshot (매수 평균단가 스냅샷) 저장
  - 이후 추가 매수로 평균단가가 바뀌어도 정확한 수익 계산 가능
  - 수익금 = (체결가 - avgPriceSnapshot) * 수량
  - 수익률 = (체결가 - avgPriceSnapshot) / avgPriceSnapshot * 100


