### PR TITLE
[Feat] 알림 조회 및 읽음 처리 API 구현

### DIFF
--- a/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
@@ -1,14 +1,21 @@
 package org.solmate.domain.notification.controller;
 
+import java.util.List;
+
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.notification.dto.response.NotificationCountResponse;
+import org.solmate.domain.notification.dto.response.NotificationResponse;
+import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.service.NotificationService;
 import org.solmate.domain.social.dto.response.MentoringResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,5 +60,20 @@ public class NotificationController {
     ) {
         MentoringResponse response = notificationService.rejectMentoringFromNotification(mentorId, notificationId);
         return ApiResponse.success(SuccessStatus.MENTORING_REJECT_SUCCESS, response);
+    }
+
+    @Operation(summary = "알림 목록 조회", description = "전체 또는 카테고리별 알림 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> getNotifications(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) NotificationCategory category) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, notificationService.getNotifications(userId, category));
+    }
+
+    @Operation(summary = "미읽음 알림 수 조회", description = "전체 및 카테고리별 미읽음 알림 수를 조회합니다.")
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResponse<NotificationCountResponse>> getUnreadCount(
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, notificationService.getUnreadCount(userId));
     }
 }

--- a/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
@@ -12,6 +12,7 @@ import org.solmate.domain.social.dto.response.MentoringResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -75,5 +76,14 @@ public class NotificationController {
     public ResponseEntity<ApiResponse<NotificationCountResponse>> getUnreadCount(
             @AuthenticationPrincipal Long userId) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, notificationService.getUnreadCount(userId));
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long notificationId) {
+        notificationService.markAsRead(userId, notificationId);
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, null);
     }
 }

--- a/src/main/java/org/solmate/domain/notification/dto/response/NotificationCountResponse.java
+++ b/src/main/java/org/solmate/domain/notification/dto/response/NotificationCountResponse.java
@@ -1,0 +1,8 @@
+package org.solmate.domain.notification.dto.response;
+
+public record NotificationCountResponse(
+    long total,
+    long social,
+    long trading,
+    long mentoring
+) {}

--- a/src/main/java/org/solmate/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/org/solmate/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,29 @@
+package org.solmate.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.solmate.domain.notification.entity.Notification;
+import org.solmate.domain.notification.enums.NotificationCategory;
+import org.solmate.domain.notification.enums.NotificationType;
+
+public record NotificationResponse(
+    Long notificationId,
+    NotificationType notificationType,
+    NotificationCategory category,
+    String content,
+    boolean isRead,
+    String actUrl,
+    LocalDateTime createdAt
+) {
+    public static NotificationResponse of(Notification notification) {
+        return new NotificationResponse(
+            notification.getId(),
+            notification.getNotificationType(),
+            notification.getCategory(),
+            notification.getContent(),
+            notification.isRead(),
+            notification.getActUrl(),
+            notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/solmate/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,18 @@
 package org.solmate.domain.notification.repository;
 
+import java.util.List;
+
 import org.solmate.domain.notification.entity.Notification;
+import org.solmate.domain.notification.enums.NotificationCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findAllByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(Long userId);
+
+    List<Notification> findAllByUserIdAndCategoryAndIsDeletedFalseOrderByCreatedAtDesc(Long userId, NotificationCategory category);
+
+    long countByUserIdAndIsReadFalseAndIsDeletedFalse(Long userId);
+
+    long countByUserIdAndCategoryAndIsReadFalseAndIsDeletedFalse(Long userId, NotificationCategory category);
 }

--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -1,8 +1,13 @@
 package org.solmate.domain.notification.service;
 
+import java.util.List;
+
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.notification.dto.response.NotificationCountResponse;
+import org.solmate.domain.notification.dto.response.NotificationResponse;
 import org.solmate.domain.notification.entity.Notification;
+import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.enums.NotificationType;
 import org.solmate.domain.notification.repository.NotificationRepository;
 import org.solmate.domain.social.dto.response.MentoringResponse;
@@ -121,5 +126,24 @@ public class NotificationService {
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus.NOTIFICATION_INVALID_TYPE);
         }
+    }
+
+    public List<NotificationResponse> getNotifications(Long userId, NotificationCategory category) {
+        List<Notification> notifications = (category != null)
+            ? notificationRepository.findAllByUserIdAndCategoryAndIsDeletedFalseOrderByCreatedAtDesc(userId, category)
+            : notificationRepository.findAllByUserIdAndIsDeletedFalseOrderByCreatedAtDesc(userId);
+
+        return notifications.stream()
+            .map(NotificationResponse::of)
+            .toList();
+    }
+
+    public NotificationCountResponse getUnreadCount(Long userId) {
+        long total = notificationRepository.countByUserIdAndIsReadFalseAndIsDeletedFalse(userId);
+        long social = notificationRepository.countByUserIdAndCategoryAndIsReadFalseAndIsDeletedFalse(userId, NotificationCategory.SOCIAL);
+        long trading = notificationRepository.countByUserIdAndCategoryAndIsReadFalseAndIsDeletedFalse(userId, NotificationCategory.TRADING);
+        long mentoring = notificationRepository.countByUserIdAndCategoryAndIsReadFalseAndIsDeletedFalse(userId, NotificationCategory.MENTORING);
+
+        return new NotificationCountResponse(total, social, trading, mentoring);
     }
 }

--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -138,6 +138,18 @@ public class NotificationService {
             .toList();
     }
 
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_UNAUTHORIZED);
+        }
+
+        notification.markAsRead();
+    }
+
     public NotificationCountResponse getUnreadCount(Long userId) {
         long total = notificationRepository.countByUserIdAndIsReadFalseAndIsDeletedFalse(userId);
         long social = notificationRepository.countByUserIdAndCategoryAndIsReadFalseAndIsDeletedFalse(userId, NotificationCategory.SOCIAL);


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #86 

## 💡 작업 배경
알림 목록 화면에서 사용자가 자신의 알림을 확인하고 읽음 처리할 수 있도록 알림 조회 및 읽음 처리 API를 구현했습니다.

## 🧩 작업 내용
 - NotificationRepository: 알림 조회 및 미읽음 수 집계 쿼리 메서드 추가
    - 전체/카테고리별 알림 목록 조회
    - 전체/카테고리별 미읽음 수 조회
  - NotificationResponse: 알림 목록 응답 DTO 추가
  - NotificationCountResponse: 미읽음 수 응답 DTO 추가 (전체, SOCIAL, TRADING, MENTORING)
  - NotificationService: 조회 및 읽음 처리 메서드 추가
  - NotificationController: 알림 API 엔드포인트 추가
    - GET /api/v1/notifications (전체 또는 카테고리별 알림 목록 조회)
    - GET /api/v1/notifications/unread-count (미읽음 수 조회)
    - PATCH /api/v1/notifications/{notificationId}/read (단건 읽음 처리)
