### PR TITLE
[Feat] 멘티의 멘토링 취소 기능 추가

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -72,7 +72,8 @@ public enum ErrorStatus implements BaseStatus {
     MENTORING_ALREADY_REQUESTED("MENTORING_409", HttpStatus.CONFLICT, "이미 멘토링 요청을 보냈습니다."),
     MENTORING_RELATION_NOT_FOUND("MENTORING_404", HttpStatus.NOT_FOUND, "멘토링 요청을 찾을 수 없습니다."),
     MENTORING_UNAUTHORIZED("MENTORING_403", HttpStatus.FORBIDDEN, "해당 멘토링 요청에 대한 권한이 없습니다."),
-    MENTORING_ALREADY_RESPONDED("MENTORING_400_3", HttpStatus.BAD_REQUEST, "이미 처리된 멘토링 요청입니다.");
+    MENTORING_ALREADY_RESPONDED("MENTORING_400_3", HttpStatus.BAD_REQUEST, "이미 처리된 멘토링 요청입니다."),
+    MENTORING_NOT_ACCEPTED("MENTORING_400_4", HttpStatus.BAD_REQUEST, "멘토링 관계가 아닙니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -44,7 +44,8 @@ public enum SuccessStatus implements BaseStatus {
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),
-    MENTORING_MY_STATUS_SUCCESS("MENTORING_200_3", HttpStatus.OK, "내 멘토링 신청 현황 조회 성공");
+    MENTORING_MY_STATUS_SUCCESS("MENTORING_200_3", HttpStatus.OK, "내 멘토링 신청 현황 조회 성공"),
+    MENTORING_CANCEL_SUCCESS("MENTORING_200_4", HttpStatus.OK, "멘토링 취소 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/social/controller/MentoringController.java
+++ b/src/main/java/org/solmate/domain/social/controller/MentoringController.java
@@ -8,7 +8,9 @@ import org.solmate.domain.social.dto.response.MyMentoringStatusResponse;
 import org.solmate.domain.social.service.MentoringService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,5 +56,20 @@ public class MentoringController {
     ) {
         MentoringResponse response = mentoringService.requestMentoring(menteeId, request.mentorUserId());
         return ApiResponse.success(SuccessStatus.MENTORING_REQUEST_SUCCESS, response);
+    }
+
+    /**
+     * 멘토링 취소 (멘티만 가능)
+     * - PENDING(신청 대기) 또는 ACCEPTED(수락된 관계) 상태 모두 취소 가능
+     * - 멘토가 호출하면 서비스 레이어에서 403 반환
+     */
+    @Operation(summary = "멘토링 취소")
+    @DeleteMapping("/mentor-requests/{relationId}")
+    public ResponseEntity<ApiResponse<Void>> cancelMentoring(
+            @AuthenticationPrincipal Long menteeId,
+            @PathVariable Long relationId
+    ) {
+        mentoringService.cancelMentoring(menteeId, relationId);
+        return ApiResponse.success(SuccessStatus.MENTORING_CANCEL_SUCCESS, null);
     }
 }

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -155,6 +155,29 @@ public class MentoringService {
     }
 
     /**
+     * 멘토링 취소 (멘티만 가능)
+     * - PENDING(신청 대기 중) 또는 ACCEPTED(수락된 관계) 상태 모두 취소 가능
+     * - relation의 mentee_id가 현재 사용자와 다르면 403 → 멘토가 호출해도 여기서 차단됨
+     */
+    @Transactional
+    public void cancelMentoring(Long menteeId, Long relationId) {
+        MentoringRelation relation = mentoringRepository.findById(relationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MENTORING_RELATION_NOT_FOUND));
+
+        // 본인(멘티)의 관계인지 확인 → 멘토가 호출하면 mentee_id != menteeId 이므로 차단
+        if (!relation.getMentee().getId().equals(menteeId)) {
+            throw new GeneralException(ErrorStatus.MENTORING_UNAUTHORIZED);
+        }
+
+        // ACCEPTED 상태(이미 맺어진 멘토-멘티 관계)만 취소 가능
+        if (relation.getStatus() != MentoringStatus.ACCEPTED) {
+            throw new GeneralException(ErrorStatus.MENTORING_NOT_ACCEPTED);
+        }
+
+        mentoringRepository.delete(relation);
+    }
+
+    /**
      * 멘토 신청 거절
      * - NotificationService에서 알림의 payload를 파싱한 후 호출됨
      * - 거절 시 멘티에게 별도 알림은 전송하지 않음


### PR DESCRIPTION
  ## #️⃣  관련 이슈
  - closed #53                                                                                                  
                  
  ## 💡 작업 배경                                                                                               
  멘티가 수락된 멘토링 관계를 직접 취소할 수 없어 추가 구현
                                                                                                                
  ## 🧩 작업 내용 
  - `DELETE /api/v1/mentor-requests/{relationId}` 엔드포인트 추가                                               
  - `MentoringService.cancelMentoring()` 구현 (ACCEPTED 상태만 취소 가능, 멘티만 호출 가능)
  - `ErrorStatus.MENTORING_NOT_ACCEPTED` 추가 ("멘토링 관계가 아닙니다.")                                       
  - `SuccessStatus.MENTORING_CANCEL_SUCCESS` 추가                                                               
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타