### PR TITLE
[Feat] Prometheus, Grafana 설정

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -5,4 +5,6 @@ scrape_configs:
   - job_name: 'solmate-be'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['host.docker.internal:8080']
+      - targets:
+          - 'host.docker.internal:8080'
+          - 'host.docker.internal:8081'


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #139

 ## 💡 작업 배경                                                                                                                                                                  
  서비스 상태 모니터링을 위해 Prometheus + Grafana를 도입하고, 조회 성능 병목(N+1, Redis 직렬 호출)을 개선합니다.
                                                                                                                                                                                   
 ## 🧩 작업 내용
  - `docker-compose-monitoring.yml` 추가 — Prometheus(9090), Grafana(3001) 구성                                                                                                    
  - 블루그린 배포 환경에 맞게 8080/8081 포트 둘 다 scrape하도록 prometheus.yml 수정                                                                                                
  - Grafana 커스텀 대시보드 및 datasource provisioning 설정 추가                                                                                                                   
  - Holdings/Portfolio 조회 N+1 제거 (Redis + DB 배치 조회)                                                                                                                        
  - Redis Pipeline 적용으로 종목 목록 조회 성능 개선                                                                                                                               
  - 읽기 전용 메서드에 `@Transactional(readOnly = true)` 적용                                                                                                                      
  - `ObjectMapper` Bean 주입으로 중복 인스턴스 제거                                                                                                                                
                                                                                                                                                                                   
  ## 📸 스크린샷(선택)      
<img width="1136" height="766" alt="image" src="https://github.com/user-attachments/assets/466b6e76-c23d-4764-b23b-466dff049c7f" />        
<img width="1136" height="766" alt="image" src="https://github.com/user-attachments/assets/c883f165-9448-44ca-89d4-c30506253da5" />
                                                                                                                       
                                                                                                                                                                                   
  ## 📝 기타                                                                                                                                                                       
  EC2 배포 환경에서는 모니터링 파일을 수동으로 전송 후 `docker compose -f docker-compose-monitoring.yml up -d` 실행 필요
                
