### PR TITLE
[Refactor] 시가총액 컬럼 추가 및 조회 구현 변경

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -85,7 +85,12 @@ public enum ErrorStatus implements BaseStatus {
      */
     FOLLOW_SELF_REQUEST("FOLLOW_400_1", HttpStatus.BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
     FOLLOW_ALREADY_FOLLOWED("FOLLOW_409", HttpStatus.CONFLICT, "이미 팔로우한 유저입니다."),
-    FOLLOW_NOT_FOUND("FOLLOW_404", HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다.");
+    FOLLOW_NOT_FOUND("FOLLOW_404", HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),
+
+    /**
+     * Admin
+     */
+    MARKET_CAP_UPDATE_FAILED("ADMIN_500", HttpStatus.INTERNAL_SERVER_ERROR, "시가총액 업데이트에 실패했습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -51,7 +51,12 @@ public enum SuccessStatus implements BaseStatus {
      * Follow
      */
     FOLLOW_SUCCESS("FOLLOW_201", HttpStatus.CREATED, "팔로우 성공"),
-    UNFOLLOW_SUCCESS("FOLLOW_200", HttpStatus.OK, "팔로우 취소 성공");
+    UNFOLLOW_SUCCESS("FOLLOW_200", HttpStatus.OK, "팔로우 취소 성공"),
+
+    /**
+     * Admin
+     */
+    MARKET_CAP_UPDATE_SUCCESS("ADMIN_200", HttpStatus.OK, "시가총액 업데이트 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/stock/controller/StockTotalController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockTotalController.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Admin Stock", description = "주식 관리자 API")
+@Tag(name = "Admin", description = "관리자 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/stocks")

--- a/src/main/java/org/solmate/domain/stock/controller/StockTotalController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockTotalController.java
@@ -24,6 +24,6 @@ public class StockTotalController {
     @PostMapping("/market-cap/update")
     public ResponseEntity<ApiResponse<Void>> updateMarketCap() {
         stockService.updateAllMarketCap();
-        return ApiResponse.success(SuccessStatus.SUCCESS_204);
+        return ApiResponse.success(SuccessStatus.MARKET_CAP_UPDATE_SUCCESS);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/controller/StockTotalController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockTotalController.java
@@ -1,0 +1,29 @@
+package org.solmate.domain.stock.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.stock.service.StockService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Admin Stock", description = "주식 관리자 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/stocks")
+public class StockTotalController {
+
+    private final StockService stockService;
+
+    @Operation(summary = "시가총액 수동 업데이트", description = "전체 종목의 시가총액을 수동으로 업데이트합니다.")
+    @PostMapping("/market-cap/update")
+    public ResponseEntity<ApiResponse<Void>> updateMarketCap() {
+        stockService.updateAllMarketCap();
+        return ApiResponse.success(SuccessStatus.SUCCESS_204);
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockListResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockListResponse.java
@@ -1,9 +1,10 @@
 package org.solmate.domain.stock.dto.response;
 
+import java.math.BigDecimal;
+import java.util.Map;
+
 import org.solmate.domain.stock.entity.Stock;
 import org.solmate.domain.stock.enums.SectorType;
-
-import java.util.Map;
 
 public record StockListResponse(
         String tickerCode,
@@ -11,7 +12,8 @@ public record StockListResponse(
         String stockLogo,
         SectorType sectorType,
         long currentPrice,
-        double changeRate
+        double changeRate,
+        BigDecimal total
 ) {
     public static StockListResponse ofWithClosePrice(Stock stock, long closePrice) {
         return new StockListResponse(
@@ -20,7 +22,8 @@ public record StockListResponse(
                 stock.getStockLogo(),
                 stock.getSectorType(),
                 closePrice,
-                0.0
+                0.0,
+                stock.getTotal()
         );
     }
 
@@ -41,7 +44,8 @@ public record StockListResponse(
                 stock.getStockLogo(),
                 stock.getSectorType(),
                 cur,
-                chgRate
+                chgRate,
+                stock.getTotal()
         );
     }
 }

--- a/src/main/java/org/solmate/domain/stock/dto/response/StockQuoteResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockQuoteResponse.java
@@ -13,7 +13,7 @@ public record StockQuoteResponse(
         long highPrice,
         long lowPrice,
         long volume,
-        long marketCap
+        long total
 ) {
     public static StockQuoteResponse from(LsQuoteResponse response) {
         LsQuoteResponse.OutBlock block = response.t1102OutBlock();

--- a/src/main/java/org/solmate/domain/stock/entity/Stock.java
+++ b/src/main/java/org/solmate/domain/stock/entity/Stock.java
@@ -1,5 +1,7 @@
 package org.solmate.domain.stock.entity;
 
+import java.math.BigDecimal;
+
 import org.solmate.domain.stock.enums.SectorType;
 import org.solmate.domain.stock.enums.StockStatus;
 
@@ -40,13 +42,16 @@ public class Stock {
     @Column(nullable = false, length = 30)
     private SectorType sectorType;
 
+    @Column(nullable = false)
+    private BigDecimal total;
 
 
     @Builder
-    public Stock(String tickerCode, String stockName, String stockLogo, SectorType sectorType) {
+    public Stock(String tickerCode, String stockName, String stockLogo, SectorType sectorType, BigDecimal total) {
         this.tickerCode = tickerCode;
         this.stockName = stockName;
         this.stockLogo = stockLogo;
         this.sectorType = sectorType;
+        this.total = total;
     }
 }

--- a/src/main/java/org/solmate/domain/stock/entity/Stock.java
+++ b/src/main/java/org/solmate/domain/stock/entity/Stock.java
@@ -53,4 +53,8 @@ public class Stock {
         this.sectorType = sectorType;
         this.total = total;
     }
+
+    public void updateTotal(BigDecimal total) {
+        this.total = total;
+    }
 }

--- a/src/main/java/org/solmate/domain/stock/entity/Stock.java
+++ b/src/main/java/org/solmate/domain/stock/entity/Stock.java
@@ -3,7 +3,6 @@ package org.solmate.domain.stock.entity;
 import java.math.BigDecimal;
 
 import org.solmate.domain.stock.enums.SectorType;
-import org.solmate.domain.stock.enums.StockStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/org/solmate/domain/stock/scheduler/StockScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/StockScheduler.java
@@ -1,0 +1,25 @@
+package org.solmate.domain.stock.scheduler;
+
+import org.solmate.domain.stock.service.StockService;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class StockScheduler {
+
+    private final StockService stockService;
+
+    // 평일 오전 8:50 - 시가총액 업데이트
+    @Scheduled(cron = "0 50 8 * * MON-FRI")
+    public void updateMarketCap() {
+        log.debug("시가총액 업데이트 스케줄러 실행");
+        stockService.updateAllMarketCap();
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/service/StockService.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockService.java
@@ -1,19 +1,24 @@
 package org.solmate.domain.stock.service;
 
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
 import org.solmate.domain.stock.dto.response.StockListResponse;
 import org.solmate.domain.stock.dto.response.StockQuoteResponse;
 import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.Stock;
 import org.solmate.domain.stock.repository.DailyCandleRepository;
 import org.solmate.domain.stock.repository.StockRepository;
 import org.solmate.external.ls.client.LsApiClient;
 import org.solmate.external.ls.dto.response.LsQuoteResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
-import java.util.Map;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class StockService {
@@ -42,5 +47,24 @@ public class StockService {
     public StockQuoteResponse getQuote(String stockCode) {
         LsQuoteResponse response = lsApiClient.getQuote(stockCode);
         return StockQuoteResponse.from(response);
+    }
+
+    @Transactional
+    public void updateAllMarketCap() {
+        List<Stock> stocks = stockRepository.findAll();
+        for (Stock stock : stocks) {
+            try {
+                LsQuoteResponse response = lsApiClient.getQuote(stock.getTickerCode());
+                BigDecimal total = BigDecimal.valueOf(response.t1102OutBlock().total());
+                stock.updateTotal(total);
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("시가총액 업데이트 중단 - 종목: {}", stock.getTickerCode());
+                break;
+            } catch (Exception e) {
+                log.warn("시가총액 업데이트 실패 - 종목: {}, 사유: {}", stock.getTickerCode(), e.getMessage());
+            }
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #85

## 💡 작업 배경
현재 종목 테이블에 시가 총액이 없다.

## 🧩 작업 내용
 1. 시가총액 수동 업데이트 API 추가

  - POST /api/admin/stocks/market-cap/update                                    
  - 기존 스케줄러(StockScheduler)가 사용하는 updateAllMarketCap() 서비스
  메서드를 그대로 활용                                                          
  - 관리자 전용 API임을 명시하기 위해 StockController에서 분리하여 별도
  컨트롤러(StockTotalController) 생성       

  2. 시가총액 스케줄러로 오전 8시 50분에 자동 업데이트 되도록 설정                                    
                  
  3. 관리자 전용 컨트롤러 분리                                                  
                  
  - StockTotalController 생성 (/api/admin/stocks)                               
  - Swagger 태그 Admin 으로 분리
  -
  4. DTO 리팩토링                                                               
                  
  - StockListResponse 응답 필드 marketCap → total 로 변경 

## 📸 스크린샷(선택)
<img width="1413" height="777" alt="Screenshot 2026-03-25 at 10 04 54 AM" src="https://github.com/user-attachments/assets/6cb8f3e3-af6c-4ffa-ade7-cbf11a702091" />


## 📝 기타
