### PR TITLE
[Feat] 종목 상세 페이지 - 종목 보유 현황 및 보유 현금 api 구현

### DIFF
--- a/src/main/java/org/solmate/domain/account/repository/AccountRepository.java
+++ b/src/main/java/org/solmate/domain/account/repository/AccountRepository.java
@@ -15,6 +15,9 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
 
     Optional<Account> findByUser(User user);
 
+    @Query("SELECT a FROM Account a WHERE a.user.id = :userId")
+    Optional<Account> findByUserId(@Param("userId") Long userId);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM Account a WHERE a.user = :user")
     Optional<Account> findByUserWithLock(@Param("user") User user);

--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -5,14 +5,17 @@ import java.util.List;
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.stock.dto.response.CandleResponse;
+import org.solmate.domain.stock.dto.response.StockHoldingResponse;
 import org.solmate.domain.stock.dto.response.StockListResponse;
 import org.solmate.domain.stock.dto.response.StockQuoteResponse;
 import org.solmate.domain.stock.service.CandleService;
 import org.solmate.domain.stock.dto.response.StockOrderBookResponse;
 import org.solmate.domain.stock.service.OrderBookService;
 import org.solmate.domain.stock.service.StockService;
+import org.solmate.domain.trade.service.HoldingsService;
 import org.solmate.external.ls.websocket.LsWebSocketClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,6 +37,7 @@ public class StockController {
     private final StockService stockService;
     private final CandleService candleService;
     private final OrderBookService orderBookService;
+    private final HoldingsService holdingsService;
     private final LsWebSocketClient lsWebSocketClient;
 
     @Operation(summary = "종목 리스트 조회 (현재가 포함)")
@@ -94,6 +98,14 @@ public class StockController {
             @PathVariable String stockCode,
             @RequestParam(defaultValue = "10") int years) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyCandles(stockCode, years));
+    }
+
+    @Operation(summary = "종목 보유현황 조회", description = "보유수량/평균매수가/평가금액/수익률 조회. 수익률은 호출 시점 현재가 기준.")
+    @GetMapping("/{stockCode}/holding")
+    public ResponseEntity<ApiResponse<StockHoldingResponse>> getStockHolding(
+            @PathVariable String stockCode,
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, holdingsService.getStockHolding(userId, stockCode));
     }
 
     @Operation(summary = "주식 실시간 시세 구독")

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockHoldingResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockHoldingResponse.java
@@ -1,0 +1,61 @@
+package org.solmate.domain.stock.dto.response;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public record StockHoldingResponse(
+        BigDecimal cash,
+        BigDecimal holdingQuantity,
+        BigDecimal availableSellQuantity,
+        BigDecimal averageBuyPrice,
+        BigDecimal evaluationAmount,
+        BigDecimal profitAmount,
+        BigDecimal profitRate
+) {
+    public static StockHoldingResponse of(
+            BigDecimal cash,
+            BigDecimal holdingsQuantity,
+            BigDecimal pendingSellQuantity,
+            BigDecimal pendingBuyAmount,
+            BigDecimal avgPrice,
+            BigDecimal currentPrice) {
+
+        // 보유수량 = Holdings 수량(매도 접수 시 차감됨) + PENDING SELL 수량
+        BigDecimal holdingQuantity = holdingsQuantity.add(pendingSellQuantity);
+
+        // 보유 현금 = Account.cash(매수 접수 시 차감됨) + PENDING BUY 금액
+        BigDecimal totalCash = cash.add(pendingBuyAmount);
+
+        // 즉시 매도 가능 수량 = Holdings 수량 (PENDING SELL 제외)
+        BigDecimal availableSellQuantity = holdingsQuantity;
+
+        if (holdingQuantity.compareTo(BigDecimal.ZERO) == 0 || avgPrice.compareTo(BigDecimal.ZERO) == 0) {
+            return new StockHoldingResponse(
+                    totalCash,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO
+            );
+        }
+
+        BigDecimal evaluationAmount = currentPrice.multiply(holdingQuantity).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal profitAmount = currentPrice.subtract(avgPrice).multiply(holdingQuantity).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal profitRate = currentPrice.subtract(avgPrice)
+                .divide(avgPrice, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new StockHoldingResponse(
+                totalCash,
+                holdingQuantity,
+                availableSellQuantity,
+                avgPrice,
+                evaluationAmount,
+                profitAmount,
+                profitRate
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockHoldingResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockHoldingResponse.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 public record StockHoldingResponse(
-        BigDecimal cash,
         BigDecimal holdingQuantity,
         BigDecimal availableSellQuantity,
         BigDecimal averageBuyPrice,
@@ -13,25 +12,19 @@ public record StockHoldingResponse(
         BigDecimal profitRate
 ) {
     public static StockHoldingResponse of(
-            BigDecimal cash,
             BigDecimal holdingsQuantity,
             BigDecimal pendingSellQuantity,
-            BigDecimal pendingBuyAmount,
             BigDecimal avgPrice,
             BigDecimal currentPrice) {
 
         // 보유수량 = Holdings 수량(매도 접수 시 차감됨) + PENDING SELL 수량
         BigDecimal holdingQuantity = holdingsQuantity.add(pendingSellQuantity);
 
-        // 보유 현금 = Account.cash(매수 접수 시 차감됨) + PENDING BUY 금액
-        BigDecimal totalCash = cash.add(pendingBuyAmount);
-
         // 즉시 매도 가능 수량 = Holdings 수량 (PENDING SELL 제외)
         BigDecimal availableSellQuantity = holdingsQuantity;
 
         if (holdingQuantity.compareTo(BigDecimal.ZERO) == 0 || avgPrice.compareTo(BigDecimal.ZERO) == 0) {
             return new StockHoldingResponse(
-                    totalCash,
                     BigDecimal.ZERO,
                     BigDecimal.ZERO,
                     BigDecimal.ZERO,
@@ -49,7 +42,6 @@ public record StockHoldingResponse(
                 .setScale(2, RoundingMode.HALF_UP);
 
         return new StockHoldingResponse(
-                totalCash,
                 holdingQuantity,
                 availableSellQuantity,
                 avgPrice,

--- a/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/HoldingsController.java
@@ -1,5 +1,6 @@
 package org.solmate.domain.trade.controller;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.solmate.common.response.ApiResponse;
@@ -39,5 +40,9 @@ public class HoldingsController {
         return ApiResponse.success(SuccessStatus.HOLDINGS_SUCCESS, holdingsService.getHoldings(userId));
     }
 
-
+    @Operation(summary = "보유 현금 조회", description = "계좌 잔고 + 미체결 매수 주문 금액을 합산한 실제 보유 현금을 조회합니다.")
+    @GetMapping("/cash")
+    public ResponseEntity<ApiResponse<BigDecimal>> getCash(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, holdingsService.getCash(userId));
+    }
 }

--- a/src/main/java/org/solmate/domain/trade/repository/HoldingsRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/HoldingsRepository.java
@@ -25,4 +25,7 @@ public interface HoldingsRepository extends JpaRepository<Holdings, Long> {
 
     @Query("SELECT h FROM Holdings h JOIN FETCH h.stock WHERE h.user.id = :userId")
     List<Holdings> findByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT h FROM Holdings h WHERE h.user.id = :userId AND h.tickerCode = :tickerCode")
+    Optional<Holdings> findByUserIdAndTickerCode(@Param("userId") Long userId, @Param("tickerCode") String tickerCode);
 }

--- a/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
@@ -28,4 +28,10 @@ public interface TradeHistoryRepository extends JpaRepository<TradeHistory, Long
 
     @Query("SELECT t FROM TradeHistory t JOIN FETCH t.stock WHERE t.user.id = :userId AND t.tradeStatus = 'FILLED' ORDER BY t.createdAt DESC")
     List<TradeHistory> findFilledByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT t FROM TradeHistory t WHERE t.user.id = :userId AND t.stock.tickerCode = :tickerCode AND t.tradeStatus = 'PENDING' AND t.tradeType = :tradeType")
+    List<TradeHistory> findPendingByUserIdAndTickerCodeAndTradeType(
+            @Param("userId") Long userId,
+            @Param("tickerCode") String tickerCode,
+            @Param("tradeType") org.solmate.domain.trade.enums.TradeType tradeType);
 }

--- a/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
+++ b/src/main/java/org/solmate/domain/trade/repository/TradeHistoryRepository.java
@@ -34,4 +34,9 @@ public interface TradeHistoryRepository extends JpaRepository<TradeHistory, Long
             @Param("userId") Long userId,
             @Param("tickerCode") String tickerCode,
             @Param("tradeType") org.solmate.domain.trade.enums.TradeType tradeType);
+
+    @Query("SELECT t FROM TradeHistory t WHERE t.user.id = :userId AND t.tradeStatus = 'PENDING' AND t.tradeType = :tradeType")
+    List<TradeHistory> findPendingByUserIdAndTradeType(
+            @Param("userId") Long userId,
+            @Param("tradeType") org.solmate.domain.trade.enums.TradeType tradeType);
 }

--- a/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
+++ b/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
@@ -6,9 +6,15 @@ import java.util.List;
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.account.entity.Account;
+import org.solmate.domain.account.repository.AccountRepository;
+import org.solmate.domain.stock.dto.response.StockHoldingResponse;
 import org.solmate.domain.trade.dto.response.HoldingsResponse;
 import org.solmate.domain.trade.entity.Holdings;
+import org.solmate.domain.trade.entity.TradeHistory;
+import org.solmate.domain.trade.enums.TradeType;
 import org.solmate.domain.trade.repository.HoldingsRepository;
+import org.solmate.domain.trade.repository.TradeHistoryRepository;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 public class HoldingsService {
 
     private final HoldingsRepository holdingsRepository;
+    private final TradeHistoryRepository tradeHistoryRepository;
+    private final AccountRepository accountRepository;
     private final StringRedisTemplate redisTemplate;
     private final S3Service s3Service;
 
@@ -32,9 +40,51 @@ public class HoldingsService {
             .toList();
     }
 
+    /** 특정 종목의 보유현황 조회 - PENDING 주문까지 반영해 실제 보유수량/현금을 계산 후 현재가 기준 평가손익 반환 */
+    @Transactional(readOnly = true)
+    public StockHoldingResponse getStockHolding(Long userId, String stockCode) {
+        // 보유 현금 조회 (없으면 0)
+        // Account.cash는 매수 주문 접수 시 선차감되어 있으므로 PENDING BUY 금액을 다시 더해야 함
+        BigDecimal cash = accountRepository.findByUserId(userId)
+                .map(Account::getCash)
+                .orElse(BigDecimal.ZERO);
+
+        // PENDING BUY 주문 금액 합산 (price × quantity)
+        List<TradeHistory> pendingBuys = tradeHistoryRepository
+                .findPendingByUserIdAndTickerCodeAndTradeType(userId, stockCode, TradeType.BUY);
+        BigDecimal pendingBuyAmount = pendingBuys.stream()
+                .map(t -> t.getPrice().multiply(t.getQuantity()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Holdings 조회 (없으면 수량/평균단가 0)
+        // Holdings.quantity는 매도 주문 접수 시 선차감되어 있으므로 PENDING SELL 수량을 다시 더해야 함
+        Holdings holdings = holdingsRepository.findByUserIdAndTickerCode(userId, stockCode)
+                .orElse(null);
+
+        BigDecimal holdingsQuantity = holdings != null ? holdings.getQuantity() : BigDecimal.ZERO;
+        BigDecimal avgPrice = holdings != null ? holdings.getAvgPrice() : BigDecimal.ZERO;
+
+        // PENDING SELL 수량 합산
+        List<TradeHistory> pendingSells = tradeHistoryRepository
+                .findPendingByUserIdAndTickerCodeAndTradeType(userId, stockCode, TradeType.SELL);
+        BigDecimal pendingSellQuantity = pendingSells.stream()
+                .map(TradeHistory::getQuantity)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // 현재가 조회 (없으면 0)
+        BigDecimal currentPrice = getCurrentPriceOrZero(stockCode);
+
+        return StockHoldingResponse.of(cash, holdingsQuantity, pendingSellQuantity, pendingBuyAmount, avgPrice, currentPrice);
+    }
+
     private BigDecimal getCurrentPrice(String ticker) {
         String curStr = (String) redisTemplate.opsForHash().get("stock:info:" + ticker, "cur");
         if (curStr == null) throw new GeneralException(ErrorStatus.STOCK_PRICE_NOT_FOUND);
         return new BigDecimal(curStr);
+    }
+
+    private BigDecimal getCurrentPriceOrZero(String ticker) {
+        String curStr = (String) redisTemplate.opsForHash().get("stock:info:" + ticker, "cur");
+        return curStr != null ? new BigDecimal(curStr) : BigDecimal.ZERO;
     }
 }

--- a/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
+++ b/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
@@ -40,22 +40,9 @@ public class HoldingsService {
             .toList();
     }
 
-    /** 특정 종목의 보유현황 조회 - PENDING 주문까지 반영해 실제 보유수량/현금을 계산 후 현재가 기준 평가손익 반환 */
+    // 특정 종목의 보유현황 조회 - PENDING 매도 주문까지 반영해 실제 보유수량을 계산 후 현재가 기준 평가손익 반환
     @Transactional(readOnly = true)
     public StockHoldingResponse getStockHolding(Long userId, String stockCode) {
-        // 보유 현금 조회 (없으면 0)
-        // Account.cash는 매수 주문 접수 시 선차감되어 있으므로 PENDING BUY 금액을 다시 더해야 함
-        BigDecimal cash = accountRepository.findByUserId(userId)
-                .map(Account::getCash)
-                .orElse(BigDecimal.ZERO);
-
-        // PENDING BUY 주문 금액 합산 (price × quantity)
-        List<TradeHistory> pendingBuys = tradeHistoryRepository
-                .findPendingByUserIdAndTickerCodeAndTradeType(userId, stockCode, TradeType.BUY);
-        BigDecimal pendingBuyAmount = pendingBuys.stream()
-                .map(t -> t.getPrice().multiply(t.getQuantity()))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
         // Holdings 조회 (없으면 수량/평균단가 0)
         // Holdings.quantity는 매도 주문 접수 시 선차감되어 있으므로 PENDING SELL 수량을 다시 더해야 함
         Holdings holdings = holdingsRepository.findByUserIdAndTickerCode(userId, stockCode)
@@ -74,7 +61,23 @@ public class HoldingsService {
         // 현재가 조회 (없으면 0)
         BigDecimal currentPrice = getCurrentPriceOrZero(stockCode);
 
-        return StockHoldingResponse.of(cash, holdingsQuantity, pendingSellQuantity, pendingBuyAmount, avgPrice, currentPrice);
+        return StockHoldingResponse.of(holdingsQuantity, pendingSellQuantity, avgPrice, currentPrice);
+    }
+
+    // 보유 현금 조회 - Account.cash(매수 접수 시 선차감) + PENDING BUY 금액 합산
+    @Transactional(readOnly = true)
+    public BigDecimal getCash(Long userId) {
+        BigDecimal cash = accountRepository.findByUserId(userId)
+                .map(Account::getCash)
+                .orElse(BigDecimal.ZERO);
+
+        List<TradeHistory> pendingBuys = tradeHistoryRepository
+                .findPendingByUserIdAndTradeType(userId, TradeType.BUY);
+        BigDecimal pendingBuyAmount = pendingBuys.stream()
+                .map(t -> t.getPrice().multiply(t.getQuantity()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return cash.add(pendingBuyAmount);
     }
 
     private BigDecimal getCurrentPrice(String ticker) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #80 

## 💡 작업 배경
1. 해당 종목에 대한 내 보유 현황 (보유수량,
    평균매수가, 평가금액, 평가손익, 수익률)

2. 매수/매도 주문 시 참고할 계좌 보유 현금

## 🧩 작업 내용

`GET /api/stocks/{stockCode}/holding` — 종목 보유현황
  조회
  • 미체결 매도 주문 수량이 Holdings에서 선차감되어
    있으므로, PENDING SELL 수량을 합산해 실제 보유수량
    계산
  • 즉시 매도 가능 수량(availableSellQuantity)은
    Holdings.quantity 그대로 반환
  • 평가금액/평가손익/수익률은 호출 시점 Redis 현재가
    기준으로 계산

`GET /api/holdings/cash` — 보유 현금 조회
  • 미체결 매수 주문 금액이 Account에서 선차감되어
    있으므로, PENDING BUY 금액을 합산해 실제 보유 현금
    계산

## 📸 스크린샷(선택)


## 📝 기타

수익률 실시간 반영 (클라이언트 작업 필요)
  
종목 상세 화면 진입 시 GET/api/stocks/{stockCode}/holding을 한 번 호출 
 -> averageBuyPrice와 holdingQuantity를 저장
-> 이후 STOMP /topic/stocks/{code}/quote 구독으로 현재가를 수신할 때마다 아래 공식으로 직접 계산 -> 화면을 갱신해야 합니다.

  evaluationAmount = 현재가 × holdingQuantity
  profitAmount     = (현재가 - averageBuyPrice) ×
  holdingQuantity
  profitRate       = (현재가 - averageBuyPrice) /
  averageBuyPrice × 100