### PR TITLE
[Refactor] 구글 로그인 탈퇴 처리 분기

### DIFF
--- a/src/main/java/org/solmate/domain/user/controller/UserController.java
+++ b/src/main/java/org/solmate/domain/user/controller/UserController.java
@@ -43,12 +43,18 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.PASSWORD_CHECK_SUCCESS, null);
     }
 
-    @Operation(summary = "회원 탈퇴", description = "현재 비밀번호 확인 후 회원 탈퇴 처리합니다. (soft delete)")
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+                    회원 탈퇴를 처리합니다. (soft delete)
+
+                    **이메일 로그인 유저:** `password` 필드 필수 — 비밀번호 불일치 시 `400` 반환
+                    **구글 로그인 유저:** `password` 필드 불필요 — 빈 body(`{}`) 또는 password 없이 요청""")
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> withdraw(
             @AuthenticationPrincipal Long userId,
-            @RequestBody @Valid WithdrawRequest request) {
-        userService.withdrawWithPassword(userId, request.password());
+            @RequestBody WithdrawRequest request) {
+        userService.withdraw(userId, request.password());
         return ApiResponse.success(SuccessStatus.WITHDRAW_SUCCESS, null);
     }
 

--- a/src/main/java/org/solmate/domain/user/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/solmate/domain/user/dto/request/WithdrawRequest.java
@@ -1,9 +1,6 @@
 package org.solmate.domain.user.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record WithdrawRequest(
-        @NotBlank(message = "비밀번호는 필수입니다.")
         String password
 ) {
 }

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -3,6 +3,8 @@ package org.solmate.domain.user.service;
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.auth.enums.OAuthProvider;
+import org.solmate.domain.auth.repository.LoginTypeRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,6 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final S3Service s3Service;
     private final PasswordEncoder passwordEncoder;
+    private final LoginTypeRepository loginTypeRepository;
 
 
     public User getUserByEmail(String email) {
@@ -68,12 +71,19 @@ public class UserService {
 
 
     @Transactional
-    public void withdrawWithPassword(Long userId, String rawPassword) {
+    public void withdraw(Long userId, String rawPassword) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
-            throw new GeneralException(ErrorStatus.INVALID_PASSWORD);
+        boolean isGoogleUser = loginTypeRepository.existsByUserAndLoginType(user, OAuthProvider.GOOGLE);
+
+        if (!isGoogleUser) {
+            if (rawPassword == null || rawPassword.isBlank()) {
+                throw new GeneralException(ErrorStatus.INVALID_PASSWORD);
+            }
+            if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+                throw new GeneralException(ErrorStatus.INVALID_PASSWORD);
+            }
         }
 
         if (user.getImageUrl() != null) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #124 

## 💡 작업 배경
- 구글 로그인과 일반 로그인의 회원 탈퇴 로직이 같아 구글 로그인 시 비밀번호를 입력하여야하여 오류가 발생


## 🧩 작업 내용
- 내 정보 조회시 provier 반환
- 구글 로그인 회원은 비밀번호 없이 바로 탈퇴 문구로 분기


## 📸 스크린샷(선택)
<img width="1482" height="588" alt="Screenshot 2026-03-27 at 10 04 56 AM" src="https://github.com/user-attachments/assets/2d981340-59f9-45b8-8821-5ed55c4377e9" />

## 📝 기타
