### PR TITLE
[Fix]  내 정보 조회시 provier 반환하도록 수정

### DIFF
--- a/src/main/java/org/solmate/domain/social/dto/response/MyProfileResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/MyProfileResponse.java
@@ -1,5 +1,6 @@
 package org.solmate.domain.social.dto.response;
 
+import org.solmate.domain.auth.enums.OAuthProvider;
 import org.solmate.domain.user.entity.User;
 
 import lombok.AllArgsConstructor;
@@ -14,14 +15,16 @@ public class MyProfileResponse {
     private String imageUrl;
     private long followerCount;
     private long followingCount;
+    private String provider;
 
-    public static MyProfileResponse of(User user, long followerCount, long followingCount) {
+    public static MyProfileResponse of(User user, long followerCount, long followingCount, OAuthProvider provider) {
         return new MyProfileResponse(
                 user.getId(),
                 user.getNickname(),
                 user.getImageUrl(),
                 followerCount,
-                followingCount
+                followingCount,
+                provider.name()
         );
     }
 }

--- a/src/main/java/org/solmate/domain/social/service/UserListService.java
+++ b/src/main/java/org/solmate/domain/social/service/UserListService.java
@@ -7,6 +7,8 @@ import java.util.stream.Collectors;
 
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.auth.enums.OAuthProvider;
+import org.solmate.domain.auth.repository.LoginTypeRepository;
 import org.solmate.domain.social.dto.response.FollowListItemResponse;
 import org.solmate.domain.social.dto.response.FollowListResponse;
 import org.solmate.domain.social.dto.response.MyMenteeListResponse;
@@ -37,6 +39,7 @@ public class UserListService {
     private final UserRepository userRepository;
     private final FollowingRepository followingRepository;
     private final MentoringRepository mentoringRepository;
+    private final LoginTypeRepository loginTypeRepository;
 
     /**
      * 유저 목록 전체 조회
@@ -126,7 +129,11 @@ public class UserListService {
                 .map(arr -> (Long) arr[1])
                 .orElse(0L);
 
-        return MyProfileResponse.of(me, followerCount, followingCount);
+        OAuthProvider provider = loginTypeRepository.existsByUserAndLoginType(me, OAuthProvider.GOOGLE)
+                ? OAuthProvider.GOOGLE
+                : OAuthProvider.EMAIL;
+
+        return MyProfileResponse.of(me, followerCount, followingCount, provider);
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #124 

## 💡 작업 배경
- 구글 로그인과 일반 로그인의 회원 탈퇴 로직이 같아 구글 로그인 시 비밀번호를 입력하여야하여 오류가 발생


## 🧩 작업 내용
- 내 정보 조회시 provier 반환
- 구글 로그인 회원은 비밀번호 없이 바로 탈퇴 문구로 분기


## 📸 스크린샷(선택)
<img width="1482" height="588" alt="Screenshot 2026-03-27 at 10 04 56 AM" src="https://github.com/user-attachments/assets/2d981340-59f9-45b8-8821-5ed55c4377e9" />


## 📝 기타
