### PR TITLE
[Feat] 회원가입시 소셜, 일반 로그인 이메일 중복 확인 로직 추가

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -37,6 +37,8 @@ public enum ErrorStatus implements BaseStatus {
     USER_ALREADY_WITHDRAWN("USER_400", HttpStatus.BAD_REQUEST, "이미 탈퇴한 유저입니다."),
     EMAIL_NOT_FOUND("USER_404", HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다."),
     EMAIL_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    EMAIL_REGISTERED_WITH_EMAIL("USER_409_1", HttpStatus.CONFLICT, "이미 이메일로 가입된 계정입니다. 이메일 로그인을 이용해 주세요."),
+    EMAIL_REGISTERED_WITH_GOOGLE("USER_409_2", HttpStatus.CONFLICT, "이미 구글로 가입된 계정입니다. 구글 로그인을 이용해 주세요."),
     NICKNAME_ALREADY_EXISTS("USER_409", HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     NICKNAME_SAME_AS_CURRENT("USER_400", HttpStatus.BAD_REQUEST, "현재 사용 중인 닉네임과 동일합니다."),
     EMAIL_NOT_VERIFIED("USER_400", HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -53,9 +53,9 @@ public class AuthService {
 
     // 회원가입
     public void signUp(SignUpRequest request) {
-        emailVerificationService.isEmailVerified(request.email());
         userService.checkEmailNotDuplicated(request.email());
         userService.checkNicknameNotDuplicated(request.nickname());
+        emailVerificationService.isEmailVerified(request.email());
 
         User user = User.builder()
                 .email(request.email())

--- a/src/main/java/org/solmate/domain/auth/service/GoogleService.java
+++ b/src/main/java/org/solmate/domain/auth/service/GoogleService.java
@@ -6,6 +6,8 @@ import org.solmate.common.jwt.JwtProvider;
 import org.solmate.domain.auth.dto.response.GoogleInfoResponse;
 import org.solmate.domain.auth.dto.response.GoogleTokenResponse;
 import org.solmate.domain.auth.dto.response.LoginResponse;
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.auth.entity.LoginType;
 import org.solmate.domain.auth.entity.Token;
 import org.solmate.domain.auth.enums.OAuthProvider;
@@ -122,6 +124,12 @@ public class GoogleService {
 
     private User findOrCreateUser(GoogleInfoResponse googleInfo, String providerToken) {
         return userRepository.findByEmail(googleInfo.email())
+                .map(user -> {
+                    if (!loginTypeRepository.existsByUserAndLoginType(user, OAuthProvider.GOOGLE)) {
+                        throw new GeneralException(ErrorStatus.EMAIL_REGISTERED_WITH_EMAIL);
+                    }
+                    return user;
+                })
                 .orElseGet(() -> createGoogleUser(googleInfo, providerToken));
     }
 

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -31,9 +31,12 @@ public class UserService {
     }
 
     public void checkEmailNotDuplicated(String email) {
-        if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
+        userRepository.findByEmailAndDeletedAtIsNull(email).ifPresent(user -> {
+            if (loginTypeRepository.existsByUserAndLoginType(user, OAuthProvider.GOOGLE)) {
+                throw new GeneralException(ErrorStatus.EMAIL_REGISTERED_WITH_GOOGLE);
+            }
             throw new GeneralException(ErrorStatus.EMAIL_ALREADY_EXISTS);
-        }
+        });
     }
 
     public void checkNicknameNotDuplicated(String nickname) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #125 

## 💡 작업 배경
회원가입시 소셜, 일반 로그인 이메일 중복이어도 가입이 현재 가능하여 불가능하도록 중복 확인이 필요하다.

## 🧩 작업 내용
- 회원가입시 소셜, 일반 로그인 이메일 중복 확인 로직 추가

## 📸 스크린샷(선택)
<img width="1081" height="751" alt="Screenshot 2026-03-27 at 11 02 31 AM" src="https://github.com/user-attachments/assets/e1c22859-3013-4dd1-ba14-129ca03691e1" />


## 📝 기타
