### PR TITLE
[Feat] 팔로우 신청 및 취소 기능 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -78,7 +78,14 @@ public enum ErrorStatus implements BaseStatus {
     MENTORING_RELATION_NOT_FOUND("MENTORING_404", HttpStatus.NOT_FOUND, "멘토링 요청을 찾을 수 없습니다."),
     MENTORING_UNAUTHORIZED("MENTORING_403", HttpStatus.FORBIDDEN, "해당 멘토링 요청에 대한 권한이 없습니다."),
     MENTORING_ALREADY_RESPONDED("MENTORING_400_3", HttpStatus.BAD_REQUEST, "이미 처리된 멘토링 요청입니다."),
-    MENTORING_NOT_ACCEPTED("MENTORING_400_4", HttpStatus.BAD_REQUEST, "멘토링 관계가 아닙니다.");
+    MENTORING_NOT_ACCEPTED("MENTORING_400_4", HttpStatus.BAD_REQUEST, "멘토링 관계가 아닙니다."),
+
+    /**
+     * Follow
+     */
+    FOLLOW_SELF_REQUEST("FOLLOW_400_1", HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
+    FOLLOW_ALREADY_FOLLOWED("FOLLOW_409", HttpStatus.CONFLICT, "이미 팔로우한 유저입니다."),
+    FOLLOW_NOT_FOUND("FOLLOW_404", HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -45,7 +45,13 @@ public enum SuccessStatus implements BaseStatus {
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),
     MENTORING_MY_STATUS_SUCCESS("MENTORING_200_3", HttpStatus.OK, "내 멘토링 신청 현황 조회 성공"),
-    MENTORING_CANCEL_SUCCESS("MENTORING_200_4", HttpStatus.OK, "멘토링 취소 성공");
+    MENTORING_CANCEL_SUCCESS("MENTORING_200_4", HttpStatus.OK, "멘토링 취소 성공"),
+
+    /**
+     * Follow
+     */
+    FOLLOW_SUCCESS("FOLLOW_201", HttpStatus.CREATED, "팔로우 성공"),
+    UNFOLLOW_SUCCESS("FOLLOW_200", HttpStatus.OK, "팔로우 취소 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/social/controller/FollowingController.java
+++ b/src/main/java/org/solmate/domain/social/controller/FollowingController.java
@@ -1,0 +1,55 @@
+package org.solmate.domain.social.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.social.service.FollowingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Follow", description = "팔로우 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/follows")
+public class FollowingController {
+
+    private final FollowingService followingService;
+
+    /**
+     * 팔로우 신청
+     * - 유저 목록 또는 프로필에서 팔로우 버튼 클릭 시 호출
+     * - userId: 팔로우할 대상 유저의 ID
+     */
+    @Operation(summary = "팔로우 신청", description = "특정 유저를 팔로우합니다. 자기 자신 또는 이미 팔로우한 유저에게는 신청할 수 없습니다.")
+    @PostMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Void>> follow(
+            @AuthenticationPrincipal Long followerId,
+            @PathVariable Long userId
+    ) {
+        followingService.follow(followerId, userId);
+        return ApiResponse.success(SuccessStatus.FOLLOW_SUCCESS, null);
+    }
+
+    /**
+     * 팔로우 취소
+     * - 유저 목록 또는 프로필에서 팔로잉 버튼 클릭 시 호출
+     * - userId: 팔로우를 취소할 대상 유저의 ID
+     */
+    @Operation(summary = "팔로우 취소", description = "팔로우 중인 유저를 언팔로우합니다. 팔로우 관계가 없는 경우 404를 반환합니다.")
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Void>> unfollow(
+            @AuthenticationPrincipal Long followerId,
+            @PathVariable Long userId
+    ) {
+        followingService.unfollow(followerId, userId);
+        return ApiResponse.success(SuccessStatus.UNFOLLOW_SUCCESS, null);
+    }
+}

--- a/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
@@ -1,0 +1,16 @@
+package org.solmate.domain.social.repository;
+
+import java.util.Optional;
+
+import org.solmate.domain.social.entity.Following;
+import org.solmate.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowingRepository extends JpaRepository<Following, Long> {
+
+    // 특정 팔로우 관계가 존재하는지 확인 (중복 팔로우 방지)
+    boolean existsByFollowerAndFollowing(User follower, User following);
+
+    // 특정 팔로우 관계 조회 (팔로우 취소 시 사용)
+    Optional<Following> findByFollowerAndFollowing(User follower, User following);
+}

--- a/src/main/java/org/solmate/domain/social/service/FollowingService.java
+++ b/src/main/java/org/solmate/domain/social/service/FollowingService.java
@@ -1,0 +1,69 @@
+package org.solmate.domain.social.service;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.social.entity.Following;
+import org.solmate.domain.social.repository.FollowingRepository;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowingService {
+
+    private final FollowingRepository followingRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 팔로우 신청
+     * - 자기 자신은 팔로우 불가
+     * - 이미 팔로우한 유저에게 중복 팔로우 불가
+     */
+    @Transactional
+    public void follow(Long followerId, Long followingId) {
+        // 자기 자신 팔로우 방지 (프론트에서도 막지만 백엔드에서도 방어)
+        if (followerId.equals(followingId)) {
+            throw new GeneralException(ErrorStatus.FOLLOW_SELF_REQUEST);
+        }
+
+        User follower = userRepository.findByIdAndDeletedAtIsNull(followerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User following = userRepository.findByIdAndDeletedAtIsNull(followingId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 이미 팔로우 중인 경우 중복 신청 불가
+        if (followingRepository.existsByFollowerAndFollowing(follower, following)) {
+            throw new GeneralException(ErrorStatus.FOLLOW_ALREADY_FOLLOWED);
+        }
+
+        followingRepository.save(Following.builder()
+                .follower(follower)
+                .following(following)
+                .build());
+    }
+
+    /**
+     * 팔로우 취소
+     * - 팔로우 관계가 존재하지 않으면 예외 발생
+     */
+    @Transactional
+    public void unfollow(Long followerId, Long followingId) {
+        User follower = userRepository.findByIdAndDeletedAtIsNull(followerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User following = userRepository.findByIdAndDeletedAtIsNull(followingId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 팔로우 관계 조회 → 없으면 예외
+        Following followRelation = followingRepository.findByFollowerAndFollowing(follower, following)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLLOW_NOT_FOUND));
+
+        followingRepository.delete(followRelation);
+    }
+}


### PR DESCRIPTION
  ## #️⃣  관련 이슈
  - closed #72                                                                                                  
                                                                                                                
  ## 💡 작업 배경                                                                                               
  유저 목록 및 프로필 화면에서 팔로우 신청 및 취소 기능이 필요하여 구현                                         
                                                                       
  ## 🧩 작업 내용                                                                                               
  - FollowingRepository 생성 (팔로우 관계 존재 여부 확인, 조회)
  - FollowingService 생성 (팔로우 신청, 팔로우 취소)                                                            
  - FollowingController 생성 (POST /api/v1/follows/{userId}, DELETE /api/v1/follows/{userId})                   
  - ErrorStatus에 팔로우 관련 에러 코드 추가 (FOLLOW_SELF_REQUEST, FOLLOW_ALREADY_FOLLOWED, FOLLOW_NOT_FOUND)   
  - SuccessStatus에 팔로우 관련 성공 코드 추가 (FOLLOW_SUCCESS, UNFOLLOW_SUCCESS)                               
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타 
  - 추후 유저 목록 및 프로필 조회 API 구현 시 응답에 `isFollowing` 필드 추가 필요                               
    (팔로우 여부에 따라 버튼 초기 상태 결정)  