### PR TITLE
[Fix]  multipart 기본 파일 용량 설정에서 2mb로 변경

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,6 +15,11 @@ spring:
     generate-ddl: true
     show-sql: true
 
+  servlet:
+    multipart:
+      max-file-size: 2MB
+      max-request-size: 2MB
+
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #129 

## 💡 작업 배경
기본 스프링 부트 multipart설정이 1mb여서 이미지 업로드가 되고 있지 않가.

## 🧩 작업 내용
multipart 기본 파일 용량 설정에서 2mb로 변경

## 📸 스크린샷(선택)


## 📝 기타
