### PR TITLE
[Feat] STOMP 실시간 알림 및 거래내역 push 구현

### DIFF
--- a/src/main/java/org/solmate/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/org/solmate/domain/auth/dto/response/LoginResponse.java
@@ -1,6 +1,7 @@
 package org.solmate.domain.auth.dto.response;
 
 public record LoginResponse(
+        Long userId,
         String nickname,
         String accessToken,
         String refreshToken

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -106,7 +106,7 @@ public class AuthService {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        return new LoginResponse(user.getNickname(), accessToken, refreshToken);
+        return new LoginResponse(user.getId(), user.getNickname(), accessToken, refreshToken);
     }
 
     // 토큰 재발급

--- a/src/main/java/org/solmate/domain/auth/service/GoogleService.java
+++ b/src/main/java/org/solmate/domain/auth/service/GoogleService.java
@@ -92,7 +92,7 @@ public class GoogleService {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        return new LoginResponse(user.getNickname(), accessToken, refreshToken);
+        return new LoginResponse(user.getId(), user.getNickname(), accessToken, refreshToken);
     }
 
 

--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -8,6 +8,7 @@ import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.notification.dto.response.NotificationCountResponse;
 import org.solmate.domain.notification.dto.response.NotificationResponse;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.solmate.domain.notification.entity.Notification;
 import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.enums.NotificationType;
@@ -34,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final SimpMessagingTemplate messagingTemplate;
     private final MentoringService mentoringService;
     private final MentoringRepository mentoringRepository;
     private final UserRepository userRepository;
@@ -192,6 +194,9 @@ public class NotificationService {
             .toList();
 
         notificationRepository.saveAll(notifications);
+
+        notifications.forEach(n ->
+            messagingTemplate.convertAndSend("/topic/notifications/" + n.getUser().getId(), NotificationResponse.of(n)));
     }
 
     public NotificationCountResponse getUnreadCount(Long userId) {

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -14,6 +14,8 @@ import org.solmate.domain.social.enums.MentoringStatus;
 import org.solmate.domain.social.repository.MentoringRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
+import org.solmate.domain.notification.dto.response.NotificationResponse;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ public class MentoringService {
     private final MentoringRepository mentoringRepository;
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
+    private final SimpMessagingTemplate messagingTemplate;
 
     /**
      * 멘토 신청
@@ -78,7 +81,8 @@ public class MentoringService {
                 .content(mentee.getNickname() + "님이 멘토 신청을 보냈습니다.")
                 .payload(payload)
                 .build();
-        notificationRepository.save(notification);
+        Notification savedNotification = notificationRepository.save(notification);
+        messagingTemplate.convertAndSend("/topic/notifications/" + mentor.getId(), NotificationResponse.of(savedNotification));
 
         return MentoringResponse.of(mentoringRelation);
     }
@@ -126,7 +130,8 @@ public class MentoringService {
                 .category(NotificationCategory.MENTORING)
                 .content(relation.getMentor().getNickname() + "님이 멘토 신청을 수락하셨습니다.")
                 .build();
-        notificationRepository.save(notification);
+        Notification savedNotification = notificationRepository.save(notification);
+        messagingTemplate.convertAndSend("/topic/notifications/" + relation.getMentee().getId(), NotificationResponse.of(savedNotification));
 
         return MentoringResponse.of(relation);
     }

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -8,11 +8,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.solmate.domain.account.entity.Account;
 import org.solmate.domain.account.repository.AccountRepository;
+import org.solmate.domain.notification.dto.response.NotificationResponse;
 import org.solmate.domain.notification.entity.Notification;
 import org.solmate.domain.notification.enums.NotificationCategory;
 import org.solmate.domain.notification.enums.NotificationType;
 import org.solmate.domain.notification.repository.NotificationRepository;
 import org.solmate.domain.notification.service.NotificationService;
+import org.solmate.domain.trade.dto.response.TradeHistoryResponse;
 import org.solmate.domain.trade.entity.Holdings;
 import org.solmate.domain.trade.entity.TradeHistory;
 import org.solmate.domain.trade.enums.TradeStatus;
@@ -25,6 +27,7 @@ import org.solmate.domain.trade.repository.TradeHistoryRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +49,7 @@ public class OrderMatchingService {
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
     private final NotificationService notificationService;
+    private final SimpMessagingTemplate messagingTemplate;
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -117,10 +121,12 @@ public class OrderMatchingService {
                     // Redis ZSet에서 제거
                     redisTemplate.opsForZSet().remove(key, json);
 
-                    // 알림 저장
-                    saveNotification(user, tradeHistory, currentPrice, quantity);
+                    // 알림 저장 및 push
+                    Notification notification = saveNotification(user, tradeHistory, currentPrice, quantity);
+                    messagingTemplate.convertAndSend("/topic/trades/" + userId, TradeHistoryResponse.OrderItem.from(tradeHistory));
+                    messagingTemplate.convertAndSend("/topic/notifications/" + userId, NotificationResponse.of(notification));
 
-                    // 팔로워 알림 저장
+                    // 팔로워 알림 저장 및 push
                     notificationService.saveTradeNotifications(user, tradeHistory.getId(), ticker, tradeHistory.getStock().getStockName(), "BUY", currentPrice, quantity);
 
                     log.info("매수 체결 완료 - orderId: {}, ticker: {}, price: {}, quantity: {}", orderId, ticker, currentPrice, quantity);
@@ -182,10 +188,12 @@ public class OrderMatchingService {
                     // Redis ZSet에서 제거
                     redisTemplate.opsForZSet().remove(key, json);
 
-                    // 알림 저장
-                    saveNotification(user, tradeHistory, currentPrice, quantity);
+                    // 알림 저장 및 push
+                    Notification notification = saveNotification(user, tradeHistory, currentPrice, quantity);
+                    messagingTemplate.convertAndSend("/topic/trades/" + userId, TradeHistoryResponse.OrderItem.from(tradeHistory));
+                    messagingTemplate.convertAndSend("/topic/notifications/" + userId, NotificationResponse.of(notification));
 
-                    // 팔로워 알림 저장
+                    // 팔로워 알림 저장 및 push
                     notificationService.saveTradeNotifications(user, tradeHistory.getId(), ticker, tradeHistory.getStock().getStockName(), "SELL", currentPrice, quantity);
 
                     log.info("매도 체결 완료 - orderId: {}, ticker: {}, price: {}, quantity: {}", orderId, ticker, currentPrice, quantity);
@@ -202,7 +210,7 @@ public class OrderMatchingService {
     }
 
     // 체결 알림 저장
-    private void saveNotification(User user, TradeHistory tradeHistory, BigDecimal currentPrice, BigDecimal quantity) {
+    private Notification saveNotification(User user, TradeHistory tradeHistory, BigDecimal currentPrice, BigDecimal quantity) {
         String stockName = tradeHistory.getStock().getStockName();
         String ticker = tradeHistory.getStock().getTickerCode();
         String side = tradeHistory.getTradeType() == TradeType.BUY ? "BUY" : "SELL";
@@ -232,7 +240,7 @@ public class OrderMatchingService {
             .payload(payload)
             .build();
 
-        notificationRepository.save(notification);
+        return notificationRepository.save(notification);
     }
 
     // 매수 체결 시 Holdings 업데이트 (없으면 생성, 있으면 평균단가 재계산)

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -114,7 +114,7 @@ public class TradeService {
         addOrderToRedis("orders:buy:" + request.ticker(), tradeHistory.getId(), userId, price, request.quantity());
 
         OrderResponse response = OrderResponse.of(tradeHistory);
-        messagingTemplate.convertAndSend("/topic/trades/" + userId, response);
+        messagingTemplate.convertAndSend("/topic/trades/" + userId, TradeHistoryResponse.OrderItem.from(tradeHistory));
         return response;
     }
 
@@ -178,7 +178,7 @@ public class TradeService {
         addOrderToRedis("orders:sell:" + request.ticker(), tradeHistory.getId(), userId, price, request.quantity());
 
         OrderResponse response = OrderResponse.of(tradeHistory);
-        messagingTemplate.convertAndSend("/topic/trades/" + userId, response);
+        messagingTemplate.convertAndSend("/topic/trades/" + userId, TradeHistoryResponse.OrderItem.from(tradeHistory));
         return response;
     }
 

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -31,6 +31,7 @@ import org.solmate.domain.trade.repository.TradeHistoryRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +52,7 @@ public class TradeService {
     private final TradeDiaryRepository tradeDiaryRepository;
     private final StringRedisTemplate redisTemplate;
     private final S3Service s3Service;
+    private final SimpMessagingTemplate messagingTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
@@ -111,7 +113,9 @@ public class TradeService {
         // Redis ZSet에 주문 추가
         addOrderToRedis("orders:buy:" + request.ticker(), tradeHistory.getId(), userId, price, request.quantity());
 
-        return OrderResponse.of(tradeHistory);
+        OrderResponse response = OrderResponse.of(tradeHistory);
+        messagingTemplate.convertAndSend("/topic/trades/" + userId, response);
+        return response;
     }
 
     @Transactional
@@ -173,7 +177,9 @@ public class TradeService {
         // Redis ZSet에 주문 추가
         addOrderToRedis("orders:sell:" + request.ticker(), tradeHistory.getId(), userId, price, request.quantity());
 
-        return OrderResponse.of(tradeHistory);
+        OrderResponse response = OrderResponse.of(tradeHistory);
+        messagingTemplate.convertAndSend("/topic/trades/" + userId, response);
+        return response;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #115

## 💡 작업 배경
- 주문 체결 시 실시간으로 알림 오게 만들었다.


## 🧩 작업 내용
  실시간 거래내역
  - 주문 접수(PENDING) 시 /topic/trades/{userId} 로 push
  - 체결 완료(FILLED) 시 /topic/trades/{userId} 로 push
  - 두 경우 모두 TradeHistoryResponse.OrderItem 구조로 통일

  실시간 알림
  - 체결 완료 시 본인에게 /topic/notifications/{userId} push
  - 체결 완료 시 팔로워들 각각 /topic/notifications/{followerId} push
  - 멘토링 신청 시 멘토에게 /topic/notifications/{mentorId} push
  - 멘토링 수락 시 멘티에게 /topic/notifications/{menteeId} push

  로그인 응답에 userId 추가
  - 프론트가 WebSocket 토픽 구독 시 userId 필요하여 LoginResponse에 추가
  - 일반 로그인, 구글 로그인 모두 적용

## 📸 스크린샷(선택)


## 📝 기타
