### PR TITLE
[Feat] 관심 종목 api 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/ErrorStatus.java
+++ b/src/main/java/org/solmate/common/status/ErrorStatus.java
@@ -94,6 +94,12 @@ public enum ErrorStatus implements BaseStatus {
     FOLLOW_NOT_FOUND("FOLLOW_404", HttpStatus.NOT_FOUND, "팔로우 관계를 찾을 수 없습니다."),
 
     /**
+     * Watchlist
+     */
+    WATCHLIST_ALREADY_EXISTS("WATCHLIST_409", HttpStatus.CONFLICT, "이미 관심종목에 추가된 종목입니다."),
+    WATCHLIST_NOT_FOUND("WATCHLIST_404", HttpStatus.NOT_FOUND, "관심종목에 없는 종목입니다."),
+
+    /**
      * Admin
      */
     MARKET_CAP_UPDATE_FAILED("ADMIN_500", HttpStatus.INTERNAL_SERVER_ERROR, "시가총액 업데이트에 실패했습니다.");

--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -66,6 +66,13 @@ public enum SuccessStatus implements BaseStatus {
 
 
     /**
+     * Watchlist
+     */
+    WATCHLIST_ADD_SUCCESS("WATCHLIST_201", HttpStatus.CREATED, "관심종목 추가 성공"),
+    WATCHLIST_REMOVE_SUCCESS("WATCHLIST_200", HttpStatus.OK, "관심종목 제거 성공"),
+    WATCHLIST_GET_SUCCESS("WATCHLIST_200_1", HttpStatus.OK, "관심종목 목록 조회 성공"),
+
+    /**
      * Admin
      */
     MARKET_CAP_UPDATE_SUCCESS("ADMIN_200", HttpStatus.OK, "시가총액 업데이트 성공");

--- a/src/main/java/org/solmate/domain/watchlist/controller/WatchlistController.java
+++ b/src/main/java/org/solmate/domain/watchlist/controller/WatchlistController.java
@@ -1,0 +1,50 @@
+package org.solmate.domain.watchlist.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.solmate.common.response.ApiResponse;
+import org.solmate.common.status.SuccessStatus;
+import org.solmate.domain.watchlist.service.WatchlistService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Watchlist", description = "관심종목 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/watchlist")
+public class WatchlistController {
+
+    private final WatchlistService watchlistService;
+
+    @Operation(summary = "관심종목 추가")
+    @PostMapping("/{tickerCode}")
+    public ResponseEntity<ApiResponse<Void>> addWatchlist(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String tickerCode
+    ) {
+        watchlistService.addWatchlist(userId, tickerCode);
+        return ApiResponse.success(SuccessStatus.WATCHLIST_ADD_SUCCESS);
+    }
+
+    @Operation(summary = "관심종목 제거")
+    @DeleteMapping("/{tickerCode}")
+    public ResponseEntity<ApiResponse<Void>> removeWatchlist(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable String tickerCode
+    ) {
+        watchlistService.removeWatchlist(userId, tickerCode);
+        return ApiResponse.success(SuccessStatus.WATCHLIST_REMOVE_SUCCESS);
+    }
+
+    @Operation(summary = "내 관심종목 ticker 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<String>>> getWatchlist(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.success(SuccessStatus.WATCHLIST_GET_SUCCESS, watchlistService.getWatchlist(userId));
+    }
+}

--- a/src/main/java/org/solmate/domain/watchlist/entity/Watchlist.java
+++ b/src/main/java/org/solmate/domain/watchlist/entity/Watchlist.java
@@ -1,0 +1,36 @@
+package org.solmate.domain.watchlist.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.solmate.common.base.BaseEntity;
+import org.solmate.domain.stock.entity.Stock;
+import org.solmate.domain.user.entity.User;
+
+@Entity
+@Table(name = "watch_list",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "stock_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Watchlist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    @Builder
+    public Watchlist(User user, Stock stock) {
+        this.user = user;
+        this.stock = stock;
+    }
+}

--- a/src/main/java/org/solmate/domain/watchlist/repository/WatchlistRepository.java
+++ b/src/main/java/org/solmate/domain/watchlist/repository/WatchlistRepository.java
@@ -1,0 +1,21 @@
+package org.solmate.domain.watchlist.repository;
+
+import org.solmate.domain.stock.entity.Stock;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.watchlist.entity.Watchlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
+
+    boolean existsByUserAndStock(User user, Stock stock);
+
+    Optional<Watchlist> findByUserAndStock(User user, Stock stock);
+
+    @Query("SELECT w.stock.tickerCode FROM Watchlist w WHERE w.user.id = :userId")
+    List<String> findTickerCodesByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/org/solmate/domain/watchlist/service/WatchlistService.java
+++ b/src/main/java/org/solmate/domain/watchlist/service/WatchlistService.java
@@ -1,0 +1,61 @@
+package org.solmate.domain.watchlist.service;
+
+import lombok.RequiredArgsConstructor;
+import org.solmate.common.exception.GeneralException;
+import org.solmate.common.status.ErrorStatus;
+import org.solmate.domain.stock.entity.Stock;
+import org.solmate.domain.stock.repository.StockRepository;
+import org.solmate.domain.user.entity.User;
+import org.solmate.domain.user.repository.UserRepository;
+import org.solmate.domain.watchlist.entity.Watchlist;
+import org.solmate.domain.watchlist.repository.WatchlistRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WatchlistService {
+
+    private final WatchlistRepository watchlistRepository;
+    private final UserRepository userRepository;
+    private final StockRepository stockRepository;
+
+    @Transactional
+    public void addWatchlist(Long userId, String tickerCode) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Stock stock = stockRepository.findByTickerCode(tickerCode)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+
+        if (watchlistRepository.existsByUserAndStock(user, stock)) {
+            throw new GeneralException(ErrorStatus.WATCHLIST_ALREADY_EXISTS);
+        }
+
+        watchlistRepository.save(Watchlist.builder()
+                .user(user)
+                .stock(stock)
+                .build());
+    }
+
+    @Transactional
+    public void removeWatchlist(Long userId, String tickerCode) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Stock stock = stockRepository.findByTickerCode(tickerCode)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.STOCK_NOT_FOUND));
+
+        Watchlist watchlist = watchlistRepository.findByUserAndStock(user, stock)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.WATCHLIST_NOT_FOUND));
+
+        watchlistRepository.delete(watchlist);
+    }
+
+    public List<String> getWatchlist(Long userId) {
+        return watchlistRepository.findTickerCodesByUserId(userId);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #147

## 💡 작업 배경
 관심종목 탭 기능 구현을 위해 사용자가 특정 종목을 관심종목으로 추가/제거하고 목록을 조회할 수 있는 API가 필요했습니다.

## 🧩 작업 내용
- watch_list 테이블 생성 (User, Stock ManyToOne, unique constraint on user_id + stock_id)                     
 - 관심종목 추가 API: POST /api/watchlist/{tickerCode}
 - 관심종목 제거 API: DELETE /api/watchlist/{tickerCode}                                                       
 - 관심종목 목록 조회 API: GET /api/watchlist → tickerCode 리스트 반환                                         
 - ErrorStatus에 WATCHLIST_ALREADY_EXISTS, WATCHLIST_NOT_FOUND 추가                                            
 - SuccessStatus에 WATCHLIST_ADD_SUCCESS, WATCHLIST_REMOVE_SUCCESS, WATCHLIST_GET_SUCCESS 추가

## 📸 스크린샷(선택)


## 📝 기타
  - 프론트에서 전체 종목 목록(GET /api/stocks)을 이미 보유하고 있으므로, 관심종목 조회는 tickerCode 리스트만    
  반환하여 프론트에서 필터링하는 방식으로 설계
  - 기존 도메인(stock, trade, user, follow, mentoring) 코드 변경 없음