### PR TITLE
[Refactor]현재 닉네임 동일 여부 확인

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus implements BaseStatus {
     EMAIL_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     EMAIL_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     NICKNAME_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    NICKNAME_SAME_AS_CURRENT("USER_400", HttpStatus.BAD_REQUEST, "현재 사용 중인 닉네임과 동일합니다."),
     EMAIL_NOT_VERIFIED("USER_400", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
     EMAIL_SEND_FAILED("USER_500", HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
 

--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -9,10 +9,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import jakarta.validation.Valid;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -55,6 +58,26 @@ public class UserController {
             @AuthenticationPrincipal Long userId) {
         userService.deleteProfileImage(userId);
         return ApiResponse.success(SuccessStatus.PROFILE_IMAGE_DELETE_SUCCESS, null);
+    }
+
+    @Operation(
+            summary = "닉네임 중복 확인",
+            description = """
+                    변경하려는 닉네임의 사용 가능 여부를 확인합니다.
+
+                    **검사 순서**
+                    1. 현재 로그인한 사용자의 닉네임과 동일한 경우 → `400` 반환
+                    2. 다른 사용자가 이미 사용 중인 닉네임인 경우 → `409` 반환
+                    3. 사용 가능한 닉네임인 경우 → `200` 반환
+
+                    **클라이언트 권장:** 닉네임 변경 폼에서 '중복 확인' 버튼 클릭 시 호출하고, `200` 응답을 받은 경우에만 변경 요청을 허용하세요.""")
+    @GetMapping("/nickname/check")
+    public ResponseEntity<ApiResponse<Void>> checkNickname(
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "중복 확인할 닉네임", example = "솔메이트123", required = true)
+            @RequestParam String nickname) {
+        userService.checkNicknameForUser(userId, nickname);
+        return ApiResponse.success(SuccessStatus.NICKNAME_CHECK_SUCCESS, null);
     }
 
     @Operation(summary = "프로필 업데이트", description = "프로필 이미지와 닉네임을 변경합니다. 각 항목은 선택적으로 전송 가능합니다.")

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -39,6 +39,15 @@ public class UserService {
         }
     }
 
+    public void checkNicknameForUser(Long userId, String nickname) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        if (nickname.equals(user.getNickname())) {
+            throw new GeneralException(ErrorStatus.NICKNAME_SAME_AS_CURRENT);
+        }
+        checkNicknameNotDuplicated(nickname);
+    }
+
     public void checkPassword(Long userId, String rawPassword) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
@@ -99,6 +108,10 @@ public class UserService {
         }
 
         if (nickname != null && !nickname.isBlank()) {
+
+            if (nickname.equals(user.getNickname())) {
+                throw new GeneralException(ErrorStatus.NICKNAME_SAME_AS_CURRENT);
+            }
             checkNicknameNotDuplicated(nickname);
             user.updateNickname(nickname);
         }


### PR DESCRIPTION
   
  ## #️⃣관련 이슈
  - closed #114                                                                                                                                                                   
                  
  ## 💡 작업 배경                                                                                                                                                                  
  - 매매 내역 응답에 종목 코드(tickerCode)가 누락되어 프론트에서 종목 식별이 불가능했음
  - 닉네임 변경 시 중복 확인 버튼을 눌렀을 때 현재 본인 닉네임과 동일한 경우를 구분하지 못하고 타인과의 중복과 동일하게 처리되어 사용자에게 맥락 없는 에러가 노출되었음                                                                                                       
                                                                                                                                                                                   
  ## 🧩 작업 내용                                                                                                                                                                  
                                                                                                                                                                                   
  ### 1. 매매 내역 응답에 tickerCode 포함 (`TradeHistoryResponse`)                                                                                                                                                                                                                       
  - `trade.getStock().getTickerCode()` 로 올바르게 수정, 나머지 `tradeType` / `tradeTypeLabel` 인자 순서도 정렬                                                                    
                                                                                                                                                                                   
  ### 2. 로그인 유저 대상 닉네임 중복 확인 API 추가 (`GET /api/users/nickname/check`)                                                                                              
  - 기존 `/auth/nickname/check`는 비인증 엔드포인트라 현재 유저 정보를 알 수 없었음                                                                                                
  - `@AuthenticationPrincipal` 기반의 인증 전용 API를 신규 추가                                                                                                                    
  - 응답 케이스:                                                                                                                                                                   
    - 현재 닉네임과 동일 → `400 NICKNAME_SAME_AS_CURRENT` ("현재 사용 중인 닉네임과 동일합니다.")                                                                                  
    - 타인이 이미 사용 중 → `409 NICKNAME_ALREADY_EXISTS` ("이미 존재하는 닉네임입니다.")                                                                                          
    - 사용 가능 → `200 NICKNAME_CHECK_SUCCESS` ("사용 가능한 닉네임입니다.")                                                                                                       
  - `ErrorStatus`에 `NICKNAME_SAME_AS_CURRENT` 추가                                                                                                                                
  - Swagger 문서에 검사 순서·응답 케이스·클라이언트 권장 사항 상세 기술      


## 📸 스크린샷(선택)                                                                                                      
<img width="1128" height="734" alt="Screenshot 2026-03-26 at 4 24 19 PM" src="https://github.com/user-attachments/assets/99025606-6307-4a63-b110-76c67c65f8c3" />
<img width="1131" height="707" alt="Screenshot 2026-03-26 at 4 24 29 PM" src="https://github.com/user-attachments/assets/a41327e9-b4be-46cf-a449-c4bde68468d2" />
                                                                                                                                                                                   

## 📝 기타                                                                                                                                                                       
  - `updateProfile`에서도 동일 닉네임 변경 시도 시 `NICKNAME_SAME_AS_CURRENT` 예외 발생하도록 처리    


 
