### PR TITLE
[Feat] 유저 목록 및 유저 프로필 조회 API 추가

### DIFF
--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -44,14 +44,19 @@ public enum SuccessStatus implements BaseStatus {
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),
-    MENTORING_MY_STATUS_SUCCESS("MENTORING_200_3", HttpStatus.OK, "내 멘토링 신청 현황 조회 성공"),
     MENTORING_CANCEL_SUCCESS("MENTORING_200_4", HttpStatus.OK, "멘토링 취소 성공"),
 
     /**
      * Follow
      */
     FOLLOW_SUCCESS("FOLLOW_201", HttpStatus.CREATED, "팔로우 성공"),
-    UNFOLLOW_SUCCESS("FOLLOW_200", HttpStatus.OK, "팔로우 취소 성공");
+    UNFOLLOW_SUCCESS("FOLLOW_200", HttpStatus.OK, "팔로우 취소 성공"),
+
+    /**
+     * User List / Profile
+     */
+    USER_LIST_SUCCESS("USER_200_1", HttpStatus.OK, "유저 목록 조회 성공"),
+    USER_PROFILE_SUCCESS("USER_200_2", HttpStatus.OK, "유저 프로필 조회 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/org/solmate/domain/social/controller/MentoringController.java
+++ b/src/main/java/org/solmate/domain/social/controller/MentoringController.java
@@ -4,7 +4,6 @@ import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.social.dto.request.MentoringRequest;
 import org.solmate.domain.social.dto.response.MentoringResponse;
-import org.solmate.domain.social.dto.response.MyMentoringStatusResponse;
 import org.solmate.domain.social.service.MentoringService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,21 +26,6 @@ import lombok.RequiredArgsConstructor;
 public class MentoringController {
 
     private final MentoringService mentoringService;
-
-    /**
-     * 내 멘토링 신청 현황 조회
-     * - 프론트에서 유저 목록의 멘토 신청 버튼 활성화 여부 판단에 사용
-     * - hasAcceptedMentor: 이미 수락된 멘토가 있으면 모든 버튼 비활성화
-     * - pendingMentorIds: 해당 멘토에게 이미 신청 중이면 그 버튼만 비활성화
-     */
-    @Operation(summary = "내 멘토링 신청 현황 조회")
-    @GetMapping("/mentor-requests/my")
-    public ResponseEntity<ApiResponse<MyMentoringStatusResponse>> getMyMentoringStatus(
-            @AuthenticationPrincipal Long menteeId
-    ) {
-        MyMentoringStatusResponse response = mentoringService.getMyMentoringStatus(menteeId);
-        return ApiResponse.success(SuccessStatus.MENTORING_MY_STATUS_SUCCESS, response);
-    }
 
     /**
      * 멘토 신청

--- a/src/main/java/org/solmate/domain/social/controller/UserListController.java
+++ b/src/main/java/org/solmate/domain/social/controller/UserListController.java
@@ -1,0 +1,111 @@
+package org.solmate.domain.social.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.social.dto.response.UserListResponse;
+import org.solmate.domain.social.dto.response.UserProfileResponse;
+import org.solmate.domain.social.service.UserListService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "UserList", description = "유저 목록 / 프로필 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserListController {
+
+    private final UserListService userListService;
+
+    /**
+     * 유저 목록 조회 (커서 기반 무한 스크롤)
+     *
+     * - 첫 페이지 요청 시 cursor 파라미터 생략
+     * - 이후 응답의 nextCursor 값을 cursor로 전달하여 다음 페이지 조회
+     * - hasAcceptedMentor가 true이면 프론트에서 NONE 상태 멘토신청 버튼 비활성화
+     * - 각 유저의 팔로우 여부(isFollowing), 멘토링 상태(mentoringStatus) 포함
+     * - 본인은 isMe=true로 표시 (팔로우/멘토 버튼 미표시)
+     *
+     * mentoringStatus 값:
+     *   NONE     → 멘토신청 버튼
+     *   PENDING  → 신청완료 버튼 (노란 테두리)
+     *   ACCEPTED → 멘토 버튼 (노란색 채움)
+     */
+    @Operation(
+            summary = "유저 목록 조회",
+            description = """
+                    커서 기반 무한 스크롤로 유저 목록을 조회합니다.
+
+                    **페이지네이션**
+                    - 첫 페이지: cursor 파라미터 생략
+                    - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
+                    - hasNext가 false이면 마지막 페이지
+
+                    **멘토링 버튼 상태**
+                    - hasAcceptedMentor=true → NONE 상태의 멘토신청 버튼 전체 비활성화
+                    - mentoringStatus=NONE → 멘토신청 버튼
+                    - mentoringStatus=PENDING → 신청완료 버튼
+                    - mentoringStatus=ACCEPTED → 멘토 버튼
+
+                    **팔로우 버튼 상태**
+                    - isFollowing=false → 팔로우 버튼
+                    - isFollowing=true → 팔로잉 버튼
+                    - isMe=true → 버튼 없음 (본인)
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserListResponse>> getUserList(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "마지막으로 받은 유저의 userId (첫 페이지는 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        UserListResponse response = userListService.getUserList(currentUserId, cursor, size);
+        return ApiResponse.success(SuccessStatus.USER_LIST_SUCCESS, response);
+    }
+
+    /**
+     * 유저 프로필 단건 조회
+     *
+     * - 팔로워 수, 팔로잉 수, 팔로우 여부, 멘토링 상태 포함
+     * - 탈퇴한 유저는 조회 불가 (404 반환)
+     * - 본인 조회 시 isMe=true, isFollowing=false
+     * - 총 수익률 / 총 수익은 추후 구현 예정
+     */
+    @Operation(
+            summary = "유저 프로필 조회",
+            description = """
+                    특정 유저의 프로필을 조회합니다.
+
+                    **응답 필드**
+                    - followerCount: 이 유저를 팔로우하는 사람 수
+                    - followingCount: 이 유저가 팔로우하는 사람 수
+                    - isMe: 본인 여부 (true이면 팔로우/멘토 버튼 미표시)
+                    - isFollowing: 현재 로그인 유저의 팔로우 여부
+                    - mentoringStatus: NONE / PENDING / ACCEPTED
+
+                    **주의**
+                    - 탈퇴한 유저 조회 시 404 반환
+                    - 총 수익률 / 총 수익은 추후 추가 예정
+                    """
+    )
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getUserProfile(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "조회할 유저의 userId")
+            @PathVariable Long userId
+    ) {
+        UserProfileResponse response = userListService.getUserProfile(currentUserId, userId);
+        return ApiResponse.success(SuccessStatus.USER_PROFILE_SUCCESS, response);
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/MyMentoringStatusResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MyMentoringStatusResponse.java
@@ -1,9 +1,0 @@
-package org.solmate.domain.social.dto.response;
-
-import java.util.List;
-
-public record MyMentoringStatusResponse(
-        boolean hasAcceptedMentor,
-        List<Long> pendingMentorIds
-) {
-}

--- a/src/main/java/org/solmate/domain/social/dto/response/UserListItemResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/UserListItemResponse.java
@@ -1,0 +1,54 @@
+package org.solmate.domain.social.dto.response;
+
+import org.solmate.domain.social.enums.UserMentoringStatus;
+import org.solmate.domain.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 유저 목록 아이템 응답 DTO
+ *
+ * 필드 설명:
+ * - userId          : 유저 식별자
+ * - nickname        : 닉네임
+ * - imageUrl        : 프로필 이미지 S3 URL (없으면 null)
+ * - followerCount   : 이 유저를 팔로우하는 사람 수
+ * - followingCount  : 이 유저가 팔로우하는 사람 수
+ * - isMe            : 현재 로그인 유저 본인 여부 (true면 팔로우/멘토 버튼 미표시)
+ * - isFollowing     : 현재 로그인 유저가 이 유저를 팔로우 중인지 여부
+ * - mentoringStatus : 현재 로그인 유저 기준 멘토링 상태 (NONE/PENDING/ACCEPTED)
+ */
+@Getter
+@AllArgsConstructor
+public class UserListItemResponse {
+
+    private Long userId;
+    private String nickname;
+    private String imageUrl;
+    private long followerCount;
+    private long followingCount;
+    private boolean isMe;
+    private boolean isFollowing;
+    private UserMentoringStatus mentoringStatus;
+
+    public static UserListItemResponse of(
+            User user,
+            long followerCount,
+            long followingCount,
+            boolean isMe,
+            boolean isFollowing,
+            UserMentoringStatus mentoringStatus
+    ) {
+        return new UserListItemResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getImageUrl(),
+                followerCount,
+                followingCount,
+                isMe,
+                isFollowing,
+                mentoringStatus
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/UserListResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/UserListResponse.java
@@ -1,0 +1,27 @@
+package org.solmate.domain.social.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 유저 목록 조회 응답 래퍼 DTO
+ *
+ * 필드 설명:
+ * - hasAcceptedMentor : 현재 로그인 유저에게 이미 수락된 멘토가 있는지 여부
+ *                       true이면 프론트에서 NONE 상태의 멘토신청 버튼을 모두 비활성화
+ * - users             : 유저 목록 (UserListItemResponse 리스트)
+ * - nextCursor        : 다음 페이지 요청 시 사용할 커서 (마지막 유저의 userId)
+ *                       hasNext=false이면 null
+ * - hasNext           : 다음 페이지 존재 여부
+ */
+@Getter
+@AllArgsConstructor
+public class UserListResponse {
+
+    private boolean hasAcceptedMentor;
+    private List<UserListItemResponse> users;
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/UserProfileResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/UserProfileResponse.java
@@ -1,0 +1,58 @@
+package org.solmate.domain.social.dto.response;
+
+import org.solmate.domain.social.enums.UserMentoringStatus;
+import org.solmate.domain.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 유저 프로필 단건 조회 응답 DTO
+ *
+ * 필드 설명:
+ * - userId          : 유저 식별자
+ * - nickname        : 닉네임
+ * - imageUrl        : 프로필 이미지 S3 URL (없으면 null)
+ * - followerCount   : 이 유저를 팔로우하는 사람 수
+ * - followingCount  : 이 유저가 팔로우하는 사람 수
+ * - isMe            : 현재 로그인 유저 본인 여부 (true면 팔로우/멘토 버튼 미표시)
+ * - isFollowing     : 현재 로그인 유저가 이 유저를 팔로우 중인지 여부
+ * - mentoringStatus : 현재 로그인 유저 기준 멘토링 상태 (NONE/PENDING/ACCEPTED)
+ *
+ * 추후 추가 예정:
+ * - totalReturnRate : 총 수익률 (TotalReturnRate 엔티티 구현 후 추가)
+ * - totalProfit     : 총 수익 (별도 집계 로직 구현 후 추가)
+ */
+@Getter
+@AllArgsConstructor
+public class UserProfileResponse {
+
+    private Long userId;
+    private String nickname;
+    private String imageUrl;
+    private long followerCount;
+    private long followingCount;
+    private boolean isMe;
+    private boolean isFollowing;
+    private UserMentoringStatus mentoringStatus;
+
+    public static UserProfileResponse of(
+            User user,
+            long followerCount,
+            long followingCount,
+            boolean isMe,
+            boolean isFollowing,
+            UserMentoringStatus mentoringStatus
+    ) {
+        return new UserProfileResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getImageUrl(),
+                followerCount,
+                followingCount,
+                isMe,
+                isFollowing,
+                mentoringStatus
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/social/enums/UserMentoringStatus.java
+++ b/src/main/java/org/solmate/domain/social/enums/UserMentoringStatus.java
@@ -1,0 +1,20 @@
+package org.solmate.domain.social.enums;
+
+/**
+ * 유저 목록 / 프로필에서 현재 로그인 유저 기준 멘토링 관계 상태
+ *
+ * - NONE     : 멘토 신청 가능 상태 (신청한 적 없음)
+ * - PENDING  : 해당 유저에게 멘토 신청을 보낸 상태 (승인 대기 중)
+ * - ACCEPTED : 해당 유저가 나의 멘토로 수락된 상태
+ *
+ * 프론트 버튼 표시 기준:
+ *   NONE     → "멘토신청" 버튼 (hasAcceptedMentor=true 이면 비활성화)
+ *   PENDING  → "신청완료" 버튼 (노란 테두리)
+ *   ACCEPTED → "멘토" 버튼 (노란색 채움)
+ *   isMe=true → 버튼 없음 (— 표시)
+ */
+public enum UserMentoringStatus {
+    NONE,
+    PENDING,
+    ACCEPTED
+}

--- a/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
@@ -1,10 +1,14 @@
 package org.solmate.domain.social.repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.solmate.domain.social.entity.Following;
 import org.solmate.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowingRepository extends JpaRepository<Following, Long> {
 
@@ -13,4 +17,21 @@ public interface FollowingRepository extends JpaRepository<Following, Long> {
 
     // 특정 팔로우 관계 조회 (팔로우 취소 시 사용)
     Optional<Following> findByFollowerAndFollowing(User follower, User following);
+
+    // 유저 ID 목록에 대한 팔로워 수 bulk 집계 (N+1 방지)
+    // 반환: [userId, count] 형태의 Object[] 리스트
+    // 팔로워가 없는 유저는 결과에 포함되지 않으므로 서비스에서 getOrDefault(0L) 처리 필요
+    @Query("SELECT f.following.id, COUNT(f) FROM Following f WHERE f.following.id IN :userIds GROUP BY f.following.id")
+    List<Object[]> countFollowersByUserIds(@Param("userIds") List<Long> userIds);
+
+    // 유저 ID 목록에 대한 팔로잉 수 bulk 집계 (N+1 방지)
+    // 반환: [userId, count] 형태의 Object[] 리스트
+    // 팔로잉이 없는 유저는 결과에 포함되지 않으므로 서비스에서 getOrDefault(0L) 처리 필요
+    @Query("SELECT f.follower.id, COUNT(f) FROM Following f WHERE f.follower.id IN :userIds GROUP BY f.follower.id")
+    List<Object[]> countFollowingByUserIds(@Param("userIds") List<Long> userIds);
+
+    // 현재 유저가 팔로우하는 유저 ID Set 조회
+    // 유저 목록에서 isFollowing 여부를 Set.contains() O(1)로 일괄 확인하기 위해 사용
+    @Query("SELECT f.following.id FROM Following f WHERE f.follower.id = :followerId")
+    Set<Long> findFollowingIdsByFollowerId(@Param("followerId") Long followerId);
 }

--- a/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
@@ -6,6 +6,8 @@ import org.solmate.domain.social.entity.MentoringRelation;
 import org.solmate.domain.social.enums.MentoringStatus;
 import org.solmate.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MentoringRepository extends JpaRepository<MentoringRelation, Long> {
 
@@ -24,4 +26,10 @@ public interface MentoringRepository extends JpaRepository<MentoringRelation, Lo
 
     // 댓글 작성자가 나의 멘토인지 확인 (mentor=댓글작성자, mentee=나, status=ACCEPTED)
     boolean existsByMentorIdAndMenteeIdAndStatus(Long mentorId, Long menteeId, MentoringStatus status);
+
+    // 내가 멘티인 멘토링 관계 일괄 조회 (유저 목록/프로필 멘토 버튼 상태 계산용)
+    // PENDING + ACCEPTED 상태만 조회 (REJECTED는 버튼 표시 불필요)
+    // 결과로 mentorId → UserMentoringStatus 맵을 구성하여 유저별 상태를 O(1)로 확인
+    @Query("SELECT m FROM MentoringRelation m WHERE m.mentee.id = :menteeId AND m.status IN :statuses")
+    List<MentoringRelation> findByMenteeIdAndStatusIn(@Param("menteeId") Long menteeId, @Param("statuses") List<MentoringStatus> statuses);
 }

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -9,7 +9,6 @@ import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.enums.NotificationType;
 import org.solmate.domain.notification.repository.NotificationRepository;
 import org.solmate.domain.social.dto.response.MentoringResponse;
-import org.solmate.domain.social.dto.response.MyMentoringStatusResponse;
 import org.solmate.domain.social.entity.MentoringRelation;
 import org.solmate.domain.social.enums.MentoringStatus;
 import org.solmate.domain.social.repository.MentoringRepository;
@@ -130,28 +129,6 @@ public class MentoringService {
         notificationRepository.save(notification);
 
         return MentoringResponse.of(relation);
-    }
-
-    /**
-     * 내 멘토링 신청 현황 조회
-     * - 유저 목록 진입 시 프론트에서 호출하여 멘토 신청 버튼 활성화 여부를 판단하는 데 사용
-     * - hasAcceptedMentor가 true이면 모든 버튼 비활성화
-     * - pendingMentorIds에 포함된 유저 ID의 버튼만 개별 비활성화
-     */
-    public MyMentoringStatusResponse getMyMentoringStatus(Long menteeId) {
-        User mentee = userRepository.findById(menteeId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        // 이미 수락된 멘토가 있는지 여부
-        boolean hasAcceptedMentor = mentoringRepository.existsByMenteeAndStatus(mentee, MentoringStatus.ACCEPTED);
-
-        // 현재 대기 중인(PENDING) 신청을 보낸 멘토들의 ID 목록
-        List<Long> pendingMentorIds = mentoringRepository.findAllByMenteeAndStatus(mentee, MentoringStatus.PENDING)
-                .stream()
-                .map(relation -> relation.getMentor().getId())
-                .toList();
-
-        return new MyMentoringStatusResponse(hasAcceptedMentor, pendingMentorIds);
     }
 
     /**

--- a/src/main/java/org/solmate/domain/social/service/UserListService.java
+++ b/src/main/java/org/solmate/domain/social/service/UserListService.java
@@ -1,0 +1,172 @@
+package org.solmate.domain.social.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.social.dto.response.UserListItemResponse;
+import org.solmate.domain.social.dto.response.UserListResponse;
+import org.solmate.domain.social.dto.response.UserProfileResponse;
+import org.solmate.domain.social.entity.MentoringRelation;
+import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.social.enums.UserMentoringStatus;
+import org.solmate.domain.social.repository.FollowingRepository;
+import org.solmate.domain.social.repository.MentoringRepository;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.user.repository.UserRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserListService {
+
+    private final UserRepository userRepository;
+    private final FollowingRepository followingRepository;
+    private final MentoringRepository mentoringRepository;
+
+    /**
+     * 유저 목록 조회 (커서 기반 무한 스크롤)
+     *
+     * 처리 순서 (총 5번의 쿼리로 N+1 없이 처리):
+     *   ① 유저 목록 조회 (cursor 기반 - 첫 페이지면 cursor=null)
+     *   ② 내가 팔로우하는 유저 ID 목록 (팔로우 여부 일괄 확인)
+     *   ③ 나의 멘토링 관계 일괄 조회 (PENDING + ACCEPTED)
+     *   ④ 유저 ID 목록으로 팔로워 수 bulk 집계
+     *   ⑤ 유저 ID 목록으로 팔로잉 수 bulk 집계
+     *
+     * hasNext 판별:
+     *   size+1개를 조회해서 실제 size보다 많으면 다음 페이지가 있음
+     *   nextCursor는 현재 페이지 마지막 유저의 userId
+     *
+     * hasAcceptedMentor:
+     *   true이면 프론트에서 NONE 상태의 멘토신청 버튼을 모두 비활성화해야 함
+     *   (이미 멘토가 있는 경우 추가 신청 불가)
+     */
+    public UserListResponse getUserList(Long currentUserId, Long cursor, int size) {
+        // ① 유저 목록 조회 (size+1개 조회로 hasNext 판별)
+        List<User> users = cursor == null
+                ? userRepository.findByDeletedAtIsNullOrderByIdAsc(PageRequest.of(0, size + 1))
+                : userRepository.findByIdGreaterThanAndDeletedAtIsNullOrderByIdAsc(cursor, PageRequest.of(0, size + 1));
+
+        // size+1개가 왔으면 다음 페이지가 존재함 → 실제 반환은 size개만
+        boolean hasNext = users.size() > size;
+        if (hasNext) {
+            users = users.subList(0, size);
+        }
+        // 다음 페이지 커서 = 현재 페이지 마지막 유저의 userId (없으면 null)
+        Long nextCursor = hasNext ? users.get(users.size() - 1).getId() : null;
+
+        List<Long> userIds = users.stream().map(User::getId).toList();
+
+        // ② 내가 팔로우하는 유저 ID 목록 (팔로우 여부 일괄 확인용)
+        Set<Long> followingIds = followingRepository.findFollowingIdsByFollowerId(currentUserId);
+
+        // ③ 나의 멘토링 관계 일괄 조회 (PENDING + ACCEPTED만 - REJECTED는 버튼 표시 불필요)
+        List<MentoringRelation> myRelations = mentoringRepository.findByMenteeIdAndStatusIn(
+                currentUserId, List.of(MentoringStatus.PENDING, MentoringStatus.ACCEPTED));
+
+        // 수락된 멘토가 있는지 여부 (true이면 NONE 상태 멘토신청 버튼 비활성화)
+        boolean hasAcceptedMentor = myRelations.stream()
+                .anyMatch(r -> r.getStatus() == MentoringStatus.ACCEPTED);
+
+        // mentorId → UserMentoringStatus 맵으로 변환 (유저별 멘토링 상태 빠른 조회용)
+        Map<Long, UserMentoringStatus> mentoringStatusMap = myRelations.stream()
+                .collect(Collectors.toMap(
+                        r -> r.getMentor().getId(),
+                        r -> r.getStatus() == MentoringStatus.ACCEPTED
+                                ? UserMentoringStatus.ACCEPTED
+                                : UserMentoringStatus.PENDING
+                ));
+
+        // ④ 유저 ID 목록으로 팔로워 수 bulk 집계 (개별 count 쿼리 N번 → 1번으로 처리)
+        Map<Long, Long> followerCountMap = followingRepository.countFollowersByUserIds(userIds).stream()
+                .collect(Collectors.toMap(
+                        arr -> (Long) arr[0],  // userId
+                        arr -> (Long) arr[1]   // count
+                ));
+
+        // ⑤ 유저 ID 목록으로 팔로잉 수 bulk 집계
+        Map<Long, Long> followingCountMap = followingRepository.countFollowingByUserIds(userIds).stream()
+                .collect(Collectors.toMap(
+                        arr -> (Long) arr[0],  // userId
+                        arr -> (Long) arr[1]   // count
+                ));
+
+        // 각 유저에 대해 소셜 정보를 조합하여 응답 생성
+        // 팔로워/팔로잉이 없는 유저는 0으로 기본값 처리
+        List<UserListItemResponse> items = users.stream()
+                .map(user -> UserListItemResponse.of(
+                        user,
+                        followerCountMap.getOrDefault(user.getId(), 0L),
+                        followingCountMap.getOrDefault(user.getId(), 0L),
+                        user.getId().equals(currentUserId),
+                        followingIds.contains(user.getId()),
+                        mentoringStatusMap.getOrDefault(user.getId(), UserMentoringStatus.NONE)
+                ))
+                .toList();
+
+        return new UserListResponse(hasAcceptedMentor, items, nextCursor, hasNext);
+    }
+
+    /**
+     * 유저 프로필 단건 조회
+     *
+     * - 탈퇴한 유저는 조회 불가 (USER_NOT_FOUND 예외)
+     * - 본인 프로필 조회 시 isMe=true, isFollowing=false, mentoringStatus=NONE
+     * - 타인 프로필 조회 시 현재 로그인 유저 기준으로 팔로우 여부 및 멘토링 상태 계산
+     */
+    public UserProfileResponse getUserProfile(Long currentUserId, Long targetUserId) {
+        User target = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        boolean isMe = currentUserId.equals(targetUserId);
+
+        // 대상 유저의 팔로워 수 (이 유저를 팔로우하는 사람 수)
+        long followerCount = followingRepository.countFollowersByUserIds(List.of(targetUserId)).stream()
+                .findFirst()
+                .map(arr -> (Long) arr[1])
+                .orElse(0L);
+
+        // 대상 유저의 팔로잉 수 (이 유저가 팔로우하는 사람 수)
+        long followingCount = followingRepository.countFollowingByUserIds(List.of(targetUserId)).stream()
+                .findFirst()
+                .map(arr -> (Long) arr[1])
+                .orElse(0L);
+
+        // 현재 로그인 유저가 대상 유저를 팔로우 중인지 (본인이면 항상 false)
+        boolean isFollowing = !isMe && followingIds(currentUserId).contains(targetUserId);
+
+        // 현재 로그인 유저 기준 대상 유저와의 멘토링 상태
+        // 본인 프로필이면 NONE 고정, 타인이면 PENDING/ACCEPTED/NONE 중 하나
+        UserMentoringStatus mentoringStatus = UserMentoringStatus.NONE;
+        if (!isMe) {
+            List<MentoringRelation> relations = mentoringRepository.findByMenteeIdAndStatusIn(
+                    currentUserId, List.of(MentoringStatus.PENDING, MentoringStatus.ACCEPTED));
+            mentoringStatus = relations.stream()
+                    .filter(r -> r.getMentor().getId().equals(targetUserId))
+                    .findFirst()
+                    .map(r -> r.getStatus() == MentoringStatus.ACCEPTED
+                            ? UserMentoringStatus.ACCEPTED
+                            : UserMentoringStatus.PENDING)
+                    .orElse(UserMentoringStatus.NONE);
+        }
+
+        return UserProfileResponse.of(target, followerCount, followingCount, isMe, isFollowing, mentoringStatus);
+    }
+
+    /**
+     * 현재 유저가 팔로우하는 유저 ID Set 조회
+     * - 팔로우 여부 확인 시 contains() O(1) 조회를 위해 Set으로 반환
+     */
+    private Set<Long> followingIds(Long userId) {
+        return followingRepository.findFollowingIdsByFollowerId(userId);
+    }
+}

--- a/src/main/java/org/solmate/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/solmate/domain/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package org.solmate.domain.user.repository;
 
-import org.solmate.domain.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import java.util.Optional;
+
+import org.solmate.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -18,4 +20,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 탈퇴 유저 포함 조회 (댓글, 매매일지 작성자 표시를 위한..)
     Optional<User> findByEmail(String email);
+
+    // 유저 목록 커서 기반 페이지네이션 (첫 페이지)
+    List<User> findByDeletedAtIsNullOrderByIdAsc(Pageable pageable);
+
+    // 유저 목록 커서 기반 페이지네이션 (다음 페이지)
+    List<User> findByIdGreaterThanAndDeletedAtIsNullOrderByIdAsc(Long cursor, Pageable pageable);
 }


### PR DESCRIPTION
⏺ ## #️⃣  관련 이슈
  - closed #87
                                                                                                                
  ## 💡 작업 배경
  유저 목록 화면에서 팔로우 여부, 멘토링 상태를 한 번의 API 호출로 제공하기 위해 구현                           
                                                                                                                
  ## 🧩 작업 내용
  - `GET /api/v1/users` 유저 목록 조회 API 추가 (커서 기반 무한 스크롤)                                         
    - 팔로워 수, 팔로잉 수, 팔로우 여부(`isFollowing`), 멘토링 상태(`mentoringStatus`) 포함                     
    - `hasAcceptedMentor` 포함으로 멘토신청 버튼 비활성화 여부 판단 가능                                        
  - `GET /api/v1/users/{userId}` 유저 프로필 단건 조회 API 추가                                                 
  - 기존 `GET /api/v1/mentor-requests/my` 멘토링 현황 조회 API 제거 (유저 목록 API에 통합)                      
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타      
  - 총 수익률 / 총 수익은 미구현으로 추후 추가 예정