### PR TITLE
[Feat] 사용자별 매매내역 조회 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -35,6 +35,7 @@ public enum SuccessStatus implements BaseStatus {
     BUY_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매수 주문 접수 성공"),
     SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
     HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공"),
+    TRADE_HISTORY_SUCCESS("TRADE_200", HttpStatus.OK, "매매내역 조회 성공"),
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),

--- a/src/main/java/org/solmate/domain/trade/controller/TradeController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,20 @@ public class TradeController {
             @AuthenticationPrincipal Long userId,
             @RequestBody SellOrderRequest request) {
         return ApiResponse.success(SuccessStatus.SELL_ORDER_SUCCESS, tradeService.sellOrder(userId, request));
+    }
+
+    @Operation(summary = "내 매매내역 조회", description = "체결완료된 나의 전체 매매내역을 조회합니다.")
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<List<TradeHistoryResponse.PortfolioItem>>> getMyPortfolioTrades(
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(SuccessStatus.TRADE_HISTORY_SUCCESS, tradeService.getPortfolioTrades(userId));
+    }
+
+    @Operation(summary = "타인 매매내역 조회", description = "체결완료된 타인의 전체 매매내역을 조회합니다.")
+    @GetMapping("/history/{userId}")
+    public ResponseEntity<ApiResponse<List<TradeHistoryResponse.PortfolioItem>>> getOtherPortfolioTrades(
+            @PathVariable Long userId) {
+        return ApiResponse.success(SuccessStatus.TRADE_HISTORY_SUCCESS, tradeService.getPortfolioTrades(userId));
     }
 
     @Operation(summary = "종목별 매매내역 리스트 조회")

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeHistoryResponse.java
@@ -1,10 +1,14 @@
 package org.solmate.domain.trade.dto.response;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.solmate.common.s3.S3Service;
 import org.solmate.domain.trade.entity.TradeHistory;
 import org.solmate.domain.trade.enums.TradeStatus;
+import org.solmate.domain.trade.enums.TradeType;
 
 public record TradeHistoryResponse(
         String stockCode,
@@ -37,6 +41,53 @@ public record TradeHistoryResponse(
                     trade.getTradeStatus().name(),
                     trade.getTradeStatus().getLabel(),
                     trade.getTradeStatus() == TradeStatus.PENDING
+            );
+        }
+    }
+
+    public record PortfolioItem(
+            String stockName,
+            String stockLogo,
+            String tradeType,
+            String tradeTypeLabel,
+            BigDecimal quantity,
+            BigDecimal price,
+            BigDecimal amount,
+            BigDecimal profitAmount,
+            BigDecimal profitRate,
+            LocalDateTime tradedAt
+    ) {
+        public static PortfolioItem of(TradeHistory trade, S3Service s3Service) {
+            String logoKey = trade.getStock().getStockLogo();
+            String stockLogo = (logoKey != null) ? s3Service.buildFileUrl(logoKey) : null;
+
+            BigDecimal profitAmount = null;
+            BigDecimal profitRate = null;
+
+            if (trade.getTradeType() == TradeType.SELL && trade.getAvgPriceSnapshot() != null
+                    && trade.getAvgPriceSnapshot().compareTo(BigDecimal.ZERO) != 0) {
+                profitAmount = trade.getPrice()
+                        .subtract(trade.getAvgPriceSnapshot())
+                        .multiply(trade.getQuantity())
+                        .setScale(0, RoundingMode.HALF_UP);
+                profitRate = trade.getPrice()
+                        .subtract(trade.getAvgPriceSnapshot())
+                        .divide(trade.getAvgPriceSnapshot(), 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(2, RoundingMode.HALF_UP);
+            }
+
+            return new PortfolioItem(
+                    trade.getStock().getStockName(),
+                    stockLogo,
+                    trade.getTradeType().name(),
+                    trade.getTradeType().getLabel(),
+                    trade.getQuantity(),
+                    trade.getPrice(),
+                    trade.getPrice().multiply(trade.getQuantity()).setScale(0, RoundingMode.HALF_UP),
+                    profitAmount,
+                    profitRate,
+                    trade.getCreatedAt()
             );
         }
     }

--- a/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
@@ -25,4 +25,7 @@ public interface TradeHistoryRepository extends JpaRepository<TradeHistory, Long
 
     @Query("SELECT t FROM TradeHistory t JOIN FETCH t.stock WHERE t.user.id = :userId AND t.stock.tickerCode = :tickerCode ORDER BY t.createdAt DESC")
     List<TradeHistory> findByUserIdAndTickerCode(@Param("userId") Long userId, @Param("tickerCode") String tickerCode);
+
+    @Query("SELECT t FROM TradeHistory t JOIN FETCH t.stock WHERE t.user.id = :userId AND t.tradeStatus = 'FILLED' ORDER BY t.createdAt DESC")
+    List<TradeHistory> findFilledByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -15,6 +15,7 @@ import org.solmate.domain.stock.entity.Stock;
 import org.solmate.domain.stock.repository.StockRepository;
 import org.solmate.domain.trade.dto.request.BuyOrderRequest;
 import org.solmate.domain.trade.dto.request.SellOrderRequest;
+import org.solmate.common.s3.S3Service;
 import org.solmate.domain.trade.dto.response.OrderResponse;
 import org.solmate.domain.trade.dto.response.TradeHistoryResponse;
 import org.solmate.domain.trade.entity.Holdings;
@@ -49,6 +50,7 @@ public class TradeService {
     private final TradeHistoryRepository tradeHistoryRepository;
     private final TradeDiaryRepository tradeDiaryRepository;
     private final StringRedisTemplate redisTemplate;
+    private final S3Service s3Service;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
@@ -172,6 +174,13 @@ public class TradeService {
         addOrderToRedis("orders:sell:" + request.ticker(), tradeHistory.getId(), userId, price, request.quantity());
 
         return OrderResponse.of(tradeHistory);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TradeHistoryResponse.PortfolioItem> getPortfolioTrades(Long userId) {
+        return tradeHistoryRepository.findFilledByUserId(userId).stream()
+                .map(trade -> TradeHistoryResponse.PortfolioItem.of(trade, s3Service))
+                .toList();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #63 

## 💡 작업 배경
포트폴리오 화면에서 보유 종목과 매매내역을 조회하는 API가 필요했다.

## 🧩 작업 내용
  - `GET /api/trades/history` - 내 체결 매매내역 조회
  - `GET /api/trades/history/{userId}` - 타인 체결 매매내역 조회

## 📸 스크린샷(선택)

<img width="1209" height="737" alt="Screenshot 2026-03-24 at 4 27 44 PM" src="https://github.com/user-attachments/assets/37d7d122-19ba-421d-9225-d5abc1efff70" />

<img width="759" height="692" alt="Screenshot 2026-03-24 at 4 36 02 PM" src="https://github.com/user-attachments/assets/f99b1a61-6af6-4f96-8923-9c3803970350" />

## 📝 기타

