### PR TITLE
[Feat] 계좌 요약 조회 api 및 포트폴리오 공통 계산, 종목 비중

### DIFF
--- a/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
+++ b/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
@@ -1,0 +1,87 @@
+package org.solmate.common.portfolio;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.account.entity.Account;
+import org.solmate.domain.account.repository.AccountRepository;
+import org.solmate.domain.trade.entity.Holdings;
+import org.solmate.domain.trade.entity.TradeHistory;
+import org.solmate.domain.trade.enums.TradeType;
+import org.solmate.domain.trade.repository.HoldingsRepository;
+import org.solmate.domain.trade.repository.TradeHistoryRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PortfolioCalculator {
+
+    private final AccountRepository accountRepository;
+    private final HoldingsRepository holdingsRepository;
+    private final TradeHistoryRepository tradeHistoryRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    // 실제 보유 현금 = Account.cash(매수 선차감 반영) + PENDING BUY 금액
+    @Transactional(readOnly = true)
+    public BigDecimal getCash(Long userId) {
+        BigDecimal cash = accountRepository.findByUserId(userId)
+                .map(Account::getCash)
+                .orElse(BigDecimal.ZERO);
+
+        BigDecimal pendingBuyAmount = tradeHistoryRepository
+                .findPendingByUserIdAndTradeType(userId, TradeType.BUY)
+                .stream()
+                .map(t -> t.getPrice().multiply(t.getQuantity()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return cash.add(pendingBuyAmount).setScale(0, RoundingMode.HALF_UP);
+    }
+
+    // 총 평가금액 = (Holdings.quantity + PENDING SELL 수량) × 현재가의 합
+    // Holdings.quantity는 매도 주문 접수 시 선차감되므로 PENDING SELL 수량을 복원해야 실제 보유 수량
+    @Transactional(readOnly = true)
+    public BigDecimal getTotalEvaluation(Long userId) {
+        List<Holdings> holdingsList = holdingsRepository.findByUserId(userId);
+
+        return holdingsList.stream()
+                .map(h -> {
+                    BigDecimal pendingSellQuantity = tradeHistoryRepository
+                            .findPendingByUserIdAndTickerCodeAndTradeType(userId, h.getTickerCode(), TradeType.SELL)
+                            .stream()
+                            .map(TradeHistory::getQuantity)
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+                    BigDecimal totalQuantity = h.getQuantity().add(pendingSellQuantity);
+                    return getCurrentPrice(h.getTickerCode()).multiply(totalQuantity);
+                })
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(0, RoundingMode.HALF_UP);
+    }
+
+    // 총 수익금 = 총 자산(평가금액 + 현금) - 시드머니
+    public BigDecimal getTotalReturnAmount(BigDecimal totalAsset, BigDecimal initialCash) {
+        return totalAsset.subtract(initialCash).setScale(0, RoundingMode.HALF_UP);
+    }
+
+    // 총 수익률 = 총 수익금 / 시드머니 × 100
+    public BigDecimal getTotalReturnRate(BigDecimal totalReturnAmount, BigDecimal initialCash) {
+        if (initialCash.compareTo(BigDecimal.ZERO) == 0) return BigDecimal.ZERO;
+        return totalReturnAmount
+                .divide(initialCash, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal getCurrentPrice(String ticker) {
+        String curStr = (String) redisTemplate.opsForHash().get("stock:info:" + ticker, "cur");
+        if (curStr == null) throw new GeneralException(ErrorStatus.STOCK_PRICE_NOT_FOUND);
+        return new BigDecimal(curStr);
+    }
+}

--- a/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
+++ b/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
@@ -2,6 +2,8 @@ package org.solmate.common.portfolio;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.solmate.common.exception.GeneralException;
@@ -44,23 +46,40 @@ public class PortfolioCalculator {
         return cash.add(pendingBuyAmount).setScale(0, RoundingMode.HALF_UP);
     }
 
+    // 종목별 평가금액 (실제 보유 수량 = Holdings.quantity + PENDING SELL)
+    @Transactional(readOnly = true)
+    public List<PortfolioHoldingLine> getHoldingEvaluationLines(Long userId) {
+        List<Holdings> holdingsList = holdingsRepository.findByUserId(userId);
+        List<PortfolioHoldingLine> lines = new ArrayList<>();
+
+        for (Holdings h : holdingsList) {
+            BigDecimal pendingSellQuantity = tradeHistoryRepository
+                    .findPendingByUserIdAndTickerCodeAndTradeType(userId, h.getTickerCode(), TradeType.SELL)
+                    .stream()
+                    .map(TradeHistory::getQuantity)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+            BigDecimal totalQuantity = h.getQuantity().add(pendingSellQuantity);
+            if (totalQuantity.compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+
+            BigDecimal evaluation = getCurrentPrice(h.getTickerCode()).multiply(totalQuantity);
+            lines.add(new PortfolioHoldingLine(
+                    h.getTickerCode(),
+                    h.getStock().getStockName(),
+                    evaluation));
+        }
+
+        lines.sort(Comparator.comparing(PortfolioHoldingLine::evaluation).reversed());
+        return lines;
+    }
+
     // 총 평가금액 = (Holdings.quantity + PENDING SELL 수량) × 현재가의 합
-    // Holdings.quantity는 매도 주문 접수 시 선차감되므로 PENDING SELL 수량을 복원해야 실제 보유 수량
     @Transactional(readOnly = true)
     public BigDecimal getTotalEvaluation(Long userId) {
-        List<Holdings> holdingsList = holdingsRepository.findByUserId(userId);
-
-        return holdingsList.stream()
-                .map(h -> {
-                    BigDecimal pendingSellQuantity = tradeHistoryRepository
-                            .findPendingByUserIdAndTickerCodeAndTradeType(userId, h.getTickerCode(), TradeType.SELL)
-                            .stream()
-                            .map(TradeHistory::getQuantity)
-                            .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-                    BigDecimal totalQuantity = h.getQuantity().add(pendingSellQuantity);
-                    return getCurrentPrice(h.getTickerCode()).multiply(totalQuantity);
-                })
+        return getHoldingEvaluationLines(userId).stream()
+                .map(PortfolioHoldingLine::evaluation)
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
                 .setScale(0, RoundingMode.HALF_UP);
     }

--- a/src/main/java/org/solmate/common/portfolio/PortfolioHoldingLine.java
+++ b/src/main/java/org/solmate/common/portfolio/PortfolioHoldingLine.java
@@ -1,0 +1,9 @@
+package org.solmate.common.portfolio;
+
+import java.math.BigDecimal;
+
+public record PortfolioHoldingLine(
+        String tickerCode,
+        String stockName,
+        BigDecimal evaluation
+) {}

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -36,6 +36,7 @@ public enum SuccessStatus implements BaseStatus {
     MOCK_DATA_INIT_SUCCESS("TRADE_200", HttpStatus.OK, "Mock 시세 데이터 초기화 성공"),
     BUY_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매수 주문 접수 성공"),
     SELL_ORDER_SUCCESS("TRADE_201", HttpStatus.CREATED, "매도 주문 접수 성공"),
+    ACCOUNT_SUMMARY_SUCCESS("ACCOUNT_200", HttpStatus.OK, "내 계좌 요약 조회 성공"),
     HOLDINGS_SUCCESS("TRADE_200", HttpStatus.OK, "보유 종목 조회 성공"),
     TRADE_HISTORY_SUCCESS("TRADE_200", HttpStatus.OK, "매매내역 조회 성공"),
     PROFILE_UPDATE_SUCCESS("USER_200", HttpStatus.OK, "프로필 업데이트 성공"),

--- a/src/main/java/org/solmate/domain/account/controller/AccountController.java
+++ b/src/main/java/org/solmate/domain/account/controller/AccountController.java
@@ -1,0 +1,31 @@
+package org.solmate.domain.account.controller;
+
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.account.dto.response.AccountSummaryResponse;
+import org.solmate.domain.account.service.AccountService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Account", description = "내 계좌 API")
+@RestController
+@RequestMapping("/api/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @Operation(summary = "내 계좌 요약 조회", description = "보유 총 자산, 보유 현금, 보유 종목 수, 수익률 카드 데이터를 조회합니다.")
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<AccountSummaryResponse>> getSummary(
+            @AuthenticationPrincipal Long userId) {
+        return ApiResponse.success(SuccessStatus.ACCOUNT_SUMMARY_SUCCESS, accountService.getSummary(userId));
+    }
+}

--- a/src/main/java/org/solmate/domain/account/controller/AccountController.java
+++ b/src/main/java/org/solmate/domain/account/controller/AccountController.java
@@ -4,6 +4,7 @@ import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.account.dto.response.AccountSummaryResponse;
 import org.solmate.domain.account.service.AccountService;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +23,22 @@ public class AccountController {
 
     private final AccountService accountService;
 
-    @Operation(summary = "내 계좌 요약 조회", description = "보유 총 자산, 보유 현금, 보유 종목 수, 수익률 카드 데이터를 조회합니다.")
+    @Operation(
+            summary = "내 계좌 요약 조회",
+            description = """
+                    보유 총 자산·현금·종목 수·수익률 카드와 종목 비중(도넛 차트) 데이터를 한 번에 조회합니다.
+
+                    **클라이언트 권장:** 내 계좌 화면에서는 약 10초 간격 폴링으로 갱신해도 무방합니다. 주문·체결 등 거래 직후에는 즉시 재조회하여 수치를 맞추는 것을 권장합니다.
+
+                    응답은 개인 자산 정보이므로 캐시하지 않습니다 (Cache-Control: no-store).""")
     @GetMapping("/summary")
     public ResponseEntity<ApiResponse<AccountSummaryResponse>> getSummary(
             @AuthenticationPrincipal Long userId) {
-        return ApiResponse.success(SuccessStatus.ACCOUNT_SUMMARY_SUCCESS, accountService.getSummary(userId));
+        ResponseEntity<ApiResponse<AccountSummaryResponse>> entity = ApiResponse.success(
+                SuccessStatus.ACCOUNT_SUMMARY_SUCCESS,
+                accountService.getSummary(userId));
+        return ResponseEntity.status(entity.getStatusCode())
+                .cacheControl(CacheControl.noStore().mustRevalidate())
+                .body(entity.getBody());
     }
 }

--- a/src/main/java/org/solmate/domain/account/dto/response/AccountSummaryResponse.java
+++ b/src/main/java/org/solmate/domain/account/dto/response/AccountSummaryResponse.java
@@ -1,6 +1,7 @@
 package org.solmate.domain.account.dto.response;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 public record AccountSummaryResponse(
         BigDecimal totalAsset,
@@ -14,5 +15,7 @@ public record AccountSummaryResponse(
         BigDecimal totalEvaluation,
 
         BigDecimal totalReturnRate,
-        BigDecimal totalReturnAmount
+        BigDecimal totalReturnAmount,
+
+        List<HoldingRatioItem> holdingsRatio
 ) {}

--- a/src/main/java/org/solmate/domain/account/dto/response/AccountSummaryResponse.java
+++ b/src/main/java/org/solmate/domain/account/dto/response/AccountSummaryResponse.java
@@ -1,0 +1,18 @@
+package org.solmate.domain.account.dto.response;
+
+import java.math.BigDecimal;
+
+public record AccountSummaryResponse(
+        BigDecimal totalAsset,
+        BigDecimal totalAssetChangeAmount,
+        BigDecimal totalAssetChangeRate,
+
+        BigDecimal cash,
+        BigDecimal initialCash,
+
+        int holdingsCount,
+        BigDecimal totalEvaluation,
+
+        BigDecimal totalReturnRate,
+        BigDecimal totalReturnAmount
+) {}

--- a/src/main/java/org/solmate/domain/account/dto/response/HoldingRatioItem.java
+++ b/src/main/java/org/solmate/domain/account/dto/response/HoldingRatioItem.java
@@ -1,0 +1,10 @@
+package org.solmate.domain.account.dto.response;
+
+import java.math.BigDecimal;
+
+public record HoldingRatioItem(
+        String tickerCode,
+        String stockName,
+        BigDecimal evaluation,
+        BigDecimal ratio
+) {}

--- a/src/main/java/org/solmate/domain/account/entity/Account.java
+++ b/src/main/java/org/solmate/domain/account/entity/Account.java
@@ -36,10 +36,14 @@ public class Account extends BaseEntity {
     @Column(nullable = false, precision = 19, scale = 4)
     private BigDecimal cash;
 
+    @Column(name = "initial_cash", nullable = false, precision = 19, scale = 4)
+    private BigDecimal initialCash;
+
     @Builder
     public Account(User user, BigDecimal cash) {
         this.user = user;
         this.cash = cash;
+        this.initialCash = cash;
     }
 
     public void addCash(BigDecimal amount) {

--- a/src/main/java/org/solmate/domain/account/service/AccountService.java
+++ b/src/main/java/org/solmate/domain/account/service/AccountService.java
@@ -1,14 +1,17 @@
 package org.solmate.domain.account.service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
 
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.portfolio.PortfolioCalculator;
+import org.solmate.common.portfolio.PortfolioHoldingLine;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.account.dto.response.AccountSummaryResponse;
+import org.solmate.domain.account.dto.response.HoldingRatioItem;
 import org.solmate.domain.account.entity.Account;
 import org.solmate.domain.account.repository.AccountRepository;
-import org.solmate.domain.trade.repository.HoldingsRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 public class AccountService {
 
     private final AccountRepository accountRepository;
-    private final HoldingsRepository holdingsRepository;
     private final PortfolioCalculator portfolioCalculator;
 
     public AccountSummaryResponse getSummary(Long userId) {
@@ -29,11 +31,19 @@ public class AccountService {
 
         BigDecimal initialCash = account.getInitialCash();
         BigDecimal cash = portfolioCalculator.getCash(userId);
-        BigDecimal totalEvaluation = portfolioCalculator.getTotalEvaluation(userId);
+
+        List<PortfolioHoldingLine> lines = portfolioCalculator.getHoldingEvaluationLines(userId);
+        BigDecimal sumEvaluationRaw = lines.stream()
+                .map(PortfolioHoldingLine::evaluation)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal totalEvaluation = sumEvaluationRaw.setScale(0, RoundingMode.HALF_UP);
+
+        List<HoldingRatioItem> holdingsRatio = buildHoldingsRatio(lines, sumEvaluationRaw);
+
         BigDecimal totalAsset = cash.add(totalEvaluation);
         BigDecimal totalReturnAmount = portfolioCalculator.getTotalReturnAmount(totalAsset, initialCash);
         BigDecimal totalReturnRate = portfolioCalculator.getTotalReturnRate(totalReturnAmount, initialCash);
-        int holdingsCount = holdingsRepository.findByUserId(userId).size();
+        int holdingsCount = lines.size();
 
         return new AccountSummaryResponse(
                 totalAsset,
@@ -44,7 +54,31 @@ public class AccountService {
                 holdingsCount,
                 totalEvaluation,
                 totalReturnRate,
-                totalReturnAmount
+                totalReturnAmount,
+                holdingsRatio
         );
+    }
+
+    private List<HoldingRatioItem> buildHoldingsRatio(List<PortfolioHoldingLine> lines, BigDecimal sumRaw) {
+        if (sumRaw.compareTo(BigDecimal.ZERO) == 0) {
+            return lines.stream()
+                    .map(l -> new HoldingRatioItem(
+                            l.tickerCode(),
+                            l.stockName(),
+                            l.evaluation().setScale(0, RoundingMode.HALF_UP),
+                            BigDecimal.ZERO))
+                    .toList();
+        }
+
+        return lines.stream()
+                .map(l -> new HoldingRatioItem(
+                        l.tickerCode(),
+                        l.stockName(),
+                        l.evaluation().setScale(0, RoundingMode.HALF_UP),
+                        l.evaluation()
+                                .divide(sumRaw, 4, RoundingMode.HALF_UP)
+                                .multiply(BigDecimal.valueOf(100))
+                                .setScale(2, RoundingMode.HALF_UP)))
+                .toList();
     }
 }

--- a/src/main/java/org/solmate/domain/account/service/AccountService.java
+++ b/src/main/java/org/solmate/domain/account/service/AccountService.java
@@ -1,0 +1,50 @@
+package org.solmate.domain.account.service;
+
+import java.math.BigDecimal;
+
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.portfolio.PortfolioCalculator;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.account.dto.response.AccountSummaryResponse;
+import org.solmate.domain.account.entity.Account;
+import org.solmate.domain.account.repository.AccountRepository;
+import org.solmate.domain.trade.repository.HoldingsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final HoldingsRepository holdingsRepository;
+    private final PortfolioCalculator portfolioCalculator;
+
+    public AccountSummaryResponse getSummary(Long userId) {
+        Account account = accountRepository.findByUserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND));
+
+        BigDecimal initialCash = account.getInitialCash();
+        BigDecimal cash = portfolioCalculator.getCash(userId);
+        BigDecimal totalEvaluation = portfolioCalculator.getTotalEvaluation(userId);
+        BigDecimal totalAsset = cash.add(totalEvaluation);
+        BigDecimal totalReturnAmount = portfolioCalculator.getTotalReturnAmount(totalAsset, initialCash);
+        BigDecimal totalReturnRate = portfolioCalculator.getTotalReturnRate(totalReturnAmount, initialCash);
+        int holdingsCount = holdingsRepository.findByUserId(userId).size();
+
+        return new AccountSummaryResponse(
+                totalAsset,
+                totalReturnAmount,
+                totalReturnRate,
+                cash,
+                initialCash,
+                holdingsCount,
+                totalEvaluation,
+                totalReturnRate,
+                totalReturnAmount
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -1,10 +1,13 @@
 package org.solmate.domain.auth.service;
 
+import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.jwt.JwtProvider;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.account.entity.Account;
+import org.solmate.domain.account.repository.AccountRepository;
 import org.solmate.domain.auth.dto.request.LoginRequest;
 import org.solmate.domain.auth.dto.request.SignUpRequest;
 import org.solmate.domain.auth.service.EmailVerificationService;
@@ -31,9 +34,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class AuthService {
 
+    private static final BigDecimal INITIAL_SEED_MONEY = new BigDecimal("10000000");
+
     private final UserService userService;
     private final UserRepository userRepository;
     private final LoginTypeRepository loginTypeRepository;
+    private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate redisTemplate;
@@ -63,6 +69,12 @@ public class AuthService {
                 .loginType(OAuthProvider.EMAIL)
                 .build();
         loginTypeRepository.save(loginType);
+
+        Account account = Account.builder()
+                .user(user)
+                .cash(INITIAL_SEED_MONEY)
+                .build();
+        accountRepository.save(account);
     }
 
     // 로그인

--- a/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
+++ b/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
@@ -4,10 +4,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.solmate.common.exception.GeneralException;
+import org.solmate.common.portfolio.PortfolioCalculator;
 import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
-import org.solmate.domain.account.entity.Account;
-import org.solmate.domain.account.repository.AccountRepository;
 import org.solmate.domain.stock.dto.response.StockHoldingResponse;
 import org.solmate.domain.trade.dto.response.HoldingsResponse;
 import org.solmate.domain.trade.entity.Holdings;
@@ -27,7 +26,7 @@ public class HoldingsService {
 
     private final HoldingsRepository holdingsRepository;
     private final TradeHistoryRepository tradeHistoryRepository;
-    private final AccountRepository accountRepository;
+    private final PortfolioCalculator portfolioCalculator;
     private final StringRedisTemplate redisTemplate;
     private final S3Service s3Service;
 
@@ -67,17 +66,7 @@ public class HoldingsService {
     // 보유 현금 조회 - Account.cash(매수 접수 시 선차감) + PENDING BUY 금액 합산
     @Transactional(readOnly = true)
     public BigDecimal getCash(Long userId) {
-        BigDecimal cash = accountRepository.findByUserId(userId)
-                .map(Account::getCash)
-                .orElse(BigDecimal.ZERO);
-
-        List<TradeHistory> pendingBuys = tradeHistoryRepository
-                .findPendingByUserIdAndTradeType(userId, TradeType.BUY);
-        BigDecimal pendingBuyAmount = pendingBuys.stream()
-                .map(t -> t.getPrice().multiply(t.getQuantity()))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        return cash.add(pendingBuyAmount);
+        return portfolioCalculator.getCash(userId);
     }
 
     private BigDecimal getCurrentPrice(String ticker) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #42 

## 💡 작업 배경
 내 계좌 화면의 요약 카드(보유 총 자산, 보유 현금, 보유 종목수, 수익률)를 렌더링하기 위한 API가 없었음. 
 또한 보유 자산 계산 시 미체결 매수/매도 주문을 반영하는 규칙이 여러 곳에 중복구현될 가능성이 있어 공통 유틸로 분리 필요.

## 🧩 작업 내용

계좌·가입
  • Account에 initial_cash(시드머니) 추가 →
    수익금·수익률 기준.
  • 회원가입 시 계좌 자동 생성, 시드 1,000만원.

공통 계산 (`PortfolioCalculator`)
  • 실제 현금 = cash + 미체결 매수(PENDING BUY) 금액.
  • 종목 평가 = (보유 수량 + 미체결 매도 수량) × Redis
    현재가; 종목별 라인(PortfolioHoldingLine)으로도
    제공.
  • 총 평가·총 자산·수익금·수익률을 동일 규칙으로 계산해
     재사용 가능하게 분리.

기존 코드 정리
  • HoldingsService.getCash() → PortfolioCalculator
    위임.

내 계좌 요약 API
  • GET /api/account/summary
  • 카드용: totalAsset, totalAssetChangeAmount /
    totalAssetChangeRate, cash, initialCash,
    holdingsCount, totalEvaluation, totalReturnRate,
    totalReturnAmount.
  • 도넛·비중: holdingsRatio(티커, 종목명, 평가액, 비율
    %).

API·운영
  • 개인 자산 응답 Cache-Control: no-store.
  • Swagger에 내 계좌 화면 약 10초 폴링·거래 직후 재조회
     권장 문구.

 DTO
  • AccountSummaryResponse, HoldingRatioItem — 계산은
    서비스, DTO는 전달만.


## 📸 스크린샷(선택)


## 📝 기타

• 랭킹 페이지의 총 수익률/수익 컬럼도 동일한
    PortfolioCalculator를 주입받아 사용 가능
• 기존 Account 데이터가 있는 경우 initial_cash 마이그레이션
    필요


    ALTER TABLE account ADD COLUMN initial_cash numeric(19,4);
    UPDATE account SET initial_cash = cash;
    ALTER TABLE account ALTER COLUMN initial_cash SET NOT NULL;