### PR TITLE
[Refactor] 계좌 조회 api 타인도 가능하도록 수정

### DIFF
--- a/src/main/java/org/solmate/domain/account/controller/AccountController.java
+++ b/src/main/java/org/solmate/domain/account/controller/AccountController.java
@@ -8,6 +8,7 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "Account", description = "내 계좌 API")
+@Tag(name = "Account", description = "계좌 요약 API (본인·타인 조회)")
 @RestController
 @RequestMapping("/api/account")
 @RequiredArgsConstructor
@@ -26,7 +27,7 @@ public class AccountController {
     @Operation(
             summary = "내 계좌 요약 조회",
             description = """
-                    보유 총 자산·현금·종목 수·수익률 카드와 종목 비중(도넛 차트) 데이터를 한 번에 조회합니다.
+                    로그인한 사용자 본인의 보유 총 자산·현금·종목 수·수익률 카드와 종목 비중(도넛 차트) 데이터를 한 번에 조회합니다.
 
                     **클라이언트 권장:** 내 계좌 화면에서는 약 10초 간격 폴링으로 갱신해도 무방합니다. 주문·체결 등 거래 직후에는 즉시 재조회하여 수치를 맞추는 것을 권장합니다.
 
@@ -34,9 +35,25 @@ public class AccountController {
     @GetMapping("/summary")
     public ResponseEntity<ApiResponse<AccountSummaryResponse>> getSummary(
             @AuthenticationPrincipal Long userId) {
+        return accountSummaryResponse(userId);
+    }
+
+    @Operation(
+            summary = "타인 계좌 요약 조회",
+            description = """
+                    특정 사용자의 계좌 요약을 조회합니다. 응답 스키마는 `GET /api/account/summary`(본인)와 동일합니다.
+
+                    보유 종목 API(`GET /api/holdings/{userId}`)와 동일하게 프로필·포트폴리오 탭 등에서 타인 정보 표시에 사용할 수 있습니다.""")
+    @GetMapping("/summary/{userId}")
+    public ResponseEntity<ApiResponse<AccountSummaryResponse>> getOtherUserSummary(
+            @PathVariable Long userId) {
+        return accountSummaryResponse(userId);
+    }
+
+    private ResponseEntity<ApiResponse<AccountSummaryResponse>> accountSummaryResponse(Long targetUserId) {
         ResponseEntity<ApiResponse<AccountSummaryResponse>> entity = ApiResponse.success(
                 SuccessStatus.ACCOUNT_SUMMARY_SUCCESS,
-                accountService.getSummary(userId));
+                accountService.getSummary(targetUserId));
         return ResponseEntity.status(entity.getStatusCode())
                 .cacheControl(CacheControl.noStore().mustRevalidate())
                 .body(entity.getBody());


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #106

## 💡 작업 배경
계좌 조회 api를 타인 프로필에서도 사용할 수 있어야 하지만 로그인한 유저에 대해서만 사용할 수 있었음.

## 🧩 작업 내용

• AccountController.java
    • getOtherUserSummary(@PathVariable Long userId) 추가
    • 본인/타인 공통 처리용 accountSummaryResponse(Long targetUserId) private 메서드로 분리
    • Swagger: 타인용 설명 + holdings와 같이 프로필·포트폴리오에 쓸 수 있다고 명시
    • @Tag 설명을 “본인·타인 조회”로 수정

## 📸 스크린샷(선택)


## 📝 기타
