### PR TITLE
[Feat] 팔로잉/팔로우 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -57,6 +57,8 @@ public enum SuccessStatus implements BaseStatus {
      */
     USER_LIST_SUCCESS("USER_200_1", HttpStatus.OK, "유저 목록 조회 성공"),
     USER_PROFILE_SUCCESS("USER_200_2", HttpStatus.OK, "유저 프로필 조회 성공"),
+    FOLLOWER_LIST_SUCCESS("USER_200_3", HttpStatus.OK, "팔로워 목록 조회 성공"),
+    FOLLOWING_LIST_SUCCESS("USER_200_4", HttpStatus.OK, "팔로잉 목록 조회 성공"),
 
 
     /**

--- a/src/main/java/org/solmate/domain/social/controller/UserListController.java
+++ b/src/main/java/org/solmate/domain/social/controller/UserListController.java
@@ -2,6 +2,7 @@ package org.solmate.domain.social.controller;
 
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.social.dto.response.FollowListResponse;
 import org.solmate.domain.social.dto.response.UserListResponse;
 import org.solmate.domain.social.dto.response.UserProfileResponse;
 import org.solmate.domain.social.service.UserListService;
@@ -107,5 +108,55 @@ public class UserListController {
     ) {
         UserProfileResponse response = userListService.getUserProfile(currentUserId, userId);
         return ApiResponse.success(SuccessStatus.USER_PROFILE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "팔로워 목록 조회",
+            description = """
+                    특정 유저의 팔로워 목록을 커서 기반 무한 스크롤로 조회합니다.
+
+                    **페이지네이션**
+                    - 첫 페이지: cursor 파라미터 생략
+                    - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
+                    - hasNext가 false이면 마지막 페이지
+                    """
+    )
+    @GetMapping("/{userId}/followers")
+    public ResponseEntity<ApiResponse<FollowListResponse>> getFollowerList(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "조회할 유저의 userId")
+            @PathVariable Long userId,
+            @Parameter(description = "마지막으로 받은 유저의 userId (첫 페이지는 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        FollowListResponse response = userListService.getFollowerList(userId, cursor, size);
+        return ApiResponse.success(SuccessStatus.FOLLOWER_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "팔로잉 목록 조회",
+            description = """
+                    특정 유저의 팔로잉 목록을 커서 기반 무한 스크롤로 조회합니다.
+
+                    **페이지네이션**
+                    - 첫 페이지: cursor 파라미터 생략
+                    - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
+                    - hasNext가 false이면 마지막 페이지
+                    """
+    )
+    @GetMapping("/{userId}/following")
+    public ResponseEntity<ApiResponse<FollowListResponse>> getFollowingList(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "조회할 유저의 userId")
+            @PathVariable Long userId,
+            @Parameter(description = "마지막으로 받은 유저의 userId (첫 페이지는 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        FollowListResponse response = userListService.getFollowingList(userId, cursor, size);
+        return ApiResponse.success(SuccessStatus.FOLLOWING_LIST_SUCCESS, response);
     }
 }

--- a/src/main/java/org/solmate/domain/social/dto/response/FollowListItemResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/FollowListItemResponse.java
@@ -1,0 +1,31 @@
+package org.solmate.domain.social.dto.response;
+
+import org.solmate.domain.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 팔로워 / 팔로잉 목록 아이템 응답 DTO
+ *
+ * 필드 설명:
+ * - userId   : 유저 식별자
+ * - nickname : 닉네임
+ * - imageUrl : 프로필 이미지 S3 URL (없으면 null)
+ */
+@Getter
+@AllArgsConstructor
+public class FollowListItemResponse {
+
+    private Long userId;
+    private String nickname;
+    private String imageUrl;
+
+    public static FollowListItemResponse of(User user) {
+        return new FollowListItemResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/FollowListResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/FollowListResponse.java
@@ -1,0 +1,23 @@
+package org.solmate.domain.social.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 팔로워 / 팔로잉 목록 응답 DTO (커서 기반 페이지네이션)
+ *
+ * 필드 설명:
+ * - users      : 팔로워 또는 팔로잉 유저 목록
+ * - nextCursor : 다음 페이지 요청 시 사용할 커서 (마지막 페이지면 null)
+ * - hasNext    : 다음 페이지 존재 여부
+ */
+@Getter
+@AllArgsConstructor
+public class FollowListResponse {
+
+    private List<FollowListItemResponse> users;
+    private Long nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.solmate.domain.social.entity.Following;
 import org.solmate.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -34,4 +35,20 @@ public interface FollowingRepository extends JpaRepository<Following, Long> {
     // 유저 목록에서 isFollowing 여부를 Set.contains() O(1)로 일괄 확인하기 위해 사용
     @Query("SELECT f.following.id FROM Following f WHERE f.follower.id = :followerId")
     Set<Long> findFollowingIdsByFollowerId(@Param("followerId") Long followerId);
+
+    // 팔로워 목록 조회 - userId를 팔로우하는 사람들 (첫 페이지)
+    @Query("SELECT f.follower FROM Following f WHERE f.following.id = :userId AND f.follower.deletedAt IS NULL ORDER BY f.follower.id ASC")
+    List<User> findFollowersFirstPage(@Param("userId") Long userId, Pageable pageable);
+
+    // 팔로워 목록 조회 - userId를 팔로우하는 사람들 (다음 페이지, 커서 기반)
+    @Query("SELECT f.follower FROM Following f WHERE f.following.id = :userId AND f.follower.id > :cursor AND f.follower.deletedAt IS NULL ORDER BY f.follower.id ASC")
+    List<User> findFollowersWithCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
+
+    // 팔로잉 목록 조회 - userId가 팔로우하는 사람들 (첫 페이지)
+    @Query("SELECT f.following FROM Following f WHERE f.follower.id = :userId AND f.following.deletedAt IS NULL ORDER BY f.following.id ASC")
+    List<User> findFollowingFirstPage(@Param("userId") Long userId, Pageable pageable);
+
+    // 팔로잉 목록 조회 - userId가 팔로우하는 사람들 (다음 페이지, 커서 기반)
+    @Query("SELECT f.following FROM Following f WHERE f.follower.id = :userId AND f.following.id > :cursor AND f.following.deletedAt IS NULL ORDER BY f.following.id ASC")
+    List<User> findFollowingWithCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 }

--- a/src/main/java/org/solmate/domain/social/service/UserListService.java
+++ b/src/main/java/org/solmate/domain/social/service/UserListService.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.social.dto.response.FollowListItemResponse;
+import org.solmate.domain.social.dto.response.FollowListResponse;
 import org.solmate.domain.social.dto.response.UserListItemResponse;
 import org.solmate.domain.social.dto.response.UserListResponse;
 import org.solmate.domain.social.dto.response.UserProfileResponse;
@@ -18,6 +20,7 @@ import org.solmate.domain.social.repository.MentoringRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -160,6 +163,62 @@ public class UserListService {
         }
 
         return UserProfileResponse.of(target, followerCount, followingCount, isMe, isFollowing, mentoringStatus);
+    }
+
+    /**
+     * 팔로워 목록 조회 (커서 기반 무한 스크롤)
+     *
+     * - targetUserId를 팔로우하는 사람들의 목록을 반환
+     * - 탈퇴한 유저는 제외
+     */
+    public FollowListResponse getFollowerList(Long targetUserId, Long cursor, int size) {
+        userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<User> followers = cursor == null
+                ? followingRepository.findFollowersFirstPage(targetUserId, pageable)
+                : followingRepository.findFollowersWithCursor(targetUserId, cursor, pageable);
+
+        boolean hasNext = followers.size() > size;
+        if (hasNext) {
+            followers = followers.subList(0, size);
+        }
+        Long nextCursor = hasNext ? followers.get(followers.size() - 1).getId() : null;
+
+        List<FollowListItemResponse> items = followers.stream()
+                .map(FollowListItemResponse::of)
+                .toList();
+
+        return new FollowListResponse(items, nextCursor, hasNext);
+    }
+
+    /**
+     * 팔로잉 목록 조회 (커서 기반 무한 스크롤)
+     *
+     * - targetUserId가 팔로우하는 사람들의 목록을 반환
+     * - 탈퇴한 유저는 제외
+     */
+    public FollowListResponse getFollowingList(Long targetUserId, Long cursor, int size) {
+        userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<User> followings = cursor == null
+                ? followingRepository.findFollowingFirstPage(targetUserId, pageable)
+                : followingRepository.findFollowingWithCursor(targetUserId, cursor, pageable);
+
+        boolean hasNext = followings.size() > size;
+        if (hasNext) {
+            followings = followings.subList(0, size);
+        }
+        Long nextCursor = hasNext ? followings.get(followings.size() - 1).getId() : null;
+
+        List<FollowListItemResponse> items = followings.stream()
+                .map(FollowListItemResponse::of)
+                .toList();
+
+        return new FollowListResponse(items, nextCursor, hasNext);
     }
 
     /**


### PR DESCRIPTION
## #️⃣  관련 이슈
  - closed #96
                                                                                                                
  ## 💡 작업 배경
  프로필 카드에서 팔로워/팔로잉 숫자를 클릭하면 해당 목록을 모달로 확인할 수 있도록 하기 위해 목록 조회 API가   
  필요했습니다.                                                                                                 
   
  ## 🧩 작업 내용                                                                                               
  - 팔로워 목록 조회 API 추가 (`GET /api/v1/users/{userId}/followers`)
  - 팔로잉 목록 조회 API 추가 (`GET /api/v1/users/{userId}/following`)                                          
  - 커서 기반 무한 스크롤 페이지네이션 적용                                                                     
  - `FollowListItemResponse`, `FollowListResponse` DTO 생성
  - `FollowingRepository` 팔로워/팔로잉 목록 조회 쿼리 추가                                                     
                  
  ## 📸 스크린샷(선택)                                                                                          
                  
                                                                                                                
  ## 📝 기타