### PR TITLE
[Refactor] 유저 프로필/팔로우 API 본인/타인 분리 및 유저 목록 전체 조회 변경

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -81,7 +81,8 @@ public enum ErrorStatus implements BaseStatus {
     MENTORING_ALREADY_RESPONDED("MENTORING_400_3", HttpStatus.BAD_REQUEST, "이미 처리된 멘토링 요청입니다."),
     MENTORING_NOT_ACCEPTED("MENTORING_400_4", HttpStatus.BAD_REQUEST, "멘토링 관계가 아닙니다."),
 
-    USER_SELF_PROFILE_FORBIDDEN("USER_403", HttpStatus.FORBIDDEN, "본인 프로필은 /api/users/me 를 이용해주세요."),
+    USER_SELF_PROFILE_FORBIDDEN("USER_403_1", HttpStatus.FORBIDDEN, "본인 프로필은 /api/users/me 를 이용해주세요."),
+    USER_SELF_FOLLOW_LIST_FORBIDDEN("USER_403_2", HttpStatus.FORBIDDEN, "본인 팔로우 목록은 /api/users/me 를 이용해주세요."),
 
     /**
      * Follow

--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -81,6 +81,8 @@ public enum ErrorStatus implements BaseStatus {
     MENTORING_ALREADY_RESPONDED("MENTORING_400_3", HttpStatus.BAD_REQUEST, "이미 처리된 멘토링 요청입니다."),
     MENTORING_NOT_ACCEPTED("MENTORING_400_4", HttpStatus.BAD_REQUEST, "멘토링 관계가 아닙니다."),
 
+    USER_SELF_PROFILE_FORBIDDEN("USER_403", HttpStatus.FORBIDDEN, "본인 프로필은 /api/users/me 를 이용해주세요."),
+
     /**
      * Follow
      */

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -60,6 +60,7 @@ public enum SuccessStatus implements BaseStatus {
     USER_PROFILE_SUCCESS("USER_200_2", HttpStatus.OK, "유저 프로필 조회 성공"),
     FOLLOWER_LIST_SUCCESS("USER_200_3", HttpStatus.OK, "팔로워 목록 조회 성공"),
     FOLLOWING_LIST_SUCCESS("USER_200_4", HttpStatus.OK, "팔로잉 목록 조회 성공"),
+    MY_PROFILE_SUCCESS("USER_200_5", HttpStatus.OK, "내 프로필 조회 성공"),
 
 
     /**

--- a/src/main/java/org/solmate/domain/social/controller/UserListController.java
+++ b/src/main/java/org/solmate/domain/social/controller/UserListController.java
@@ -3,6 +3,7 @@ package org.solmate.domain.social.controller;
 import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.social.dto.response.FollowListResponse;
+import org.solmate.domain.social.dto.response.MyProfileResponse;
 import org.solmate.domain.social.dto.response.UserListResponse;
 import org.solmate.domain.social.dto.response.UserProfileResponse;
 import org.solmate.domain.social.service.UserListService;
@@ -83,6 +84,18 @@ public class UserListController {
      * - 본인 조회 시 isMe=true, isFollowing=false
      * - 총 수익률 / 총 수익은 추후 구현 예정
      */
+    @Operation(
+            summary = "내 프로필 카드 조회",
+            description = "현재 로그인한 유저의 프로필을 조회합니다."
+    )
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal Long currentUserId
+    ) {
+        MyProfileResponse response = userListService.getMyProfile(currentUserId);
+        return ApiResponse.success(SuccessStatus.MY_PROFILE_SUCCESS, response);
+    }
+
     @Operation(
             summary = "유저 프로필 카드 조회",
             description = """

--- a/src/main/java/org/solmate/domain/social/controller/UserListController.java
+++ b/src/main/java/org/solmate/domain/social/controller/UserListController.java
@@ -1,6 +1,8 @@
 package org.solmate.domain.social.controller;
 
+import org.solmate.common.exception.GeneralException;
 import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.ErrorStatus;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.social.dto.response.FollowListResponse;
 import org.solmate.domain.social.dto.response.MyProfileResponse;
@@ -28,29 +30,10 @@ public class UserListController {
 
     private final UserListService userListService;
 
-    /**
-     * 유저 목록 조회 (커서 기반 무한 스크롤)
-     *
-     * - 첫 페이지 요청 시 cursor 파라미터 생략
-     * - 이후 응답의 nextCursor 값을 cursor로 전달하여 다음 페이지 조회
-     * - hasAcceptedMentor가 true이면 프론트에서 NONE 상태 멘토신청 버튼 비활성화
-     * - 각 유저의 팔로우 여부(isFollowing), 멘토링 상태(mentoringStatus) 포함
-     * - 본인은 isMe=true로 표시 (팔로우/멘토 버튼 미표시)
-     *
-     * mentoringStatus 값:
-     *   NONE     → 멘토신청 버튼
-     *   PENDING  → 신청완료 버튼 (노란 테두리)
-     *   ACCEPTED → 멘토 버튼 (노란색 채움)
-     */
     @Operation(
             summary = "유저 목록 조회",
             description = """
-                    커서 기반 무한 스크롤로 유저 목록을 조회합니다.
-
-                    **페이지네이션**
-                    - 첫 페이지: cursor 파라미터 생략
-                    - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
-                    - hasNext가 false이면 마지막 페이지
+                    전체 유저 목록을 조회합니다.
 
                     **멘토링 버튼 상태**
                     - hasAcceptedMentor=true → NONE 상태의 멘토신청 버튼 전체 비활성화
@@ -66,24 +49,12 @@ public class UserListController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<UserListResponse>> getUserList(
-            @AuthenticationPrincipal Long currentUserId,
-            @Parameter(description = "마지막으로 받은 유저의 userId (첫 페이지는 생략)")
-            @RequestParam(required = false) Long cursor,
-            @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
-            @RequestParam(defaultValue = "20") int size
+            @AuthenticationPrincipal Long currentUserId
     ) {
-        UserListResponse response = userListService.getUserList(currentUserId, cursor, size);
+        UserListResponse response = userListService.getUserList(currentUserId);
         return ApiResponse.success(SuccessStatus.USER_LIST_SUCCESS, response);
     }
 
-    /**
-     * 유저 프로필 단건 조회
-     *
-     * - 팔로워 수, 팔로잉 수, 팔로우 여부, 멘토링 상태 포함
-     * - 탈퇴한 유저는 조회 불가 (404 반환)
-     * - 본인 조회 시 isMe=true, isFollowing=false
-     * - 총 수익률 / 총 수익은 추후 구현 예정
-     */
     @Operation(
             summary = "내 프로필 카드 조회",
             description = "현재 로그인한 유저의 프로필을 조회합니다."
@@ -104,13 +75,12 @@ public class UserListController {
                     **응답 필드**
                     - followerCount: 이 유저를 팔로우하는 사람 수
                     - followingCount: 이 유저가 팔로우하는 사람 수
-                    - isMe: 본인 여부 (true이면 팔로우/멘토 버튼 미표시)
                     - isFollowing: 현재 로그인 유저의 팔로우 여부
                     - mentoringStatus: NONE / PENDING / ACCEPTED
 
                     **주의**
                     - 탈퇴한 유저 조회 시 404 반환
-                    - 총 수익률 / 총 수익은 추후 추가 예정
+                    - 본인 userId 입력 시 403 반환
                     """
     )
     @GetMapping("/{userId}")
@@ -124,7 +94,53 @@ public class UserListController {
     }
 
     @Operation(
-            summary = "팔로워 목록 조회",
+            summary = "내 팔로워 목록 조회",
+            description = """
+                    내 팔로워 목록을 커서 기반 무한 스크롤로 조회합니다.
+
+                    **페이지네이션**
+                    - 첫 페이지: cursor 파라미터 생략
+                    - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
+                    - hasNext가 false이면 마지막 페이지
+                    """
+    )
+    @GetMapping("/me/followers")
+    public ResponseEntity<ApiResponse<FollowListResponse>> getMyFollowerList(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "마지막으로 받은 유저의 userId (첫 페이지는 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        FollowListResponse response = userListService.getFollowerList(currentUserId, cursor, size);
+        return ApiResponse.success(SuccessStatus.FOLLOWER_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "내 팔로잉 목록 조회",
+            description = """
+                    내 팔로잉 목록을 커서 기반 무한 스크롤로 조회합니다.
+
+                    **페이지네이션**
+                    - 첫 페이지: cursor 파라미터 생략
+                    - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
+                    - hasNext가 false이면 마지막 페이지
+                    """
+    )
+    @GetMapping("/me/following")
+    public ResponseEntity<ApiResponse<FollowListResponse>> getMyFollowingList(
+            @AuthenticationPrincipal Long currentUserId,
+            @Parameter(description = "마지막으로 받은 유저의 userId (첫 페이지는 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        FollowListResponse response = userListService.getFollowingList(currentUserId, cursor, size);
+        return ApiResponse.success(SuccessStatus.FOLLOWING_LIST_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "타인 팔로워 목록 조회",
             description = """
                     특정 유저의 팔로워 목록을 커서 기반 무한 스크롤로 조회합니다.
 
@@ -132,6 +148,9 @@ public class UserListController {
                     - 첫 페이지: cursor 파라미터 생략
                     - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
                     - hasNext가 false이면 마지막 페이지
+
+                    **주의**
+                    - 본인 userId 입력 시 403 반환
                     """
     )
     @GetMapping("/{userId}/followers")
@@ -144,12 +163,15 @@ public class UserListController {
             @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
             @RequestParam(defaultValue = "20") int size
     ) {
+        if (currentUserId.equals(userId)) {
+            throw new GeneralException(ErrorStatus.USER_SELF_FOLLOW_LIST_FORBIDDEN);
+        }
         FollowListResponse response = userListService.getFollowerList(userId, cursor, size);
         return ApiResponse.success(SuccessStatus.FOLLOWER_LIST_SUCCESS, response);
     }
 
     @Operation(
-            summary = "팔로잉 목록 조회",
+            summary = "타인 팔로잉 목록 조회",
             description = """
                     특정 유저의 팔로잉 목록을 커서 기반 무한 스크롤로 조회합니다.
 
@@ -157,6 +179,9 @@ public class UserListController {
                     - 첫 페이지: cursor 파라미터 생략
                     - 다음 페이지: 이전 응답의 nextCursor 값을 cursor로 전달
                     - hasNext가 false이면 마지막 페이지
+
+                    **주의**
+                    - 본인 userId 입력 시 403 반환
                     """
     )
     @GetMapping("/{userId}/following")
@@ -169,6 +194,9 @@ public class UserListController {
             @Parameter(description = "한 번에 가져올 유저 수 (기본값: 20)")
             @RequestParam(defaultValue = "20") int size
     ) {
+        if (currentUserId.equals(userId)) {
+            throw new GeneralException(ErrorStatus.USER_SELF_FOLLOW_LIST_FORBIDDEN);
+        }
         FollowListResponse response = userListService.getFollowingList(userId, cursor, size);
         return ApiResponse.success(SuccessStatus.FOLLOWING_LIST_SUCCESS, response);
     }

--- a/src/main/java/org/solmate/domain/social/dto/response/MyProfileResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MyProfileResponse.java
@@ -1,0 +1,27 @@
+package org.solmate.domain.social.dto.response;
+
+import org.solmate.domain.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyProfileResponse {
+
+    private Long userId;
+    private String nickname;
+    private String imageUrl;
+    private long followerCount;
+    private long followingCount;
+
+    public static MyProfileResponse of(User user, long followerCount, long followingCount) {
+        return new MyProfileResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getImageUrl(),
+                followerCount,
+                followingCount
+        );
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/UserListResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/UserListResponse.java
@@ -11,10 +11,7 @@ import lombok.Getter;
  * 필드 설명:
  * - hasAcceptedMentor : 현재 로그인 유저에게 이미 수락된 멘토가 있는지 여부
  *                       true이면 프론트에서 NONE 상태의 멘토신청 버튼을 모두 비활성화
- * - users             : 유저 목록 (UserListItemResponse 리스트)
- * - nextCursor        : 다음 페이지 요청 시 사용할 커서 (마지막 유저의 userId)
- *                       hasNext=false이면 null
- * - hasNext           : 다음 페이지 존재 여부
+ * - users             : 전체 유저 목록 (UserListItemResponse 리스트)
  */
 @Getter
 @AllArgsConstructor
@@ -22,6 +19,4 @@ public class UserListResponse {
 
     private boolean hasAcceptedMentor;
     private List<UserListItemResponse> users;
-    private Long nextCursor;
-    private boolean hasNext;
 }

--- a/src/main/java/org/solmate/domain/social/service/UserListService.java
+++ b/src/main/java/org/solmate/domain/social/service/UserListService.java
@@ -9,6 +9,7 @@ import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.social.dto.response.FollowListItemResponse;
 import org.solmate.domain.social.dto.response.FollowListResponse;
+import org.solmate.domain.social.dto.response.MyProfileResponse;
 import org.solmate.domain.social.dto.response.UserListItemResponse;
 import org.solmate.domain.social.dto.response.UserListResponse;
 import org.solmate.domain.social.dto.response.UserProfileResponse;
@@ -120,17 +121,40 @@ public class UserListService {
     }
 
     /**
-     * 유저 프로필 단건 조회
+     * 내 프로필 조회
      *
      * - 탈퇴한 유저는 조회 불가 (USER_NOT_FOUND 예외)
-     * - 본인 프로필 조회 시 isMe=true, isFollowing=false, mentoringStatus=NONE
-     * - 타인 프로필 조회 시 현재 로그인 유저 기준으로 팔로우 여부 및 멘토링 상태 계산
      */
-    public UserProfileResponse getUserProfile(Long currentUserId, Long targetUserId) {
-        User target = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+    public MyProfileResponse getMyProfile(Long currentUserId) {
+        User me = userRepository.findByIdAndDeletedAtIsNull(currentUserId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        boolean isMe = currentUserId.equals(targetUserId);
+        long followerCount = followingRepository.countFollowersByUserIds(List.of(currentUserId)).stream()
+                .findFirst()
+                .map(arr -> (Long) arr[1])
+                .orElse(0L);
+
+        long followingCount = followingRepository.countFollowingByUserIds(List.of(currentUserId)).stream()
+                .findFirst()
+                .map(arr -> (Long) arr[1])
+                .orElse(0L);
+
+        return MyProfileResponse.of(me, followerCount, followingCount);
+    }
+
+    /**
+     * 타인 프로필 단건 조회
+     *
+     * - 본인 userId로 요청 시 403 반환 (USER_SELF_PROFILE_FORBIDDEN)
+     * - 탈퇴한 유저는 조회 불가 (USER_NOT_FOUND 예외)
+     */
+    public UserProfileResponse getUserProfile(Long currentUserId, Long targetUserId) {
+        if (currentUserId.equals(targetUserId)) {
+            throw new GeneralException(ErrorStatus.USER_SELF_PROFILE_FORBIDDEN);
+        }
+
+        User target = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 대상 유저의 팔로워 수 (이 유저를 팔로우하는 사람 수)
         long followerCount = followingRepository.countFollowersByUserIds(List.of(targetUserId)).stream()
@@ -144,25 +168,21 @@ public class UserListService {
                 .map(arr -> (Long) arr[1])
                 .orElse(0L);
 
-        // 현재 로그인 유저가 대상 유저를 팔로우 중인지 (본인이면 항상 false)
-        boolean isFollowing = !isMe && followingIds(currentUserId).contains(targetUserId);
+        // 현재 로그인 유저가 대상 유저를 팔로우 중인지
+        boolean isFollowing = followingIds(currentUserId).contains(targetUserId);
 
-        // 현재 로그인 유저 기준 대상 유저와의 멘토링 상태
-        // 본인 프로필이면 NONE 고정, 타인이면 PENDING/ACCEPTED/NONE 중 하나
-        UserMentoringStatus mentoringStatus = UserMentoringStatus.NONE;
-        if (!isMe) {
-            List<MentoringRelation> relations = mentoringRepository.findByMenteeIdAndStatusIn(
-                    currentUserId, List.of(MentoringStatus.PENDING, MentoringStatus.ACCEPTED));
-            mentoringStatus = relations.stream()
-                    .filter(r -> r.getMentor().getId().equals(targetUserId))
-                    .findFirst()
-                    .map(r -> r.getStatus() == MentoringStatus.ACCEPTED
-                            ? UserMentoringStatus.ACCEPTED
-                            : UserMentoringStatus.PENDING)
-                    .orElse(UserMentoringStatus.NONE);
-        }
+        // 현재 로그인 유저 기준 대상 유저와의 멘토링 상태 (PENDING/ACCEPTED/NONE)
+        List<MentoringRelation> relations = mentoringRepository.findByMenteeIdAndStatusIn(
+                currentUserId, List.of(MentoringStatus.PENDING, MentoringStatus.ACCEPTED));
+        UserMentoringStatus mentoringStatus = relations.stream()
+                .filter(r -> r.getMentor().getId().equals(targetUserId))
+                .findFirst()
+                .map(r -> r.getStatus() == MentoringStatus.ACCEPTED
+                        ? UserMentoringStatus.ACCEPTED
+                        : UserMentoringStatus.PENDING)
+                .orElse(UserMentoringStatus.NONE);
 
-        return UserProfileResponse.of(target, followerCount, followingCount, isMe, isFollowing, mentoringStatus);
+        return UserProfileResponse.of(target, followerCount, followingCount, false, isFollowing, mentoringStatus);
     }
 
     /**

--- a/src/main/java/org/solmate/domain/social/service/UserListService.java
+++ b/src/main/java/org/solmate/domain/social/service/UserListService.java
@@ -37,36 +37,22 @@ public class UserListService {
     private final MentoringRepository mentoringRepository;
 
     /**
-     * 유저 목록 조회 (커서 기반 무한 스크롤)
+     * 유저 목록 전체 조회
      *
      * 처리 순서 (총 5번의 쿼리로 N+1 없이 처리):
-     *   ① 유저 목록 조회 (cursor 기반 - 첫 페이지면 cursor=null)
+     *   ① 전체 유저 목록 조회 (탈퇴 유저 제외)
      *   ② 내가 팔로우하는 유저 ID 목록 (팔로우 여부 일괄 확인)
      *   ③ 나의 멘토링 관계 일괄 조회 (PENDING + ACCEPTED)
      *   ④ 유저 ID 목록으로 팔로워 수 bulk 집계
      *   ⑤ 유저 ID 목록으로 팔로잉 수 bulk 집계
      *
-     * hasNext 판별:
-     *   size+1개를 조회해서 실제 size보다 많으면 다음 페이지가 있음
-     *   nextCursor는 현재 페이지 마지막 유저의 userId
-     *
      * hasAcceptedMentor:
      *   true이면 프론트에서 NONE 상태의 멘토신청 버튼을 모두 비활성화해야 함
      *   (이미 멘토가 있는 경우 추가 신청 불가)
      */
-    public UserListResponse getUserList(Long currentUserId, Long cursor, int size) {
-        // ① 유저 목록 조회 (size+1개 조회로 hasNext 판별)
-        List<User> users = cursor == null
-                ? userRepository.findByDeletedAtIsNullOrderByIdAsc(PageRequest.of(0, size + 1))
-                : userRepository.findByIdGreaterThanAndDeletedAtIsNullOrderByIdAsc(cursor, PageRequest.of(0, size + 1));
-
-        // size+1개가 왔으면 다음 페이지가 존재함 → 실제 반환은 size개만
-        boolean hasNext = users.size() > size;
-        if (hasNext) {
-            users = users.subList(0, size);
-        }
-        // 다음 페이지 커서 = 현재 페이지 마지막 유저의 userId (없으면 null)
-        Long nextCursor = hasNext ? users.get(users.size() - 1).getId() : null;
+    public UserListResponse getUserList(Long currentUserId) {
+        // ① 전체 유저 목록 조회 (탈퇴 유저 제외)
+        List<User> users = userRepository.findByDeletedAtIsNullOrderByIdAsc();
 
         List<Long> userIds = users.stream().map(User::getId).toList();
 
@@ -105,7 +91,6 @@ public class UserListService {
                 ));
 
         // 각 유저에 대해 소셜 정보를 조합하여 응답 생성
-        // 팔로워/팔로잉이 없는 유저는 0으로 기본값 처리
         List<UserListItemResponse> items = users.stream()
                 .map(user -> UserListItemResponse.of(
                         user,
@@ -117,7 +102,7 @@ public class UserListService {
                 ))
                 .toList();
 
-        return new UserListResponse(hasAcceptedMentor, items, nextCursor, hasNext);
+        return new UserListResponse(hasAcceptedMentor, items);
     }
 
     /**

--- a/src/main/java/org/solmate/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/solmate/domain/user/repository/UserRepository.java
@@ -21,9 +21,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 탈퇴 유저 포함 조회 (댓글, 매매일지 작성자 표시를 위한..)
     Optional<User> findByEmail(String email);
 
-    // 유저 목록 커서 기반 페이지네이션 (첫 페이지)
-    List<User> findByDeletedAtIsNullOrderByIdAsc(Pageable pageable);
-
-    // 유저 목록 커서 기반 페이지네이션 (다음 페이지)
-    List<User> findByIdGreaterThanAndDeletedAtIsNullOrderByIdAsc(Long cursor, Pageable pageable);
+    // 유저 목록 전체 조회
+    List<User> findByDeletedAtIsNullOrderByIdAsc();
 }


### PR DESCRIPTION
## #️⃣  관련 이슈 
  - closed #111  
               
  ## 💡 작업 배경
  기존 `/api/users/{userId}` 하나로 본인/타인 프로필을 모두 처리하고 있어                                       
  불필요한 소셜 필드(isFollowing, mentoringStatus)가 본인 조회 시에도 포함되는 문제가 있었습니다.
  팔로워/팔로잉 목록도 동일한 엔드포인트를 공유하고 있어 본인/타인 구분이 명확하지 않았습니다.                  
  또한 유저 목록의 커서 기반 페이지네이션 방식이 프론트엔드의 수익률 기준 정렬을 어렵게 만들어                  
  전체 목록을 한 번에 반환하는 방식으로 변경했습니다.                                                           
                                                                                                                
  ## 🧩 작업 내용                                                                                               
                                                                                                                
  ### 프로필 API 분리                                                                                           
  - `GET /api/users/me` 신규 추가 — 본인 프로필 전용 (isFollowing, mentoringStatus, isMe 제거)                  
  - `GET /api/users/{userId}` — 타인 전용으로 변경, 본인 userId 요청 시 403 반환              
  - `MyProfileResponse` DTO 신규 생성                                                                           
                                                                                                                
  ### 팔로워/팔로잉 API 분리                                                                                    
  - `GET /api/users/me/followers`, `GET /api/users/me/following` 신규 추가                                      
  - `GET /api/users/{userId}/followers`, `GET /api/users/{userId}/following` — 타인 전용으로 변경, 본인 요청 시 
  403 반환                                                                                                      
                                                                                                                
  ### 유저 목록 전체 조회로 변경                                                                                
  - `GET /api/users` 커서 기반 페이지네이션 제거, 전체 목록 반환으로 변경                                       
  - `cursor`, `size` 파라미터 제거                                       
  - `UserListResponse`에서 `nextCursor`, `hasNext` 필드 제거                                                    
  - `UserRepository` 커서 쿼리 제거, 전체 조회 메서드로 교체
                                                                                                                
  ### 에러/성공 코드 추가                                                                                       
  - `MY_PROFILE_SUCCESS` (USER_200_5)                                                                           
  - `USER_SELF_PROFILE_FORBIDDEN` (USER_403_1)                                                                  
  - `USER_SELF_FOLLOW_LIST_FORBIDDEN` (USER_403_2)                                                              
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타      