### PR TITLE
[Feat] 프로필 관련 기능 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseStatus {
      * User
      */
     USER_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    USER_ALREADY_WITHDRAWN("USER_400", HttpStatus.BAD_REQUEST, "이미 탈퇴한 유저입니다."),
     EMAIL_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     EMAIL_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     NICKNAME_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -27,6 +27,7 @@ public enum SuccessStatus implements BaseStatus {
     EMAIL_SEND_SUCCESS("AUTH_200", HttpStatus.OK, "인증 메일 발송 성공"),
     EMAIL_VERIFY_SUCCESS("AUTH_200", HttpStatus.OK, "이메일 인증 성공"),
     NICKNAME_CHECK_SUCCESS("AUTH_200", HttpStatus.OK, "사용 가능한 닉네임입니다."),
+    PASSWORD_RESET_SUCCESS("AUTH_200", HttpStatus.OK, "비밀번호 재설정 성공"),
 
     /**
      * Trade (모의투자)

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -36,6 +36,7 @@ public enum SuccessStatus implements BaseStatus {
     SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
     HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공"),
     TRADE_HISTORY_SUCCESS("TRADE_200", HttpStatus.OK, "매매내역 조회 성공"),
+    PROFILE_IMAGE_UPDATE_SUCCESS("USER_200", HttpStatus.OK, "프로필 이미지 업데이트 성공"),
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -38,6 +38,7 @@ public enum SuccessStatus implements BaseStatus {
     TRADE_HISTORY_SUCCESS("TRADE_200", HttpStatus.OK, "매매내역 조회 성공"),
     PROFILE_UPDATE_SUCCESS("USER_200", HttpStatus.OK, "프로필 업데이트 성공"),
     PROFILE_IMAGE_DELETE_SUCCESS("USER_200", HttpStatus.OK, "프로필 이미지 삭제 성공"),
+    WITHDRAW_SUCCESS("USER_200", HttpStatus.OK, "회원 탈퇴 성공"),
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -36,7 +36,7 @@ public enum SuccessStatus implements BaseStatus {
     SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
     HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공"),
     TRADE_HISTORY_SUCCESS("TRADE_200", HttpStatus.OK, "매매내역 조회 성공"),
-    PROFILE_IMAGE_UPDATE_SUCCESS("USER_200", HttpStatus.OK, "프로필 이미지 업데이트 성공"),
+    PROFILE_UPDATE_SUCCESS("USER_200", HttpStatus.OK, "프로필 업데이트 성공"),
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -28,6 +28,7 @@ public enum SuccessStatus implements BaseStatus {
     EMAIL_VERIFY_SUCCESS("AUTH_200", HttpStatus.OK, "이메일 인증 성공"),
     NICKNAME_CHECK_SUCCESS("AUTH_200", HttpStatus.OK, "사용 가능한 닉네임입니다."),
     PASSWORD_RESET_SUCCESS("AUTH_200", HttpStatus.OK, "비밀번호 재설정 성공"),
+    PASSWORD_CHECK_SUCCESS("USER_200", HttpStatus.OK, "비밀번호 확인 성공"),
 
     /**
      * Trade (모의투자)

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -37,6 +37,7 @@ public enum SuccessStatus implements BaseStatus {
     HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공"),
     TRADE_HISTORY_SUCCESS("TRADE_200", HttpStatus.OK, "매매내역 조회 성공"),
     PROFILE_UPDATE_SUCCESS("USER_200", HttpStatus.OK, "프로필 업데이트 성공"),
+    PROFILE_IMAGE_DELETE_SUCCESS("USER_200", HttpStatus.OK, "프로필 이미지 삭제 성공"),
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),

--- a/src/main/java/org/solmate/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/solmate/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.auth.dto.request.ConfirmEmailVerificationRequest;
 import org.solmate.domain.auth.dto.request.EmailVerificationRequest;
 import org.solmate.domain.auth.dto.request.LoginRequest;
+import org.solmate.domain.auth.dto.request.PasswordResetRequest;
 import org.solmate.domain.auth.dto.request.SignUpRequest;
 import org.solmate.domain.auth.dto.response.LoginResponse;
 import org.solmate.domain.auth.service.AuthService;
@@ -63,6 +64,24 @@ public class AuthController {
     ) {
         emailVerificationService.confirmEmailVerificationCode(request.email(), request.emailVerificationCode());
         return ApiResponse.success(SuccessStatus.EMAIL_VERIFY_SUCCESS);
+    }
+
+    @Operation(summary = "비밀번호 재설정 인증 메일 발송", description = "비밀번호 재설정을 위한 인증 코드를 이메일로 발송합니다.")
+    @PostMapping("/password/email/send")
+    public ResponseEntity<ApiResponse<Void>> sendPasswordResetEmail(
+            @RequestBody @Valid EmailVerificationRequest request
+    ) {
+        emailVerificationService.requestPasswordResetCode(request.email());
+        return ApiResponse.success(SuccessStatus.EMAIL_SEND_SUCCESS);
+    }
+
+    @Operation(summary = "비밀번호 재설정", description = "이메일 인증 완료 후 새 비밀번호로 변경합니다.")
+    @PostMapping("/password/reset")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(
+            @RequestBody @Valid PasswordResetRequest request
+    ) {
+        authService.resetPassword(request.email(), request.newPassword());
+        return ApiResponse.success(SuccessStatus.PASSWORD_RESET_SUCCESS);
     }
 
     @Operation(summary = "회원가입")

--- a/src/main/java/org/solmate/domain/auth/dto/request/PasswordResetRequest.java
+++ b/src/main/java/org/solmate/domain/auth/dto/request/PasswordResetRequest.java
@@ -1,0 +1,15 @@
+package org.solmate.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        String newPassword
+) {
+}

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -114,6 +114,13 @@ public class AuthService {
         return jwtProvider.generateAccessToken(userId);
     }
 
+    // 비밀번호 재설정
+    public void resetPassword(String email, String newPassword) {
+        emailVerificationService.isEmailVerified(email);
+        User user = userService.getUserByEmail(email);
+        userService.updatePassword(user, passwordEncoder.encode(newPassword));
+    }
+
     // 로그아웃
     public void logout(String accessToken, String refreshToken, HttpServletResponse response) {
         if (jwtProvider.validateToken(refreshToken)) {

--- a/src/main/java/org/solmate/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/solmate/domain/auth/service/EmailVerificationService.java
@@ -38,6 +38,19 @@ public class EmailVerificationService {
         emailSender.send(email, verificationCode);
     }
 
+    // 비밀번호 재설정 인증 코드 요청
+    @Transactional
+    public void requestPasswordResetCode(String email) {
+        String verificationCode = createEmailVerificationCode();
+        emailVerificationRepository.findByEmail(email)
+                .ifPresentOrElse(
+                        existing -> updateEmailVerification(existing, verificationCode),
+                        () -> registerEmailVerification(email, verificationCode)
+                );
+
+        emailSender.sendPasswordReset(email, verificationCode);
+    }
+
     // 이메일 인증 코드 확인
     @Transactional
     public void confirmEmailVerificationCode(String email, String code) {

--- a/src/main/java/org/solmate/domain/auth/util/EmailSender.java
+++ b/src/main/java/org/solmate/domain/auth/util/EmailSender.java
@@ -44,9 +44,35 @@ public class EmailSender {
         }
     }
 
+    // 비밀번호 재설정 인증 코드 발송
+    public void sendPasswordReset(String recipientEmail, String verificationCode) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(senderAddress);
+            helper.setTo(recipientEmail);
+            helper.setSubject("[SOLMATE] 비밀번호 재설정 인증 코드입니다.");
+            helper.setText(buildPasswordResetHtmlContent(verificationCode), true);
+
+            mailSender.send(message);
+
+            log.info("비밀번호 재설정 이메일 전송 완료 → {}", recipientEmail);
+        } catch (Exception e) {
+            log.error("비밀번호 재설정 이메일 전송 실패 → {}", recipientEmail, e);
+            throw new GeneralException(ErrorStatus.EMAIL_SEND_FAILED);
+        }
+    }
+
     private String buildHtmlContent(String code) {
         Context context = new Context();
         context.setVariable("verificationCode", code);
         return templateEngine.process("mail/verificationEmail", context);
+    }
+
+    private String buildPasswordResetHtmlContent(String code) {
+        Context context = new Context();
+        context.setVariable("verificationCode", code);
+        return templateEngine.process("mail/passwordResetEmail", context);
     }
 }

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package org.solmate.domain.user.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.user.service.UserService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "User", description = "유저 API")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "프로필 이미지 업데이트", description = "프로필 이미지를 업로드하고 변경합니다.")
+    @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<String>> updateProfileImage(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart MultipartFile image) {
+        return ApiResponse.success(SuccessStatus.PROFILE_IMAGE_UPDATE_SUCCESS,
+                userService.updateProfileImage(userId, image));
+    }
+}

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -24,12 +24,13 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "프로필 이미지 업데이트", description = "프로필 이미지를 업로드하고 변경합니다.")
-    @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<String>> updateProfileImage(
+    @Operation(summary = "프로필 업데이트", description = "프로필 이미지와 닉네임을 변경합니다. 각 항목은 선택적으로 전송 가능합니다.")
+    @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
             @AuthenticationPrincipal Long userId,
-            @RequestPart MultipartFile image) {
-        return ApiResponse.success(SuccessStatus.PROFILE_IMAGE_UPDATE_SUCCESS,
-                userService.updateProfileImage(userId, image));
+            @RequestPart(required = false) MultipartFile image,
+            @RequestPart(required = false) String nickname) {
+        userService.updateProfile(userId, image, nickname);
+        return ApiResponse.success(SuccessStatus.PROFILE_UPDATE_SUCCESS, null);
     }
 }

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -25,6 +25,14 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리합니다. (soft delete)")
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+            @AuthenticationPrincipal Long userId) {
+        userService.withdraw(userId);
+        return ApiResponse.success(SuccessStatus.WITHDRAW_SUCCESS, null);
+    }
+
     @Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 삭제하고 기본 이미지로 되돌립니다.")
     @DeleteMapping("/profile-image")
     public ResponseEntity<ApiResponse<Void>> deleteProfileImage(

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -2,16 +2,21 @@ package org.solmate.domain.user.controller;
 
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.user.dto.request.PasswordCheckRequest;
 import org.solmate.domain.user.service.UserService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.Valid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +29,15 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
     private final UserService userService;
+
+    @Operation(summary = "비밀번호 확인", description = "현재 비밀번호가 맞는지 확인합니다.")
+    @PostMapping("/password/check")
+    public ResponseEntity<ApiResponse<Void>> checkPassword(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid PasswordCheckRequest request) {
+        userService.checkPassword(userId, request.password());
+        return ApiResponse.success(SuccessStatus.PASSWORD_CHECK_SUCCESS, null);
+    }
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리합니다. (soft delete)")
     @DeleteMapping

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package org.solmate.domain.user.controller;
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.user.dto.request.PasswordCheckRequest;
+import org.solmate.domain.user.dto.request.WithdrawRequest;
 import org.solmate.domain.user.service.UserService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -39,11 +40,12 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.PASSWORD_CHECK_SUCCESS, null);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리합니다. (soft delete)")
+    @Operation(summary = "회원 탈퇴", description = "현재 비밀번호 확인 후 회원 탈퇴 처리합니다. (soft delete)")
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> withdraw(
-            @AuthenticationPrincipal Long userId) {
-        userService.withdraw(userId);
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid WithdrawRequest request) {
+        userService.withdrawWithPassword(userId, request.password());
         return ApiResponse.success(SuccessStatus.WITHDRAW_SUCCESS, null);
     }
 

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import org.solmate.domain.user.service.UserService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -23,6 +24,14 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
     private final UserService userService;
+
+    @Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 삭제하고 기본 이미지로 되돌립니다.")
+    @DeleteMapping("/profile-image")
+    public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
+            @AuthenticationPrincipal Long userId) {
+        userService.deleteProfileImage(userId);
+        return ApiResponse.success(SuccessStatus.PROFILE_IMAGE_DELETE_SUCCESS, null);
+    }
 
     @Operation(summary = "프로필 업데이트", description = "프로필 이미지와 닉네임을 변경합니다. 각 항목은 선택적으로 전송 가능합니다.")
     @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/org/solmate/domain/user/dto/request/PasswordCheckRequest.java
+++ b/src/main/java/org/solmate/domain/user/dto/request/PasswordCheckRequest.java
@@ -1,0 +1,9 @@
+package org.solmate.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordCheckRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/org/solmate/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/solmate/domain/user/dto/request/WithdrawRequest.java
@@ -1,0 +1,9 @@
+package org.solmate.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/org/solmate/domain/user/entity/User.java
+++ b/src/main/java/org/solmate/domain/user/entity/User.java
@@ -52,6 +52,10 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
 
 
 }

--- a/src/main/java/org/solmate/domain/user/entity/User.java
+++ b/src/main/java/org/solmate/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package org.solmate.domain.user.entity;
 
 import org.solmate.common.base.BaseEntity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,6 +38,9 @@ public class User extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     public User(String email, String password, String nickname, String imageUrl) {
         this.email = email;
@@ -54,6 +59,14 @@ public class User extends BaseEntity {
 
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
+    }
+
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isWithdrawn() {
+        return this.deletedAt != null;
     }
 
 

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -52,16 +52,21 @@ public class UserService {
     }
 
     @Transactional
-    public String updateProfileImage(Long userId, MultipartFile image) {
+    public void updateProfile(Long userId, MultipartFile image, String nickname) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        if (user.getImageUrl() != null) {
-            s3Service.deleteFile(user.getImageUrl());
+        if (image != null && !image.isEmpty()) {
+            if (user.getImageUrl() != null) {
+                s3Service.deleteFile(user.getImageUrl());
+            }
+            String imageUrl = s3Service.uploadFile(image, "profile/" + userId);
+            user.updateImageUrl(imageUrl);
         }
 
-        String imageUrl = s3Service.uploadFile(image, "profile/" + userId);
-        user.updateImageUrl(imageUrl);
-        return imageUrl;
+        if (nickname != null && !nickname.isBlank()) {
+            checkNicknameNotDuplicated(nickname);
+            user.updateNickname(nickname);
+        }
     }
 }

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -52,6 +52,17 @@ public class UserService {
     }
 
     @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (user.getImageUrl() != null) {
+            s3Service.deleteFile(user.getImageUrl());
+            user.updateImageUrl(null);
+        }
+    }
+
+    @Transactional
     public void updateProfile(Long userId, MultipartFile image, String nickname) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -78,6 +78,26 @@ public class UserService {
     }
 
     @Transactional
+    public void withdrawWithPassword(Long userId, String rawPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+            throw new GeneralException(ErrorStatus.INVALID_PASSWORD);
+        }
+
+        if (user.isWithdrawn()) {
+            throw new GeneralException(ErrorStatus.USER_ALREADY_WITHDRAWN);
+        }
+
+        if (user.getImageUrl() != null) {
+            s3Service.deleteFile(user.getImageUrl());
+        }
+
+        user.withdraw();
+    }
+
+    @Transactional
     public void deleteProfileImage(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,6 +19,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final PasswordEncoder passwordEncoder;
 
     public User getUserById(Long id) {
         return userRepository.findById(id)
@@ -38,6 +40,14 @@ public class UserService {
     public void checkNicknameNotDuplicated(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new GeneralException(ErrorStatus.NICKNAME_ALREADY_EXISTS);
+        }
+    }
+
+    public void checkPassword(Long userId, String rawPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+            throw new GeneralException(ErrorStatus.INVALID_PASSWORD);
         }
     }
 

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -52,6 +52,22 @@ public class UserService {
     }
 
     @Transactional
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (user.isWithdrawn()) {
+            throw new GeneralException(ErrorStatus.USER_ALREADY_WITHDRAWN);
+        }
+
+        if (user.getImageUrl() != null) {
+            s3Service.deleteFile(user.getImageUrl());
+        }
+
+        user.withdraw();
+    }
+
+    @Transactional
     public void deleteProfileImage(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -1,11 +1,13 @@
 package org.solmate.domain.user.service;
 
 import org.solmate.common.exception.GeneralException;
+import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3Service s3Service;
 
     public User getUserById(Long id) {
         return userRepository.findById(id)
@@ -46,5 +49,19 @@ public class UserService {
     @Transactional
     public void updateNickname(User user, String nickname) {
         user.updateNickname(nickname);
+    }
+
+    @Transactional
+    public String updateProfileImage(Long userId, MultipartFile image) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (user.getImageUrl() != null) {
+            s3Service.deleteFile(user.getImageUrl());
+        }
+
+        String imageUrl = s3Service.uploadFile(image, "profile/" + userId);
+        user.updateImageUrl(imageUrl);
+        return imageUrl;
     }
 }

--- a/src/main/resources/templates/mail/passwordResetEmail.html
+++ b/src/main/resources/templates/mail/passwordResetEmail.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>비밀번호 재설정</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', Dotum, '돋움', sans-serif;">
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="background-color: #f4f4f4;">
+    <tr>
+        <td align="center">
+            <table width="600" border="0" cellspacing="0" cellpadding="0"
+                   style="max-width: 600px; margin: 20px auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 4px 10px rgba(0,0,0,0.1);">
+
+                <tr>
+                    <td style="padding: 40px 30px;">
+                        <h2 style="margin: 0 0 20px 0; font-size: 24px; font-weight: 600; color: #333333;">비밀번호 재설정 인증 코드를
+                            확인해주세요.</h2>
+                        <p style="margin: 0 0 30px 0; font-size: 16px; line-height: 1.5; color: #555555;">
+                            안녕하세요. Solmate입니다.<br>
+                            비밀번호 재설정을 요청하셨습니다. 아래 인증 코드를 입력하여 본인 확인을 완료해주세요.
+                        </p>
+
+                        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                            <tr>
+                                <td align="center"
+                                    style="padding: 20px; background-color: #f9f9f9; border-radius: 4px;">
+                                    <span style="font-size: 32px; font-weight: bold; color: #016794; letter-spacing: 8px;"
+                                          th:text="${verificationCode}"> 123456 </span>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <p style="margin: 30px 0 0 0; font-size: 14px; color: #888888;">
+                            * 이 인증 코드는 5분 동안 유효합니다.<br>
+                            * 본인이 요청하지 않은 메일이라면 이 메일을 무시하고 비밀번호를 변경해주세요.
+                        </p>
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #69

## 💡 작업 배경

 회원이 프로필을 관리하고, 비밀번호를 잊었을 때 재설정할 수 있는 기능이 필요했다. 또한 탈퇴 시 본인 확인 절차를 통해 실수로 인한 탈퇴를 방지하는 기능이 필요하다

## 🧩 작업 내용
  프로필 관리                                                                   
  - PATCH /api/users/profile — 프로필 이미지 + 닉네임 통합 수정 (각 필드 선택적 전송 가능)                                                                    
  - DELETE /api/users/profile-image — 프로필 이미지 삭제 후 기본 이미지로 복원
                                                                                
  회원 탈퇴                                                                     
  - DELETE /api/users — 현재 비밀번호 확인 후 soft delete (deletedAt 기록)
                                                                                
  비밀번호 확인   
  - POST /api/users/password/check — 현재 비밀번호 일치 여부 확인 (비밀번호 재설정 등 사전 검증용)                                                        
                                                                                
  비밀번호 재설정                                                               
  - POST /api/auth/password/email/send — 재설정용 인증 코드 발송 (회원가입용과  
  별도 이메일 템플릿)                                                           
                    - POST /api/auth/password/reset — 이메일 인증 완료 후 새 비밀번호 설정  

## 📸 스크린샷(선택)

<img width="980" height="739" alt="Screenshot 2026-03-24 at 6 18 26 PM" src="https://github.com/user-attachments/assets/550b8d96-adba-449f-8836-a7d132472b4f" />
<img width="1093" height="781" alt="Screenshot 2026-03-24 at 6 40 10 PM" src="https://github.com/user-attachments/assets/3fd11878-7a35-4b25-b5de-6c8777957b89" />
<img width="1097" height="730" alt="Screenshot 2026-03-24 at 7 51 12 PM" src="https://github.com/user-attachments/assets/97d85219-e044-4163-91c1-9348afc529d5" />

<img width="1010" height="545" alt="Screenshot 2026-03-24 at 7 51 28 PM" src="https://github.com/user-attachments/assets/353f87e0-6733-4da5-8f17-cd86c6d926b7" />
<img width="1108" height="630" alt="Screenshot 2026-03-24 at 7 51 40 PM" src="https://github.com/user-attachments/assets/63a68d23-d74f-4ddf-a40a-5ff020c1bfbe" />

<img width="694" height="699" alt="Screenshot 2026-03-24 at 8 15 04 PM" src="https://github.com/user-attachments/assets/afbc1981-9f6d-4ca0-9c46-cffa54bc1055" />

## 📝 기타
  - 프로필 이미지는 S3 profile/{userId}/ 경로에 저장, 변경 시 기존 이미지 자동  삭제                                                                          
  - 비밀번호 재설정 이메일은 회원가입 이메일과 문구를 구분하여 별도 템플릿(passwordResetEmail.html) 사용                                          
  - soft delete 방식으로 deleted_at 컬럼에 탈퇴 시각 기록
