### PR TITLE
[Refactor] 멘토링 취소 api 수정

### DIFF
--- a/src/main/java/org/solmate/domain/social/controller/MentoringController.java
+++ b/src/main/java/org/solmate/domain/social/controller/MentoringController.java
@@ -44,16 +44,16 @@ public class MentoringController {
 
     /**
      * 멘토링 취소 (멘티만 가능)
-     * - PENDING(신청 대기) 또는 ACCEPTED(수락된 관계) 상태 모두 취소 가능
-     * - 멘토가 호출하면 서비스 레이어에서 403 반환
+     * - ACCEPTED(수락된 관계) 상태만 취소 가능
+     * - mentorUserId 기반으로 관계를 조회하므로 프론트에서 relationId 불필요
      */
     @Operation(summary = "멘토링 취소")
-    @DeleteMapping("/mentor-requests/{relationId}")
+    @DeleteMapping("/mentor-requests/{mentorUserId}")
     public ResponseEntity<ApiResponse<Void>> cancelMentoring(
             @AuthenticationPrincipal Long menteeId,
-            @PathVariable Long relationId
+            @PathVariable Long mentorUserId
     ) {
-        mentoringService.cancelMentoring(menteeId, relationId);
+        mentoringService.cancelMentoring(menteeId, mentorUserId);
         return ApiResponse.success(SuccessStatus.MENTORING_CANCEL_SUCCESS, null);
     }
 }

--- a/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
@@ -32,4 +32,8 @@ public interface MentoringRepository extends JpaRepository<MentoringRelation, Lo
     // 결과로 mentorId → UserMentoringStatus 맵을 구성하여 유저별 상태를 O(1)로 확인
     @Query("SELECT m FROM MentoringRelation m WHERE m.mentee.id = :menteeId AND m.status IN :statuses")
     List<MentoringRelation> findByMenteeIdAndStatusIn(@Param("menteeId") Long menteeId, @Param("statuses") List<MentoringStatus> statuses);
+
+    // 멘토링 취소 시 (menteeId, mentorId)로 관계 조회
+    @Query("SELECT m FROM MentoringRelation m WHERE m.mentee.id = :menteeId AND m.mentor.id = :mentorId AND m.status IN :statuses")
+    List<MentoringRelation> findByMenteeIdAndMentorIdAndStatusIn(@Param("menteeId") Long menteeId, @Param("mentorId") Long mentorId, @Param("statuses") List<MentoringStatus> statuses);
 }

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -133,18 +133,16 @@ public class MentoringService {
 
     /**
      * 멘토링 취소 (멘티만 가능)
-     * - PENDING(신청 대기 중) 또는 ACCEPTED(수락된 관계) 상태 모두 취소 가능
-     * - relation의 mentee_id가 현재 사용자와 다르면 403 → 멘토가 호출해도 여기서 차단됨
+     * - ACCEPTED(수락된 관계) 상태만 취소 가능
+     * - mentorUserId 기반으로 관계를 조회하므로 프론트에서 relationId 불필요
      */
     @Transactional
-    public void cancelMentoring(Long menteeId, Long relationId) {
-        MentoringRelation relation = mentoringRepository.findById(relationId)
+    public void cancelMentoring(Long menteeId, Long mentorUserId) {
+        MentoringRelation relation = mentoringRepository
+                .findByMenteeIdAndMentorIdAndStatusIn(menteeId, mentorUserId, List.of(MentoringStatus.ACCEPTED))
+                .stream()
+                .findFirst()
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MENTORING_RELATION_NOT_FOUND));
-
-        // 본인(멘티)의 관계인지 확인 → 멘토가 호출하면 mentee_id != menteeId 이므로 차단
-        if (!relation.getMentee().getId().equals(menteeId)) {
-            throw new GeneralException(ErrorStatus.MENTORING_UNAUTHORIZED);
-        }
 
         // ACCEPTED 상태(이미 맺어진 멘토-멘티 관계)만 취소 가능
         if (relation.getStatus() != MentoringStatus.ACCEPTED) {


### PR DESCRIPTION
  ## #️⃣  관련 이슈
  - closed #109                                                                                                   
                                                                                                                
  ## 💡 작업 배경
  기존 멘토링 취소 API(`DELETE /api/mentor-requests/{relationId}`)는 relationId를 path variable로 받는          
  구조였으나,                                                                                         
  유저 목록 API 응답에 relationId가 포함되어 있지 않아 프론트에서 취소 요청이 불가능한 상태였음.                
  mentorUserId 기반으로 변경하면 프론트는 항상 알고 있는 userId만으로 취소 요청이 가능하고,     
  향후 다른 페이지(멘토/멘티 페이지 등)에서도 별도 처리 없이 재사용 가능.                                       
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - `DELETE /api/mentor-requests/{relationId}` → `DELETE /api/mentor-requests/{mentorUserId}` 엔드포인트 변경   
  - `MentoringRepository`에 `findByMenteeIdAndMentorIdAndStatusIn()` 쿼리 메서드 추가                           
  - `MentoringService.cancelMentoring()`에서 (menteeId, mentorUserId)로 relation 조회 후 삭제하도록 수정 (추가  
  DB 쿼리 없음)                                                                                                 
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
                  
  ## 📝 기타 