### PR TITLE
[Feat] 체결 완료 시 팔로워 거래 알림 전송 구현

### DIFF
--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -1,5 +1,6 @@
 package org.solmate.domain.notification.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.solmate.common.exception.GeneralException;
@@ -12,11 +13,13 @@ import org.solmate.domain.notification.enums.NotificationType;
 import org.solmate.domain.notification.repository.NotificationRepository;
 import org.solmate.domain.social.dto.response.MentoringResponse;
 import org.solmate.domain.social.enums.MentoringStatus;
+import org.solmate.domain.social.repository.FollowingRepository;
 import org.solmate.domain.social.repository.MentoringRepository;
 import org.solmate.domain.social.service.MentoringService;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -33,6 +36,7 @@ public class NotificationService {
     private final MentoringService mentoringService;
     private final MentoringRepository mentoringRepository;
     private final UserRepository userRepository;
+    private final FollowingRepository followingRepository;
     private final ObjectMapper objectMapper;
 
     /**
@@ -148,6 +152,27 @@ public class NotificationService {
         }
 
         notification.markAsRead();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveTradeNotifications(User trader, String stockName, String side, BigDecimal price) {
+        List<User> followers = followingRepository.findAllFollowersByFollowingId(trader.getId());
+        if (followers.isEmpty()) return;
+
+        String sideText = "BUY".equals(side) ? "매수" : "매도";
+        String content = String.format("%s님이 %s을(를) %s원에 %s했습니다.",
+            trader.getNickname(), stockName, price.toPlainString(), sideText);
+
+        List<Notification> notifications = followers.stream()
+            .map(follower -> Notification.builder()
+                .user(follower)
+                .notificationType(NotificationType.TRADE)
+                .category(NotificationCategory.TRADING)
+                .content(content)
+                .build())
+            .toList();
+
+        notificationRepository.saveAll(notifications);
     }
 
     public NotificationCountResponse getUnreadCount(Long userId) {

--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package org.solmate.domain.notification.service;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
@@ -155,7 +156,7 @@ public class NotificationService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveTradeNotifications(User trader, String stockName, String side, BigDecimal price) {
+    public void saveTradeNotifications(User trader, Long tradeHistoryId, String stockCode, String stockName, String side, BigDecimal price, BigDecimal quantity) {
         List<User> followers = followingRepository.findAllFollowersByFollowingId(trader.getId());
         if (followers.isEmpty()) return;
 
@@ -163,12 +164,30 @@ public class NotificationService {
         String content = String.format("%s님이 %s을(를) %s원에 %s했습니다.",
             trader.getNickname(), stockName, price.toPlainString(), sideText);
 
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsString(Map.of(
+                "targetUserId", trader.getId(),
+                "targetUserName", trader.getNickname(),
+                "tradeHistoryId", tradeHistoryId,
+                "stockCode", stockCode,
+                "stockName", stockName,
+                "side", side,
+                "price", price,
+                "quantity", quantity
+            ));
+        } catch (Exception e) {
+            payload = null;
+        }
+
+        String finalPayload = payload;
         List<Notification> notifications = followers.stream()
             .map(follower -> Notification.builder()
                 .user(follower)
                 .notificationType(NotificationType.TRADE)
                 .category(NotificationCategory.TRADING)
                 .content(content)
+                .payload(finalPayload)
                 .build())
             .toList();
 

--- a/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/FollowingRepository.java
@@ -34,4 +34,8 @@ public interface FollowingRepository extends JpaRepository<Following, Long> {
     // 유저 목록에서 isFollowing 여부를 Set.contains() O(1)로 일괄 확인하기 위해 사용
     @Query("SELECT f.following.id FROM Following f WHERE f.follower.id = :followerId")
     Set<Long> findFollowingIdsByFollowerId(@Param("followerId") Long followerId);
+
+    // 나를 팔로우하는 유저 목록 조회 (체결 알림 전송용)
+    @Query("SELECT f.follower FROM Following f WHERE f.following.id = :followingId")
+    List<User> findAllFollowersByFollowingId(@Param("followingId") Long followingId);
 }

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -12,6 +12,7 @@ import org.solmate.domain.notification.entity.Notification;
 import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.enums.NotificationType;
 import org.solmate.domain.notification.repository.NotificationRepository;
+import org.solmate.domain.notification.service.NotificationService;
 import org.solmate.domain.trade.entity.Holdings;
 import org.solmate.domain.trade.entity.TradeHistory;
 import org.solmate.domain.trade.enums.TradeStatus;
@@ -44,6 +45,7 @@ public class OrderMatchingService {
     private final AccountRepository accountRepository;
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
+    private final NotificationService notificationService;
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -111,11 +113,14 @@ public class OrderMatchingService {
                     tradeDiaryRepository.findByTradeHistoryId(orderId)
                         .ifPresent(diary -> diary.updateStatus(TradeDiaryStatus.FILLED));
 
+                    // Redis ZSet에서 제거
+                    redisTemplate.opsForZSet().remove(key, json);
+
                     // 알림 저장
                     saveNotification(user, tradeHistory, currentPrice, quantity);
 
-                    // Redis ZSet에서 제거
-                    redisTemplate.opsForZSet().remove(key, json);
+                    // 팔로워 알림 저장
+                    notificationService.saveTradeNotifications(user, tradeHistory.getStock().getStockName(), "BUY", currentPrice);
 
                     log.info("매수 체결 완료 - orderId: {}, ticker: {}, price: {}, quantity: {}", orderId, ticker, currentPrice, quantity);
 
@@ -172,11 +177,14 @@ public class OrderMatchingService {
                     tradeDiaryRepository.findByTradeHistoryId(orderId)
                         .ifPresent(diary -> diary.updateStatus(TradeDiaryStatus.FILLED));
 
+                    // Redis ZSet에서 제거
+                    redisTemplate.opsForZSet().remove(key, json);
+
                     // 알림 저장
                     saveNotification(user, tradeHistory, currentPrice, quantity);
 
-                    // Redis ZSet에서 제거
-                    redisTemplate.opsForZSet().remove(key, json);
+                    // 팔로워 알림 저장
+                    notificationService.saveTradeNotifications(user, tradeHistory.getStock().getStockName(), "SELL", currentPrice);
 
                     log.info("매도 체결 완료 - orderId: {}, ticker: {}, price: {}, quantity: {}", orderId, ticker, currentPrice, quantity);
 

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -120,7 +120,7 @@ public class OrderMatchingService {
                     saveNotification(user, tradeHistory, currentPrice, quantity);
 
                     // 팔로워 알림 저장
-                    notificationService.saveTradeNotifications(user, tradeHistory.getStock().getStockName(), "BUY", currentPrice);
+                    notificationService.saveTradeNotifications(user, tradeHistory.getId(), ticker, tradeHistory.getStock().getStockName(), "BUY", currentPrice, quantity);
 
                     log.info("매수 체결 완료 - orderId: {}, ticker: {}, price: {}, quantity: {}", orderId, ticker, currentPrice, quantity);
 
@@ -184,7 +184,7 @@ public class OrderMatchingService {
                     saveNotification(user, tradeHistory, currentPrice, quantity);
 
                     // 팔로워 알림 저장
-                    notificationService.saveTradeNotifications(user, tradeHistory.getStock().getStockName(), "SELL", currentPrice);
+                    notificationService.saveTradeNotifications(user, tradeHistory.getId(), ticker, tradeHistory.getStock().getStockName(), "SELL", currentPrice, quantity);
 
                     log.info("매도 체결 완료 - orderId: {}, ticker: {}, price: {}, quantity: {}", orderId, ticker, currentPrice, quantity);
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #94 

## 💡 작업 배경
체결이 완료됐을 때 해당 유저를 팔로우하는 사람들에게 거래 내역을 알림으로 전달하는 기능이 필요하여 구현했습니다.

## 🧩 작업 내용
  - FollowingRepository: 나를 팔로우하는 유저 목록 조회 쿼리 추가
  - NotificationService: 팔로워 알림 저장 메서드 추가
    - @Transactional(REQUIRES_NEW)로 체결 트랜잭션과 분리
    - 팔로워 수만큼 알림을 saveAll()로 배치 insert 처리
    - payload에 거래 상세 정보 포함
      (targetUserId, targetUserName, tradeHistoryId, stockCode, stockName, side, price, quantity)
  - OrderMatchingService: 체결 완료 후 팔로워 알림 호출 추가
    - Redis ZSet 제거 후 알림 저장 순서로 처리
      (중복 체결 방지 + 알림 저장 지연이 체결에 영향 없도록)
    - 매수/매도 각각 적용


