### PR TITLE
[RENAME] v1을 api 엔드포인트에서 제거

### DIFF
--- a/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/solmate/domain/notification/controller/NotificationController.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Notification", description = "알림 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/notifications")
+@RequestMapping("/api/notifications")
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/src/main/java/org/solmate/domain/social/controller/FollowingController.java
+++ b/src/main/java/org/solmate/domain/social/controller/FollowingController.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Follow", description = "팔로우 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/follows")
+@RequestMapping("/api/follows")
 public class FollowingController {
 
     private final FollowingService followingService;

--- a/src/main/java/org/solmate/domain/social/controller/MentoringController.java
+++ b/src/main/java/org/solmate/domain/social/controller/MentoringController.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Mentoring", description = "멘토링 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 public class MentoringController {
 
     private final MentoringService mentoringService;

--- a/src/main/java/org/solmate/domain/social/controller/UserListController.java
+++ b/src/main/java/org/solmate/domain/social/controller/UserListController.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "UserList", description = "유저 목록 / 프로필 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/users")
 public class UserListController {
 
     private final UserListService userListService;

--- a/src/main/java/org/solmate/domain/trade/controller/TradeOrderController.java
+++ b/src/main/java/org/solmate/domain/trade/controller/TradeOrderController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Trade", description = "주문 내역 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 public class TradeOrderController {
 
     private final TradeOrderService tradeOrderService;


### PR DESCRIPTION
## #️⃣  관련 이슈                                                                                               
  - closed #102                                                                                                 
                                                                                                                
  ## 💡 작업 배경                                                                                               
  API 엔드포인트 경로에 불필요하게 포함된 버전 정보(`v1`)를 제거하여 경로 일관성을 맞추기 위함                  
                                                                                                                
  ## 🧩 작업 내용
  - `NotificationController`: `/api/v1/notifications` → `/api/notifications`                                    
  - `FollowingController`: `/api/v1/follows` → `/api/follows`
  - `UserListController`: `/api/v1/users` → `/api/users`                                                        
  - `TradeOrderController`: `/api/v1` → `/api`
  - `MentoringController`: `/api/v1` → `/api`                                                                   
                                                                                                                
  ## 📸 스크린샷(선택)
  없음                                                                                                          
                  
  ## 📝 기타
  없음