### PR TITLE
[Feat] 종목리스트 조회 데이터에 거래량 추가

### DIFF
--- a/src/main/java/org/solmate/domain/stock/dto/response/StockListResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockListResponse.java
@@ -13,7 +13,8 @@ public record StockListResponse(
         SectorType sectorType,
         long currentPrice,
         double changeRate,
-        BigDecimal total
+        BigDecimal total,
+        long volume
 ) {
     public static StockListResponse ofWithClosePrice(Stock stock, long closePrice) {
         return new StockListResponse(
@@ -23,19 +24,23 @@ public record StockListResponse(
                 stock.getSectorType(),
                 closePrice,
                 0.0,
-                stock.getTotal()
+                stock.getTotal(),
+                0L
         );
     }
 
     public static StockListResponse of(Stock stock, Map<Object, Object> redisInfo) {
         long cur = 0;
         double chgRate = 0.0;
+        long vol = 0;
 
         if (redisInfo != null && !redisInfo.isEmpty()) {
             String curStr = (String) redisInfo.get("cur");
             String chgRateStr = (String) redisInfo.get("chgRate");
+            String volStr = (String) redisInfo.get("vol");
             if (curStr != null && !curStr.isBlank()) cur = Long.parseLong(curStr);
             if (chgRateStr != null && !chgRateStr.isBlank()) chgRate = Double.parseDouble(chgRateStr);
+            if (volStr != null && !volStr.isBlank()) vol = Long.parseLong(volStr);
         }
 
         return new StockListResponse(
@@ -45,7 +50,8 @@ public record StockListResponse(
                 stock.getSectorType(),
                 cur,
                 chgRate,
-                stock.getTotal()
+                stock.getTotal(),
+                vol
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #83 

## 💡 작업 배경
실시간 주식 데이터를 Redis에서 읽어올 때 거래량(vol)까지 포함하도록 응답 구조를 확장했습니다.

## 🧩 작업 내용
변경 파일: StockListResponse.java                                                                                                                      
작업 내용: 종목 리스트 조회 응답 DTO에 거래량(volume) 필드를 추가했습니다.                                                                                        
세부 변경사항:                                                                                                                                                           
  1. StockListResponse record에 volume 필드 추가                                                                                                         
    - 기존: currentPrice, changeRate, total
    - 변경: currentPrice, changeRate, total, volume (타입: long)                                                                                         
  2. ofWithClosePrice() 팩토리 메서드 수정
    - 장 마감 가격 기반 생성 시 거래량은 0L로 초기화                                                                                                     
  3. of() 팩토리 메서드 수정                                                                                                                             
    - Redis에서 실시간 데이터를 조회할 때 "vol" 키로 거래량 값을 파싱                                                                                    
    - Redis 데이터가 없거나 비어있을 경우 0으로 기본값 처리                                                                                              
    - 정상 데이터가 있을 경우 Long.parseLong(volStr)으로 변환하여 반환   

## 📸 스크린샷(선택)


## 📝 기타
