### PR TITLE
[Feat] 멘토멘티 조회 api 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -46,6 +46,8 @@ public enum SuccessStatus implements BaseStatus {
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),
     MENTORING_CANCEL_SUCCESS("MENTORING_200_4", HttpStatus.OK, "멘토링 취소 성공"),
+    MY_MENTOR_SUCCESS("MENTORING_200_5", HttpStatus.OK, "내 멘토 조회 성공"),
+    MY_MENTEE_LIST_SUCCESS("MENTORING_200_6", HttpStatus.OK, "내 멘티 목록 조회 성공"),
 
     /**
      * Follow

--- a/src/main/java/org/solmate/domain/social/controller/UserListController.java
+++ b/src/main/java/org/solmate/domain/social/controller/UserListController.java
@@ -5,6 +5,8 @@ import org.solmate.common.response.ApiResponse;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.common.status.SuccessStatus;
 import org.solmate.domain.social.dto.response.FollowListResponse;
+import org.solmate.domain.social.dto.response.MyMenteeListResponse;
+import org.solmate.domain.social.dto.response.MyMentorResponse;
 import org.solmate.domain.social.dto.response.MyProfileResponse;
 import org.solmate.domain.social.dto.response.UserListResponse;
 import org.solmate.domain.social.dto.response.UserProfileResponse;
@@ -91,6 +93,42 @@ public class UserListController {
     ) {
         UserProfileResponse response = userListService.getUserProfile(currentUserId, userId);
         return ApiResponse.success(SuccessStatus.USER_PROFILE_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "내 멘토 조회",
+            description = """
+                    현재 로그인한 유저의 멘토를 조회합니다.
+
+                    **응답 필드**
+                    - hasMentor=true  → userId, nickname, imageUrl 포함
+                    - hasMentor=false → userId, nickname, imageUrl은 null
+                    """
+    )
+    @GetMapping("/me/mentor")
+    public ResponseEntity<ApiResponse<MyMentorResponse>> getMyMentor(
+            @AuthenticationPrincipal Long currentUserId
+    ) {
+        MyMentorResponse response = userListService.getMyMentor(currentUserId);
+        return ApiResponse.success(SuccessStatus.MY_MENTOR_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "내 멘티 목록 조회",
+            description = """
+                    현재 로그인한 유저의 멘티 목록을 조회합니다.
+
+                    **응답 필드**
+                    - hasMentee=true  → mentees 리스트에 멘티 정보 포함
+                    - hasMentee=false → mentees는 빈 리스트
+                    """
+    )
+    @GetMapping("/me/mentees")
+    public ResponseEntity<ApiResponse<MyMenteeListResponse>> getMyMentees(
+            @AuthenticationPrincipal Long currentUserId
+    ) {
+        MyMenteeListResponse response = userListService.getMyMentees(currentUserId);
+        return ApiResponse.success(SuccessStatus.MY_MENTEE_LIST_SUCCESS, response);
     }
 
     @Operation(

--- a/src/main/java/org/solmate/domain/social/dto/response/MyMenteeListResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MyMenteeListResponse.java
@@ -1,0 +1,26 @@
+package org.solmate.domain.social.dto.response;
+
+import java.util.List;
+
+import org.solmate.domain.user.entity.User;
+
+/**
+ * 내 멘티 목록 조회 응답 DTO
+ *
+ * 필드 설명:
+ * - hasMentee : 수락된 멘티 존재 여부
+ * - mentees   : 멘티 목록 (없으면 빈 리스트)
+ */
+public record MyMenteeListResponse(boolean hasMentee, List<MenteeItem> mentees) {
+
+    public record MenteeItem(Long userId) {
+        public static MenteeItem of(User mentee) {
+            return new MenteeItem(mentee.getId());
+        }
+    }
+
+    public static MyMenteeListResponse of(List<User> mentees) {
+        List<MenteeItem> items = mentees.stream().map(MenteeItem::of).toList();
+        return new MyMenteeListResponse(!items.isEmpty(), items);
+    }
+}

--- a/src/main/java/org/solmate/domain/social/dto/response/MyMentorResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MyMentorResponse.java
@@ -1,0 +1,21 @@
+package org.solmate.domain.social.dto.response;
+
+import org.solmate.domain.user.entity.User;
+
+/**
+ * 내 멘토 조회 응답 DTO
+ *
+ * 필드 설명:
+ * - hasMentor : 수락된 멘토 존재 여부
+ * - userId    : 멘토 유저 식별자 (hasMentor=false이면 null)
+ */
+public record MyMentorResponse(boolean hasMentor, Long userId) {
+
+    public static MyMentorResponse of(User mentor) {
+        return new MyMentorResponse(true, mentor.getId());
+    }
+
+    public static MyMentorResponse empty() {
+        return new MyMentorResponse(false, null);
+    }
+}

--- a/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
+++ b/src/main/java/org/solmate/domain/social/repository/MentoringRepository.java
@@ -1,6 +1,7 @@
 package org.solmate.domain.social.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.solmate.domain.social.entity.MentoringRelation;
 import org.solmate.domain.social.enums.MentoringStatus;
@@ -36,4 +37,10 @@ public interface MentoringRepository extends JpaRepository<MentoringRelation, Lo
     // 멘토링 취소 시 (menteeId, mentorId)로 관계 조회
     @Query("SELECT m FROM MentoringRelation m WHERE m.mentee.id = :menteeId AND m.mentor.id = :mentorId AND m.status IN :statuses")
     List<MentoringRelation> findByMenteeIdAndMentorIdAndStatusIn(@Param("menteeId") Long menteeId, @Param("mentorId") Long mentorId, @Param("statuses") List<MentoringStatus> statuses);
+
+    // 내 멘토 조회 (내가 멘티인 ACCEPTED 관계)
+    Optional<MentoringRelation> findByMenteeIdAndStatus(Long menteeId, MentoringStatus status);
+
+    // 내 멘티 목록 조회 (내가 멘토인 ACCEPTED 관계 전체)
+    List<MentoringRelation> findAllByMentorIdAndStatus(Long mentorId, MentoringStatus status);
 }

--- a/src/main/java/org/solmate/domain/social/service/UserListService.java
+++ b/src/main/java/org/solmate/domain/social/service/UserListService.java
@@ -9,6 +9,8 @@ import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.social.dto.response.FollowListItemResponse;
 import org.solmate.domain.social.dto.response.FollowListResponse;
+import org.solmate.domain.social.dto.response.MyMenteeListResponse;
+import org.solmate.domain.social.dto.response.MyMentorResponse;
 import org.solmate.domain.social.dto.response.MyProfileResponse;
 import org.solmate.domain.social.dto.response.UserListItemResponse;
 import org.solmate.domain.social.dto.response.UserListResponse;
@@ -168,6 +170,36 @@ public class UserListService {
                 .orElse(UserMentoringStatus.NONE);
 
         return UserProfileResponse.of(target, followerCount, followingCount, false, isFollowing, mentoringStatus);
+    }
+
+    /**
+     * 내 멘토 조회
+     *
+     * - ACCEPTED 상태인 멘토링 관계에서 멘토 정보를 반환
+     * - 멘토가 없으면 hasMentor=false, 나머지 필드는 null 반환
+     */
+    public MyMentorResponse getMyMentor(Long currentUserId) {
+        return mentoringRepository
+                .findByMenteeIdAndStatus(currentUserId, MentoringStatus.ACCEPTED)
+                .map(r -> MyMentorResponse.of(r.getMentor()))
+                .orElse(MyMentorResponse.empty());
+    }
+
+    /**
+     * 내 멘티 목록 조회
+     *
+     * - 내가 멘토인 ACCEPTED 상태의 멘토링 관계에서 멘티 목록을 반환
+     * - 멘티가 없으면 hasMentee=false, mentees=[] 반환
+     */
+    public MyMenteeListResponse getMyMentees(Long currentUserId) {
+        List<MentoringRelation> relations = mentoringRepository
+                .findAllByMentorIdAndStatus(currentUserId, MentoringStatus.ACCEPTED);
+
+        List<User> mentees = relations.stream()
+                .map(MentoringRelation::getMentee)
+                .toList();
+
+        return MyMenteeListResponse.of(mentees);
     }
 
     /**


### PR DESCRIPTION
## #️⃣  관련 이슈                           
  - closed #122
                                                                                                                
  ## 💡 작업 배경
  내 멘토 존재 여부 및 내 멘티 목록 존재 여부를 프론트에서 확인할 수 있는 전용 API가 없어 추가                  
                                                                                                                
  ## 🧩 작업 내용
  - `GET /api/users/me/mentor` 추가 — 내 멘토 조회 (hasMentor + userId 반환, 없으면 hasMentor=false)            
  - `GET /api/users/me/mentees` 추가 — 내 멘티 목록 조회 (hasMentee + userId 목록 반환, 없으면 빈 리스트)       
  - `MentoringRepository`에 `findByMenteeIdAndStatus`, `findAllByMentorIdAndStatus` 쿼리 추가                   
  - `MyMentorResponse`, `MyMenteeListResponse` DTO 추가                                                         
  - `SuccessStatus`에 `MY_MENTOR_SUCCESS`, `MY_MENTEE_LIST_SUCCESS` 추가                                        
                                                                                                                
  ## 📸 스크린샷(선택)
                                                                                                                
  ## 📝 기타