### PR TITLE
[Fix] 매도 주문 시 Holdings 비관적 락 누락 수정

### DIFF
--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -1,4 +1,4 @@
-package org.solmate.domain.trade.service;
+﻿package org.solmate.domain.trade.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -122,7 +122,7 @@ public class TradeService {
         Stock stock = stockRepository.findByTickerCode(request.ticker())
             .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
 
-        Holdings holdings = holdingsRepository.findByUserAndTickerCode(user, request.ticker())
+        Holdings holdings = holdingsRepository.findByUserAndTickerCodeWithLock(user, request.ticker())
             .orElseThrow(() -> new GeneralException(ErrorStatus.INSUFFICIENT_HOLDINGS));
 
         // 보유 수량 검증

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -1,4 +1,4 @@
-﻿package org.solmate.domain.trade.service;
+package org.solmate.domain.trade.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;


### PR DESCRIPTION
## #️⃣ 관련 이슈
* closed #101 

## 💡 작업 배경
모의투자 서비스에서 동시 요청이 들어올 경우 데이터 정합성이 깨질 수 있는 취약점이 존재했습니다.
매도 주문 시 동일 사용자가 동시에 여러 요청을 보내면 보유 수량이 중복 차감되는 문제가 있었고, 이를 수정했습니다.

## 🧩 작업 내용
현재 동시성 제어 구조

  1. 주문 체결 (OrderMatchingService) — Redis 분산 락
  - 체결은 LS증권 실시간 데이터가 올 때마다 자동 실행되며, 1초에 수십 번 발생
  - DB 락을 사용하면 대기 스레드가 쌓여 DB 부하가 폭증하므로 Redis 락 사용
  - 락 획득 실패 시 즉시 스킵 → 대기 없이 빠르게 처리
  - 동일 주문이 여러 번 체결되는 중복 체결 방지

  2. 매수 주문 (TradeService.buyOrder) — DB 비관적 락 (계좌)
  - 동시 매수 요청 시 잔액을 동시에 읽어 이중 차감되는 문제 방지
  - accountRepository.findByUserWithLock() 으로 계좌 row 잠금

  3. 주문 취소 (TradeOrderService.cancelOrder) — DB 비관적 락 (주문 + 계좌/보유주식)
  - 동일 주문 이중 취소 방지
  - 매수 취소 시 계좌 잔액 복원, 매도 취소 시 보유 수량 복원 과정에서 덮어쓰기 방지

  이번 수정 사항

  매도 주문 (TradeService.sellOrder) — DB 비관적 락 추가 (보유주식)

  기존에는 findByUserAndTickerCode() 를 사용해 락 없이 보유 수량을 조회했습니다.

  // 변경 전
  holdingsRepository.findByUserAndTickerCode(user, request.ticker())

  // 변경 후
  holdingsRepository.findByUserAndTickerCodeWithLock(user, request.ticker())

  동시에 매도 요청이 들어오면 두 스레드가 동일한 수량을 읽고 동시에 차감해 실제 보유량보다 더 많은 수량이 매도되는 문제가 있었습니다. 비관적 락으로 Holdings     
  row를 잠가 하나씩 순서대로 처리되도록 수정했습니다.


