### PR TITLE
[Feat] 매매일지 댓글 CRUD API 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -54,6 +54,7 @@ public enum ErrorStatus implements BaseStatus {
     INSUFFICIENT_HOLDINGS("TRADE_400_2", HttpStatus.BAD_REQUEST, "보유 수량이 부족합니다."),
     STOCK_PRICE_NOT_FOUND("TRADE_404_3", HttpStatus.NOT_FOUND, "Redis에 해당 종목 시세가 없습니다."),
     TRADE_DIARY_NOT_FOUND("TRADE_404_4", HttpStatus.NOT_FOUND, "매매일지를 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND("TRADE_404_5", HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
 
     /**
      * Mentoring

--- a/src/main/java/org/solmate/domain/social/controller/CommentController.java
+++ b/src/main/java/org/solmate/domain/social/controller/CommentController.java
@@ -1,0 +1,60 @@
+package org.solmate.domain.social.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.social.dto.request.CreateCommentRequest;
+import org.solmate.domain.social.dto.request.UpdateCommentRequest;
+import org.solmate.domain.social.dto.response.CommentResponse;
+import org.solmate.domain.social.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Comment", description = "댓글 API")
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 작성", description = "매매일지에 댓글을 작성합니다. 멘토/멘티 관계일 때만 가능합니다.")
+    @PostMapping("/diaries/{diaryId}/comments")
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable Long diaryId,
+            Authentication authentication,
+            @RequestBody CreateCommentRequest request) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(SuccessStatus.SUCCESS_201, commentService.createComment(diaryId, userId, request));
+    }
+
+    @Operation(summary = "댓글 수정", description = "본인이 작성한 댓글을 수정합니다.")
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @PathVariable Long commentId,
+            Authentication authentication,
+            @RequestBody UpdateCommentRequest request) {
+        Long userId = (Long) authentication.getPrincipal();
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, commentService.updateComment(commentId, userId, request));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "본인이 작성한 댓글을 삭제합니다.")
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long commentId,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        commentService.deleteComment(commentId, userId);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, null);
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/request/CreateCommentRequest.java
+++ b/src/main/java/org/solmate/domain/social/dto/request/CreateCommentRequest.java
@@ -1,0 +1,5 @@
+package org.solmate.domain.social.dto.request;
+
+public record CreateCommentRequest(
+    String content
+) {}

--- a/src/main/java/org/solmate/domain/social/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/org/solmate/domain/social/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,5 @@
+package org.solmate.domain.social.dto.request;
+
+public record UpdateCommentRequest(
+    String content
+) {}

--- a/src/main/java/org/solmate/domain/social/dto/response/CommentResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/CommentResponse.java
@@ -1,0 +1,23 @@
+package org.solmate.domain.social.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.solmate.domain.social.entity.Comment;
+
+public record CommentResponse(
+    Long commentId,
+    String nickname,
+    boolean isMentor,       // 댓글 작성자가 일지 주인의 멘토인지
+    String content,
+    LocalDateTime createdAt
+) {
+    public static CommentResponse of(Comment comment, boolean isMentor) {
+        return new CommentResponse(
+            comment.getId(),
+            comment.getUser().getNickname(),
+            isMentor,
+            comment.getContent(),
+            comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/social/entity/Comment.java
+++ b/src/main/java/org/solmate/domain/social/entity/Comment.java
@@ -50,6 +50,10 @@ public class Comment extends BaseEntity {
         this.isDeleted = false;
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
     public void delete() {
         this.isDeleted = true;
     }

--- a/src/main/java/org/solmate/domain/social/service/CommentService.java
+++ b/src/main/java/org/solmate/domain/social/service/CommentService.java
@@ -1,0 +1,103 @@
+package org.solmate.domain.social.service;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.social.dto.request.CreateCommentRequest;
+import org.solmate.domain.social.dto.request.UpdateCommentRequest;
+import org.solmate.domain.social.dto.response.CommentResponse;
+import org.solmate.domain.social.entity.Comment;
+import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.social.repository.CommentRepository;
+import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.trade.entity.TradeDiary;
+import org.solmate.domain.trade.repository.TradeDiaryRepository;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final TradeDiaryRepository tradeDiaryRepository;
+    private final MentoringRepository mentoringRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CommentResponse createComment(Long diaryId, Long currentUserId, CreateCommentRequest request) {
+        TradeDiary diary = tradeDiaryRepository.findById(diaryId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.TRADE_DIARY_NOT_FOUND));
+
+        checkMentoringRelation(currentUserId, diary.getUser().getId());
+
+        User user = userRepository.findById(currentUserId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Comment comment = Comment.builder()
+            .user(user)
+            .tradeDiary(diary)
+            .content(request.content())
+            .build();
+
+        commentRepository.save(comment);
+
+        boolean isMentor = mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(
+            currentUserId, diary.getUser().getId(), MentoringStatus.ACCEPTED);
+
+        return CommentResponse.of(comment, isMentor);
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long commentId, Long currentUserId, UpdateCommentRequest request) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (comment.isDeleted()) {
+            throw new GeneralException(ErrorStatus.COMMENT_NOT_FOUND);
+        }
+
+        if (!comment.getUser().getId().equals(currentUserId)) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN);
+        }
+
+        comment.updateContent(request.content());
+
+        Long diaryOwnerId = comment.getTradeDiary().getUser().getId();
+        boolean isMentor = mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(
+            currentUserId, diaryOwnerId, MentoringStatus.ACCEPTED);
+
+        return CommentResponse.of(comment, isMentor);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long currentUserId) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        if (comment.isDeleted()) {
+            throw new GeneralException(ErrorStatus.COMMENT_NOT_FOUND);
+        }
+
+        if (!comment.getUser().getId().equals(currentUserId)) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN);
+        }
+
+        comment.delete();
+    }
+
+    private void checkMentoringRelation(Long currentUserId, Long diaryOwnerId) {
+        if (currentUserId.equals(diaryOwnerId)) return;
+
+        boolean isMentoringRelation =
+            mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(currentUserId, diaryOwnerId, MentoringStatus.ACCEPTED)
+            || mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(diaryOwnerId, currentUserId, MentoringStatus.ACCEPTED);
+
+        if (!isMentoringRelation) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #73

## 💡 작업 배경
  매매일지 상세 페이지에서 멘토/멘티 간 댓글을 통한 소통 기능이 필요하여 댓글 CRUD API를 구현했습니다.
  멘토/멘티 관계(ACCEPTED)일 때만 댓글 작성·수정·삭제가 가능하도록 권한을 제어합니다.


## 🧩 작업 내용
  - CommentService: 댓글 작성/수정/삭제 로직 구현
    - 멘토/멘티 관계가 아닌 경우 403 Forbidden 처리
    - 본인 댓글만 수정/삭제 가능
    - 소프트 딜리트(isDeleted) 방식으로 삭제 처리
  - CommentController: 댓글 API 엔드포인트 추가
    - POST /api/diaries/{diaryId}/comments (댓글 작성)
    - PATCH /api/comments/{commentId} (댓글 수정)
    - DELETE /api/comments/{commentId} (댓글 삭제)
  - CommentResponse: 댓글 작성자의 멘토 여부(isMentor) 포함
  - ErrorStatus: COMMENT_NOT_FOUND 에러 코드 추가

