### PR TITLE
[Refactor] 캔들 데이터 적재방식 변경

### DIFF
--- a/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
@@ -1,6 +1,7 @@
 package org.solmate.domain.stock.controller;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -9,6 +10,7 @@ import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.stock.repository.StockRepository;
 import org.solmate.domain.stock.service.CandleLoadService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/admin/candles")
 public class CandleLoadController {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private final CandleLoadService candleLoadService;
@@ -49,16 +52,16 @@ public class CandleLoadController {
         log.info("│ [캔들 일괄 적재 시작] 종목={}개, 분봉={}일, 일봉={}일", total, minuteDays, dailyDays);
         log.info("└─────────────────────────────────────────────");
 
-        String today      = LocalDate.now().format(DATE_FMT);
-        String minuteFrom = LocalDate.now().minusDays(minuteDays).format(DATE_FMT);
-        String dailyFrom  = LocalDate.now().minusDays(dailyDays).format(DATE_FMT);
+        String today      = LocalDate.now(KST).format(DATE_FMT);
+        String minuteFrom = LocalDate.now(KST).minusDays(minuteDays).format(DATE_FMT);
+        String dailyFrom  = LocalDate.now(KST).minusDays(dailyDays).format(DATE_FMT);
 
         int minuteSuccess = 0, minuteFail = 0, dailySuccess = 0, dailyFail = 0;
 
         for (int i = 0; i < codes.size(); i++) {
             String code = codes.get(i);
             log.info("[{}/{}] 적재 중: {}", i + 1, total, code);
-            if (candleLoadService.loadMinuteCandles(code, minuteFrom, today)) minuteSuccess++;
+            if (candleLoadService.loadUnifiedMinuteCandles(code, minuteFrom, today, "U")) minuteSuccess++;
             else minuteFail++;
             if (candleLoadService.loadDailyCandles(code, dailyFrom, today)) dailySuccess++;
             else dailyFail++;
@@ -73,6 +76,58 @@ public class CandleLoadController {
     }
 
     @Operation(
+            summary = "특정 종목 캔들 단건 적재 (t8412, 정규장만)",
+            description = "특정 종목의 분봉/일봉을 LS t8412 API로 적재합니다. 정규장(09:00~15:30)만 제공됩니다. "
+                        + "DB에 이미 존재하는 데이터는 자동으로 스킵됩니다."
+    )
+    @PostMapping("/stock/{stockCode}")
+    public ResponseEntity<ApiResponse<Void>> loadStock(
+            @PathVariable String stockCode,
+            @RequestParam String sdate,
+            @RequestParam String edate,
+            @RequestParam(defaultValue = "true") boolean minute,
+            @RequestParam(defaultValue = "true") boolean daily
+    ) {
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [종목 캔들 적재 시작] stockCode={}, {}~{}, 분봉={}, 일봉={}",
+                stockCode, sdate, edate, minute, daily);
+        log.info("└─────────────────────────────────────────────");
+
+        if (minute) {
+            boolean ok = candleLoadService.loadMinuteCandles(stockCode, sdate, edate);
+            log.info("│ 분봉 적재 {}", ok ? "완료" : "실패");
+        }
+        if (daily) {
+            boolean ok = candleLoadService.loadDailyCandles(stockCode, sdate, edate);
+            log.info("│ 일봉 적재 {}", ok ? "완료" : "실패");
+        }
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+
+    @Operation(
+            summary = "특정 종목 통합 분봉 적재 (t8452, NXT 프리/에프터 포함)",
+            description = "t8452 API로 KRX+NXT 통합 1분봉을 적재합니다. "
+                        + "exchgubun: K=KRX, N=NXT, U=통합(기본). "
+                        + "N 또는 U 선택 시 프리마켓(08:00~08:50), 에프터마켓(15:40~20:00) 포함 여부 확인 가능. "
+                        + "DB에 이미 존재하는 데이터는 자동으로 스킵됩니다."
+    )
+    @PostMapping("/stock/{stockCode}/unified")
+    public ResponseEntity<ApiResponse<Void>> loadStockUnified(
+            @PathVariable String stockCode,
+            @RequestParam String sdate,
+            @RequestParam String edate,
+            @RequestParam(defaultValue = "U") String exchgubun
+    ) {
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [통합분봉 적재 시작] stockCode={}, {}~{}, exchgubun={}", stockCode, sdate, edate, exchgubun);
+        log.info("└─────────────────────────────────────────────");
+
+        boolean ok = candleLoadService.loadUnifiedMinuteCandles(stockCode, sdate, edate, exchgubun);
+        log.info("│ 통합분봉 적재 {}", ok ? "완료" : "실패");
+        return ApiResponse.success(SuccessStatus.SUCCESS_200);
+    }
+
+    @Operation(
             summary = "특정 종목 캔들 재적재",
             description = "실패한 종목 코드 목록을 받아 분봉/일봉을 재시도합니다."
     )
@@ -82,9 +137,9 @@ public class CandleLoadController {
             @RequestParam(defaultValue = "30") int minuteDays,
             @RequestParam(defaultValue = "3650") int dailyDays
     ) {
-        String today      = LocalDate.now().format(DATE_FMT);
-        String minuteFrom = LocalDate.now().minusDays(minuteDays).format(DATE_FMT);
-        String dailyFrom  = LocalDate.now().minusDays(dailyDays).format(DATE_FMT);
+        String today      = LocalDate.now(KST).format(DATE_FMT);
+        String minuteFrom = LocalDate.now(KST).minusDays(minuteDays).format(DATE_FMT);
+        String dailyFrom  = LocalDate.now(KST).minusDays(dailyDays).format(DATE_FMT);
 
         log.info("┌─────────────────────────────────────────────");
         log.info("│ [캔들 재적재 시작] 종목={}개", stockCodes.size());
@@ -95,7 +150,7 @@ public class CandleLoadController {
         for (int i = 0; i < stockCodes.size(); i++) {
             String code = stockCodes.get(i);
             log.info("[{}/{}] 재적재 중: {}", i + 1, stockCodes.size(), code);
-            if (candleLoadService.loadMinuteCandles(code, minuteFrom, today)) minuteSuccess++;
+            if (candleLoadService.loadUnifiedMinuteCandles(code, minuteFrom, today, "U")) minuteSuccess++;
             else minuteFail++;
             if (candleLoadService.loadDailyCandles(code, dailyFrom, today)) dailySuccess++;
             else dailyFail++;

--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -55,48 +55,50 @@ public class StockController {
 
     @Operation(
         summary = "분봉 조회",
-        description = "unit=1: 1분봉(DB 직접 조회) / unit=5|30|60: DB 1분봉 집계 + Redis 현재 봉. 오늘 장 시간(09:00~15:30) 기준."
+        description = "unit=1: 1분봉 / unit=5|30|60: DB 1분봉 집계 + Redis 현재 봉. " +
+                      "days 미지정 시 unit별 기본값 적용 (1분=5일, 5분=20일, 30분=60일, 60분=90일)"
     )
     @GetMapping("/{stockCode}/candles/minute")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getMinuteCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "1") int unit) {
+            @RequestParam(defaultValue = "1") int unit,
+            @RequestParam(defaultValue = "0") int days) {
         if (unit != 1 && unit != 5 && unit != 30 && unit != 60) {
             throw new org.solmate.common.exception.GeneralException(
                     org.solmate.common.status.ErrorStatus.INVALID_CANDLE_UNIT);
         }
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMinuteCandles(stockCode, unit));
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMinuteCandles(stockCode, unit, days));
     }
 
-    @Operation(summary = "일봉 조회", description = "days 파라미터로 조회 기간 지정 (기본 30일)")
+    @Operation(summary = "일봉 조회", description = "days 미지정 시 365일")
     @GetMapping("/{stockCode}/candles/daily")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getDailyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "30") int days) {
+            @RequestParam(defaultValue = "365") int days) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getDailyCandles(stockCode, days));
     }
 
-    @Operation(summary = "주봉 조회", description = "weeks 파라미터로 조회 기간 지정 (기본 52주). DB 일봉 집계.")
+    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). DB 일봉 집계.")
     @GetMapping("/{stockCode}/candles/weekly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getWeeklyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "52") int weeks) {
+            @RequestParam(defaultValue = "260") int weeks) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyCandles(stockCode, weeks));
     }
 
-    @Operation(summary = "월봉 조회", description = "months 파라미터로 조회 기간 지정 (기본 60개월). DB 일봉 집계.")
+    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). DB 일봉 집계.")
     @GetMapping("/{stockCode}/candles/monthly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getMonthlyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "60") int months) {
+            @RequestParam(defaultValue = "120") int months) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyCandles(stockCode, months));
     }
 
-    @Operation(summary = "년봉 조회", description = "years 파라미터로 조회 기간 지정 (기본 10년). DB 일봉 집계.")
+    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. DB 일봉 집계.")
     @GetMapping("/{stockCode}/candles/yearly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getYearlyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "10") int years) {
+            @RequestParam(defaultValue = "20") int years) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyCandles(stockCode, years));
     }
 

--- a/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
@@ -1,9 +1,16 @@
 package org.solmate.domain.stock.scheduler;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 
 import org.solmate.domain.stock.service.CandleAccumulatorService;
+import org.solmate.domain.stock.service.CandleLoadService;
 import org.solmate.external.ls.websocket.LsWebSocketClient;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -13,11 +20,16 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@EnableAsync
 @EnableScheduling
 @RequiredArgsConstructor
 public class CandleScheduler {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
     private final CandleAccumulatorService candleAccumulatorService;
+    private final CandleLoadService candleLoadService;
     private final LsWebSocketClient lsWebSocketClient;
 
     // 매 분 00초 - 1분봉 DB 저장
@@ -58,5 +70,36 @@ public class CandleScheduler {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
         log.debug("일봉 스케줄러 실행");
         codes.forEach(candleAccumulatorService::flushDailyCandle);
+    }
+
+    // 프리마켓 종료 후 08:51 - 어제 에프터마켓 + 오늘 프리마켓 백필 (ON CONFLICT DO NOTHING)
+    @Async
+    @Scheduled(cron = "0 51 8 * * MON-FRI")
+    public void backfillCandles() {
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        if (codes.isEmpty()) return;
+
+        String yesterday = lastTradingDay(LocalDate.now(KST)).format(DATE_FMT);
+        String today     = LocalDate.now(KST).format(DATE_FMT);
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [분봉 백필 시작] 종목={}개, {}~{}", codes.size(), yesterday, today);
+        log.info("└─────────────────────────────────────────────");
+
+        int success = 0, fail = 0;
+        for (String code : codes) {
+            if (candleLoadService.loadUnifiedMinuteCandles(code, yesterday, today, "U")) success++;
+            else fail++;
+        }
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [분봉 백필 완료] 성공={}건, 실패={}건", success, fail);
+        log.info("└─────────────────────────────────────────────");
+    }
+
+    // 직전 영업일 계산 (월요일이면 금요일, 그 외는 어제)
+    private LocalDate lastTradingDay(LocalDate date) {
+        LocalDate prev = date.minusDays(1);
+        if (prev.getDayOfWeek() == DayOfWeek.SUNDAY)   return prev.minusDays(1); // 일 → 금
+        if (prev.getDayOfWeek() == DayOfWeek.SATURDAY) return prev.minusDays(1); // 토 → 금
+        return prev;
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -3,6 +3,7 @@ package org.solmate.domain.stock.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ public class CandleAccumulatorService {
             KEY_1MIN, KEY_5MIN, KEY_30MIN, KEY_60MIN, KEY_1DAY
     );
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final StringRedisTemplate redisTemplate;
@@ -44,7 +46,7 @@ public class CandleAccumulatorService {
 
     // 체결 수신 시 정규장 여부 확인 후 모든 봉 Redis 키 동시 업데이트
     public void accumulate(LsWsStockResponse.Body body) {
-        LocalTime now = LocalTime.now();
+        LocalTime now = LocalTime.now(KST);
         if (now.isBefore(MARKET_OPEN) || now.isAfter(MARKET_CLOSE)) return;
 
         String stockCode = body.shcode();
@@ -69,7 +71,7 @@ public class CandleAccumulatorService {
                     "low",       String.valueOf(price),
                     "close",     String.valueOf(price),
                     "volume",    String.valueOf(cvolume),
-                    "startTime", LocalDateTime.now().format(TIME_FORMATTER)
+                    "startTime", LocalDateTime.now(KST).format(TIME_FORMATTER)
             ));
         } else {
             long high   = Math.max(price, Long.parseLong((String) current.get("high")));
@@ -115,7 +117,7 @@ public class CandleAccumulatorService {
         if (data.isEmpty()) return;
 
         try {
-            LocalDateTime candleTime = LocalDate.now().atStartOfDay();
+            LocalDateTime candleTime = LocalDate.now(KST).atStartOfDay();
 
             DailyCandle candle = DailyCandle.builder()
                     .stockCode(stockCode)
@@ -157,7 +159,7 @@ public class CandleAccumulatorService {
             String startTime = (String) data.get("startTime");
             LocalDateTime candleTime = (startTime != null)
                     ? LocalDateTime.parse(startTime, TIME_FORMATTER)
-                    : LocalDateTime.now().withSecond(0).withNano(0);
+                    : LocalDateTime.now(KST).withSecond(0).withNano(0);
 
             MinuteCandle candle = MinuteCandle.builder()
                     .stockCode(stockCode)

--- a/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
@@ -17,6 +17,7 @@ import org.solmate.domain.stock.entity.MinuteCandle;
 import org.solmate.external.ls.client.LsApiClient;
 import org.solmate.external.ls.dto.response.LsDailyCandleResponse;
 import org.solmate.external.ls.dto.response.LsMinuteCandleResponse;
+import org.solmate.external.ls.dto.response.LsUnifiedMinuteCandleResponse;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -64,6 +65,72 @@ public class CandleLoadService {
     }
 
     /**
+     * t8452 통합 1분봉 과거 데이터 적재 (KRX+NXT, 프리/에프터마켓 포함)
+     * exchgubun: "K"=KRX, "N"=NXT, "U"=통합
+     */
+    public boolean loadUnifiedMinuteCandles(String stockCode, String sdate, String edate, String exchgubun) {
+        List<MinuteCandle> candles = new ArrayList<>();
+
+        try {
+            LsUnifiedMinuteCandleResponse response =
+                    lsApiClient.getUnifiedMinuteCandles(stockCode, sdate, edate, exchgubun);
+            collectUnifiedMinuteCandles(response, stockCode, candles);
+
+            while (response.hasNext()) {
+                sleep();
+                String ctsDate = response.t8452OutBlock().cts_date();
+                String ctsTime = response.t8452OutBlock().cts_time();
+                response = lsApiClient.getUnifiedMinuteCandlesContinue(
+                        stockCode, sdate, edate, ctsDate, ctsTime, exchgubun);
+                collectUnifiedMinuteCandles(response, stockCode, candles);
+            }
+
+            saveMinuteCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [통합분봉 적재 실패] stockCode={}, exchgubun={} - {}", stockCode, exchgubun, e.getMessage());
+            return false;
+        }
+    }
+
+    private void collectUnifiedMinuteCandles(LsUnifiedMinuteCandleResponse response, String stockCode,
+                                              List<MinuteCandle> candles) {
+        if (response.candles().isEmpty()) return;
+
+        LsUnifiedMinuteCandleResponse.OutBlock1 first = response.candles().get(0);
+        LsUnifiedMinuteCandleResponse.OutBlock1 last  = response.candles().get(response.candles().size() - 1);
+        log.info("  [t8452 응답] 건수={}, 첫 봉={} {}, 마지막 봉={} {}",
+                response.candles().size(), first.date(), first.time(), last.date(), last.time());
+
+        // NXT 세션 시간 로깅 (첫 페이지에만 출력됨)
+        if (response.t8452OutBlock() != null) {
+            log.info("  [NXT 세션] 프리마켓={}-{}, 에프터마켓={}-{}",
+                    response.t8452OutBlock().nxt_fm_s_time(), response.t8452OutBlock().nxt_fm_e_time(),
+                    response.t8452OutBlock().nxt_am_s_time(), response.t8452OutBlock().nxt_am_e_time());
+        }
+
+        for (LsUnifiedMinuteCandleResponse.OutBlock1 item : response.candles()) {
+            try {
+                String timeStr = item.time().length() >= 6 ? item.time().substring(0, 6) : item.time();
+                LocalDateTime candleTime = LocalDateTime.parse(item.date() + timeStr, DATETIME_FMT);
+
+                candles.add(MinuteCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                log.warn("[통합분봉 파싱 실패] stockCode={}, date={}, time={}", stockCode, item.date(), item.time());
+            }
+        }
+    }
+
+    /**
      * 일봉 과거 데이터 적재
      * - sdate ~ edate 범위 (최근 365일 기준으로 호출)
      * - 연속조회로 전체 데이터 수집
@@ -105,9 +172,16 @@ public class CandleLoadService {
                                        List<MinuteCandle> candles) {
         if (response.t8412OutBlock1() == null) return;
 
-        for (LsMinuteCandleResponse.OutBlock1 item : response.t8412OutBlock1()) {
+        List<LsMinuteCandleResponse.OutBlock1> items = response.t8412OutBlock1();
+        if (!items.isEmpty()) {
+            LsMinuteCandleResponse.OutBlock1 first = items.get(0);
+            LsMinuteCandleResponse.OutBlock1 last  = items.get(items.size() - 1);
+            log.info("  [LS API 응답] 건수={}, 첫 봉={} {}, 마지막 봉={} {}",
+                    items.size(), first.date(), first.time(), last.date(), last.time());
+        }
+
+        for (LsMinuteCandleResponse.OutBlock1 item : items) {
             try {
-                // time 필드: HHMMSS 형식 (6자리) → 앞 4자리만 사용(HHMM)
                 String timeStr = item.time().length() >= 6 ? item.time().substring(0, 6) : item.time();
                 LocalDateTime candleTime = LocalDateTime.parse(item.date() + timeStr, DATETIME_FMT);
 

--- a/src/main/java/org/solmate/domain/stock/service/CandleService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleService.java
@@ -2,7 +2,7 @@ package org.solmate.domain.stock.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CandleService {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final MinuteCandleRepository minuteCandleRepository;
@@ -34,17 +35,29 @@ public class CandleService {
      * unit=1  → DB minute_candle 직접 조회 + Redis 현재 1분봉
      * unit=5|30|60 → DB 1분봉 집계 + Redis 현재 N분봉
      */
-    public List<CandleResponse> getMinuteCandles(String stockCode, int unit) {
+    public List<CandleResponse> getMinuteCandles(String stockCode, int unit, int days) {
+        int effectiveDays = days > 0 ? days : defaultDaysForUnit(unit);
         if (unit == 1) {
-            return getOneMinuteCandles(stockCode);
+            return getOneMinuteCandles(stockCode, effectiveDays);
         }
-        return getAggregatedMinuteCandles(stockCode, unit);
+        return getAggregatedMinuteCandles(stockCode, unit, effectiveDays);
+    }
+
+    // unit별 기본 조회 일수 (days=0으로 요청 시 적용)
+    private int defaultDaysForUnit(int unit) {
+        return switch (unit) {
+            case 1  -> 5;   // 1분봉:  5 영업일  (~1,950개)
+            case 5  -> 20;  // 5분봉:  20 영업일 (~1,560개)
+            case 30 -> 60;  // 30분봉: 60 영업일 (~780개)
+            case 60 -> 90;  // 60분봉: 90 영업일 (~630개)
+            default -> 5;
+        };
     }
 
     // unit=1: DB minute_candle 직접 조회 + Redis 현재 봉
-    private List<CandleResponse> getOneMinuteCandles(String stockCode) {
-        LocalDateTime from = LocalDate.now().atTime(LocalTime.of(9, 0));
-        LocalDateTime to   = LocalDate.now().atTime(LocalTime.of(15, 30));
+    private List<CandleResponse> getOneMinuteCandles(String stockCode, int days) {
+        LocalDateTime from = LocalDate.now(KST).minusDays(days - 1).atStartOfDay();
+        LocalDateTime to   = LocalDate.now(KST).atTime(23, 59, 59);
 
         List<MinuteCandle> candles = minuteCandleRepository
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
@@ -60,9 +73,9 @@ public class CandleService {
     }
 
     // unit=5|30|60: DB 1분봉을 N분 단위로 집계 + Redis 현재 N분봉
-    private List<CandleResponse> getAggregatedMinuteCandles(String stockCode, int unit) {
-        LocalDateTime from = LocalDate.now().atTime(LocalTime.of(9, 0));
-        LocalDateTime to   = LocalDate.now().atTime(LocalTime.of(15, 30));
+    private List<CandleResponse> getAggregatedMinuteCandles(String stockCode, int unit, int days) {
+        LocalDateTime from = LocalDate.now(KST).minusDays(days - 1).atStartOfDay();
+        LocalDateTime to   = LocalDate.now(KST).atTime(23, 59, 59);
 
         List<MinuteCandle> oneMinCandles = minuteCandleRepository
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
@@ -86,8 +99,8 @@ public class CandleService {
 
     // 일봉 조회 (DB + 오늘 진행 중인 봉 포함)
     public List<CandleResponse> getDailyCandles(String stockCode, int days) {
-        LocalDateTime from = LocalDate.now().minusDays(days).atStartOfDay();
-        LocalDateTime to   = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDateTime from = LocalDate.now(KST).minusDays(days).atStartOfDay();
+        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
 
         List<DailyCandle> candles = dailyCandleRepository
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
@@ -104,22 +117,22 @@ public class CandleService {
 
     // 주봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
     public List<CandleResponse> getWeeklyCandles(String stockCode, int weeks) {
-        LocalDateTime from = LocalDate.now().minusWeeks(weeks).atStartOfDay();
-        LocalDateTime to   = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDateTime from = LocalDate.now(KST).minusWeeks(weeks).atStartOfDay();
+        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
         return aggregateDailyCandles(stockCode, from, to, this::toWeekBucketStart);
     }
 
     // 월봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
     public List<CandleResponse> getMonthlyCandles(String stockCode, int months) {
-        LocalDateTime from = LocalDate.now().minusMonths(months).atStartOfDay();
-        LocalDateTime to   = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDateTime from = LocalDate.now(KST).minusMonths(months).atStartOfDay();
+        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
         return aggregateDailyCandles(stockCode, from, to, this::toMonthBucketStart);
     }
 
     // 년봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
     public List<CandleResponse> getYearlyCandles(String stockCode, int years) {
-        LocalDateTime from = LocalDate.now().minusYears(years).atStartOfDay();
-        LocalDateTime to   = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDateTime from = LocalDate.now(KST).minusYears(years).atStartOfDay();
+        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
         return aggregateDailyCandles(stockCode, from, to, this::toYearBucketStart);
     }
 
@@ -219,13 +232,11 @@ public class CandleService {
         return date.withDayOfYear(1);
     }
 
-    // 장 시작(09:00) 기준 N분 단위 버킷 시작 시각 계산
+    // 절대 분 단위 버킷 시작 시각 계산 (프리/에프터 마켓 포함)
     private LocalDateTime toBucketStart(LocalDateTime candleTime, int unit) {
         int minuteOfDay = candleTime.getHour() * 60 + candleTime.getMinute();
-        int marketOpenMinute = 9 * 60;
-        int offset = minuteOfDay - marketOpenMinute;
-        int bucketOffset = (offset / unit) * unit;
-        return LocalDate.now().atTime(9, 0).plusMinutes(bucketOffset);
+        int bucketMinute = Math.floorDiv(minuteOfDay, unit) * unit;
+        return candleTime.toLocalDate().atTime(bucketMinute / 60, bucketMinute % 60);
     }
 
     // 1분봉 리스트를 하나의 N분봉으로 집계

--- a/src/main/java/org/solmate/external/ls/client/LsApiClient.java
+++ b/src/main/java/org/solmate/external/ls/client/LsApiClient.java
@@ -4,9 +4,11 @@ import org.solmate.external.ls.LsProperties;
 import org.solmate.external.ls.dto.request.LsDailyCandleRequest;
 import org.solmate.external.ls.dto.request.LsMinuteCandleRequest;
 import org.solmate.external.ls.dto.request.LsQuoteRequest;
+import org.solmate.external.ls.dto.request.LsUnifiedMinuteCandleRequest;
 import org.solmate.external.ls.dto.response.LsDailyCandleResponse;
 import org.solmate.external.ls.dto.response.LsMinuteCandleResponse;
 import org.solmate.external.ls.dto.response.LsQuoteResponse;
+import org.solmate.external.ls.dto.response.LsUnifiedMinuteCandleResponse;
 import org.solmate.external.ls.service.LsTokenService;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -60,6 +62,36 @@ public class LsApiClient {
                 .body(LsMinuteCandleRequest.ofContinue(stockCode, sdate, edate, ctsDate, ctsTime))
                 .retrieve()
                 .body(LsMinuteCandleResponse.class);
+    }
+
+    /** t8452: 통합 1분봉 조회 (KRX+NXT, exchgubun: K/N/U) */
+    public LsUnifiedMinuteCandleResponse getUnifiedMinuteCandles(String stockCode, String sdate, String edate,
+                                                                   String exchgubun) {
+        return restClient.post()
+                .uri(lsProperties.getBaseUrl() + "/stock/chart")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", "Bearer " + lsTokenService.getToken())
+                .header("tr_cd", "t8452")
+                .header("tr_cont", "N")
+                .body(LsUnifiedMinuteCandleRequest.of(stockCode, sdate, edate, exchgubun))
+                .retrieve()
+                .body(LsUnifiedMinuteCandleResponse.class);
+    }
+
+    /** t8452: 통합 1분봉 연속 조회 */
+    public LsUnifiedMinuteCandleResponse getUnifiedMinuteCandlesContinue(String stockCode, String sdate, String edate,
+                                                                           String ctsDate, String ctsTime,
+                                                                           String exchgubun) {
+        return restClient.post()
+                .uri(lsProperties.getBaseUrl() + "/stock/chart")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", "Bearer " + lsTokenService.getToken())
+                .header("tr_cd", "t8452")
+                .header("tr_cont", "Y")
+                .header("tr_cont_key", ctsDate + ctsTime)
+                .body(LsUnifiedMinuteCandleRequest.ofContinue(stockCode, sdate, edate, ctsDate, ctsTime, exchgubun))
+                .retrieve()
+                .body(LsUnifiedMinuteCandleResponse.class);
     }
 
     /** t8410: 일봉 조회 (처음 조회) */

--- a/src/main/java/org/solmate/external/ls/dto/request/LsUnifiedMinuteCandleRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/request/LsUnifiedMinuteCandleRequest.java
@@ -1,0 +1,57 @@
+package org.solmate.external.ls.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LsUnifiedMinuteCandleRequest(
+        @JsonProperty("t8452InBlock") InBlock t8452InBlock
+) {
+    public record InBlock(
+            String shcode,
+            int ncnt,
+            int qrycnt,
+            String nday,
+            String sdate,
+            String stime,
+            String edate,
+            String etime,
+            String cts_date,
+            String cts_time,
+            String comp_yn,
+            String exchgubun
+    ) {}
+
+    public static LsUnifiedMinuteCandleRequest of(String shcode, String sdate, String edate, String exchgubun) {
+        return new LsUnifiedMinuteCandleRequest(new InBlock(
+                shcode,
+                1,
+                500,
+                "0",
+                sdate,
+                "000000",
+                edate,
+                "235959",
+                " ",
+                " ",
+                "N",
+                exchgubun
+        ));
+    }
+
+    public static LsUnifiedMinuteCandleRequest ofContinue(String shcode, String sdate, String edate,
+                                                           String ctsDate, String ctsTime, String exchgubun) {
+        return new LsUnifiedMinuteCandleRequest(new InBlock(
+                shcode,
+                1,
+                500,
+                "0",
+                sdate,
+                "000000",
+                edate,
+                "235959",
+                ctsDate,
+                ctsTime,
+                "N",
+                exchgubun
+        ));
+    }
+}

--- a/src/main/java/org/solmate/external/ls/dto/response/LsUnifiedMinuteCandleResponse.java
+++ b/src/main/java/org/solmate/external/ls/dto/response/LsUnifiedMinuteCandleResponse.java
@@ -1,0 +1,43 @@
+package org.solmate.external.ls.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LsUnifiedMinuteCandleResponse(
+        @JsonProperty("t8452OutBlock")  OutBlock t8452OutBlock,
+        @JsonProperty("t8452OutBlock1") List<OutBlock1> t8452OutBlock1
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutBlock(
+            String cts_date,
+            String cts_time,
+            String nxt_fm_s_time,   // NXT 프리마켓 시작 (HHMMSS)
+            String nxt_fm_e_time,   // NXT 프리마켓 종료 (HHMMSS)
+            String nxt_am_s_time,   // NXT 에프터마켓 시작 (HHMMSS)
+            String nxt_am_e_time    // NXT 에프터마켓 종료 (HHMMSS)
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutBlock1(
+            String date,
+            String time,
+            long open,
+            long high,
+            long low,
+            long close,
+            long jdiff_vol
+    ) {}
+
+    public boolean hasNext() {
+        return t8452OutBlock != null
+                && t8452OutBlock.cts_date() != null
+                && !t8452OutBlock.cts_date().isBlank();
+    }
+
+    public List<OutBlock1> candles() {
+        return t8452OutBlock1 != null ? t8452OutBlock1 : List.of();
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #108 

## 💡 작업 배경
- UTC 서버 환경에서 KST 타임존 미설정으로 장 시간 판단
  오류 발생 → 분봉 차트에 데이터 미표시

- t8412(정규장 전용) API만 사용하여 프리마켓(08:00~08:50),
   에프터마켓(15:40~20:00) 캔들 데이터 누락

- 서버 재기동 시 당일 및 전일 에프터마켓 데이터 공백 발생

## 🧩 작업 내용
- **KST 타임존 명시**: `LocalTime/DateTime/Date.now()` →`now(ZoneId.of("Asia/Seoul"))` 전체 적용
  
- **t8452 통합 분봉 API 연동**: LS증권 KRX+NXT 통합 분봉 조회 (`exchgubun=U`)로 프리/에프터마켓 데이터 적재
  
- **분봉 쿼리 범위 확장**: `09:00~15:30` → `00:00~23:59` (프리/에프터 포함)
  
- **toBucketStart 버그 수정**: 프리마켓 음수 offset에서 Java 정수 나눗셈 오류 → `Math.floorDiv` 적용
  
- **백필 스케줄러 추가**: 08:51(전날 에프터+오늘 프리),
  09:01(오늘 정규장 개시 직후) 자동 적재
  
- 수동 적재 API 추가: 
`POST /api/admin/candles/stock/{stockCode}`, 
`POST /api/admin/candles/stock/{stockCode}/unified`
  
- lastTradingDay(): 월요일 백필 시 금요일 에프터 누락 방지


## 📸 스크린샷(선택)


## 📝 기타
