### PR TITLE
[Fix] 주문 체결 부분 오류 해결

### DIFF
--- a/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
+++ b/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
@@ -30,20 +30,14 @@ public class PortfolioCalculator {
     private final TradeHistoryRepository tradeHistoryRepository;
     private final StringRedisTemplate redisTemplate;
 
-    // 실제 보유 현금 = Account.cash(매수 선차감 반영) + PENDING BUY 금액
+    // 주문 가능 금액 = Account.cash (매수 선차감 반영된 실제 잔액)
     @Transactional(readOnly = true)
     public BigDecimal getCash(Long userId) {
         BigDecimal cash = accountRepository.findByUserId(userId)
                 .map(Account::getCash)
                 .orElse(BigDecimal.ZERO);
 
-        BigDecimal pendingBuyAmount = tradeHistoryRepository
-                .findPendingByUserIdAndTradeType(userId, TradeType.BUY)
-                .stream()
-                .map(t -> t.getPrice().multiply(t.getQuantity()))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        return cash.add(pendingBuyAmount).setScale(0, RoundingMode.HALF_UP);
+        return cash.setScale(0, RoundingMode.HALF_UP);
     }
 
     // 종목별 평가금액 (실제 보유 수량 = Holdings.quantity + PENDING SELL)

--- a/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
+++ b/src/main/java/org/solmate/domain/trade/entity/TradeHistory.java
@@ -89,4 +89,8 @@ public class TradeHistory extends BaseEntity {
     public void updateStatus(TradeStatus tradeStatus) {
         this.tradeStatus = tradeStatus;
     }
+
+    public void updateFilledPrice(BigDecimal filledPrice) {
+        this.price = filledPrice;
+    }
 }

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -108,6 +108,7 @@ public class OrderMatchingService {
 
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
+                    tradeHistory.updateFilledPrice(currentPrice);
 
                     // TradeDiary 상태 업데이트
                     tradeDiaryRepository.findByTradeHistoryId(orderId)
@@ -172,6 +173,7 @@ public class OrderMatchingService {
 
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
+                    tradeHistory.updateFilledPrice(currentPrice);
 
                     // TradeDiary 상태 업데이트
                     tradeDiaryRepository.findByTradeHistoryId(orderId)


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #131 

## 💡 작업 배경
매수/매도 체결 이후 체결가로 매매내역 업데이트 시켜줘야 함.
예수금이랑 보유 현금 용어가 정리가 안됨.

## 🧩 작업 내용
체결 이후에 매매내역 price 를 업데이트 시킴

