### PR TITLE
[Fix]1분봉 적재 안되는 오류 수정

### DIFF
--- a/src/main/java/org/solmate/common/config/SchedulerConfig.java
+++ b/src/main/java/org/solmate/common/config/SchedulerConfig.java
@@ -1,0 +1,20 @@
+package org.solmate.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    // 스케줄러 스레드풀: 1분봉/5분봉/30분봉/60분봉/일봉 flush가 동시에 실행될 수 있도록
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("candle-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        return scheduler;
+    }
+}

--- a/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/DailyCandleRepository.java
@@ -6,8 +6,10 @@ import java.util.Optional;
 
 import org.solmate.domain.stock.entity.DailyCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
 
@@ -20,4 +22,22 @@ public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> 
     // 여러 종목의 가장 최근 일봉 한 번에 조회
     @Query("SELECT d FROM DailyCandle d WHERE d.stockCode IN :tickerCodes AND d.candleTime = (SELECT MAX(d2.candleTime) FROM DailyCandle d2 WHERE d2.stockCode = d.stockCode)")
     List<DailyCandle> findLatestByStockCodes(@Param("tickerCodes") List<String> tickerCodes);
+
+    @Modifying
+    @Transactional
+    @Query(value =
+        "INSERT INTO daily_candle " +
+        "(stock_code, open_price, high_price, low_price, close_price, volume, candle_time) " +
+        "VALUES (:stockCode, :openPrice, :highPrice, :lowPrice, :closePrice, :volume, :candleTime) " +
+        "ON CONFLICT DO NOTHING",
+        nativeQuery = true)
+    int insertIgnoreDuplicate(
+        @Param("stockCode")  String stockCode,
+        @Param("openPrice")  Long openPrice,
+        @Param("highPrice")  Long highPrice,
+        @Param("lowPrice")   Long lowPrice,
+        @Param("closePrice") Long closePrice,
+        @Param("volume")     Long volume,
+        @Param("candleTime") LocalDateTime candleTime
+    );
 }

--- a/src/main/java/org/solmate/domain/stock/repository/MinuteCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/MinuteCandleRepository.java
@@ -5,10 +5,32 @@ import java.util.List;
 
 import org.solmate.domain.stock.entity.MinuteCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MinuteCandleRepository extends JpaRepository<MinuteCandle, Long> {
 
     // 특정 종목의 시간 범위 내 1분봉 조회 (오름차순)
     List<MinuteCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
+
+    @Modifying
+    @Transactional
+    @Query(value =
+        "INSERT INTO minute_candle " +
+        "(stock_code, open_price, high_price, low_price, close_price, volume, candle_time) " +
+        "VALUES (:stockCode, :openPrice, :highPrice, :lowPrice, :closePrice, :volume, :candleTime) " +
+        "ON CONFLICT DO NOTHING",
+        nativeQuery = true)
+    int insertIgnoreDuplicate(
+        @Param("stockCode")  String stockCode,
+        @Param("openPrice")  Long openPrice,
+        @Param("highPrice")  Long highPrice,
+        @Param("lowPrice")   Long lowPrice,
+        @Param("closePrice") Long closePrice,
+        @Param("volume")     Long volume,
+        @Param("candleTime") LocalDateTime candleTime
+    );
 }

--- a/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
@@ -32,47 +32,38 @@ public class CandleScheduler {
     private final CandleLoadService candleLoadService;
     private final LsWebSocketClient lsWebSocketClient;
 
-    // 매 분 00초 - 1분봉 DB 저장
+    // 매 분 00초: 1분봉 DB 저장
     @Scheduled(cron = "0 * * * * MON-FRI")
     public void flushMinuteCandles() {
         Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.debug("1분봉 스케줄러 실행 - 구독 종목 수: {}", codes.size());
         codes.forEach(candleAccumulatorService::flushMinuteCandle);
     }
 
-    // 매 5분 - 5분봉 Redis 초기화
+    // 매 5분: 5분봉 Redis 초기화
     @Scheduled(cron = "0 */5 * * * MON-FRI")
     public void flush5MinCandles() {
-        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.debug("5분봉 스케줄러 실행");
-        codes.forEach(candleAccumulatorService::flush5MinCandle);
+        lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flush5MinCandle);
     }
 
-    // 매 30분 - 30분봉 Redis 초기화
+    // 매 30분: 30분봉 Redis 초기화
     @Scheduled(cron = "0 */30 * * * MON-FRI")
     public void flush30MinCandles() {
-        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.debug("30분봉 스케줄러 실행");
-        codes.forEach(candleAccumulatorService::flush30MinCandle);
+        lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flush30MinCandle);
     }
 
-    // 매 정시 - 60분봉 Redis 초기화
+    // 매 정시: 60분봉 Redis 초기화
     @Scheduled(cron = "0 0 * * * MON-FRI")
     public void flush60MinCandles() {
-        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.debug("60분봉 스케줄러 실행");
-        codes.forEach(candleAccumulatorService::flush60MinCandle);
+        lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flush60MinCandle);
     }
 
-    // 에프터마켓 종료 20:00 - 일봉 DB 저장
+    // 20:00 에프터마켓 종료: 일봉 DB 저장
     @Scheduled(cron = "0 0 20 * * MON-FRI")
     public void flushDailyCandles() {
-        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        log.debug("일봉 스케줄러 실행");
-        codes.forEach(candleAccumulatorService::flushDailyCandle);
+        lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flushDailyCandle);
     }
 
-    // 매일 오전 07:00 - 전 영업일 분봉/일봉 백필 (서버 다운 등으로 누락된 데이터 보정)
+    // 07:00 전 영업일 분봉/일봉 백필 (누락 데이터 보정)
     @Async
     @Scheduled(cron = "0 0 7 * * MON-FRI")
     public void backfillCandles() {
@@ -91,16 +82,20 @@ public class CandleScheduler {
             if (candleLoadService.loadUnifiedDailyCandles(code, yesterday, yesterday)) dailySuccess++;
             else dailyFail++;
         }
+
         log.info("┌─────────────────────────────────────────────");
         log.info("│ [캔들 백필 완료] 분봉 성공={}건/실패={}건, 일봉 성공={}건/실패={}건",
                 minuteSuccess, minuteFail, dailySuccess, dailyFail);
+        if (minuteSuccess == 0) {
+            log.warn("│ [백필 경고] 분봉 적재 성공 0건 - 대상일({})이 공휴일이거나 API 오류일 수 있음", yesterday);
+        }
         log.info("└─────────────────────────────────────────────");
     }
 
-    // 직전 영업일 계산 (월요일이면 금요일, 그 외는 어제)
+    // 직전 영업일 계산
     private LocalDate lastTradingDay(LocalDate date) {
         LocalDate prev = date.minusDays(1);
-        if (prev.getDayOfWeek() == DayOfWeek.SUNDAY)   return prev.minusDays(1); // 일 → 금
+        if (prev.getDayOfWeek() == DayOfWeek.SUNDAY)   return prev.minusDays(2); // 일 → 금
         if (prev.getDayOfWeek() == DayOfWeek.SATURDAY) return prev.minusDays(1); // 토 → 금
         return prev;
     }

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -8,12 +8,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
-import org.solmate.domain.stock.entity.DailyCandle;
-import org.solmate.domain.stock.entity.MinuteCandle;
 import org.solmate.domain.stock.repository.DailyCandleRepository;
 import org.solmate.domain.stock.repository.MinuteCandleRepository;
 import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -25,9 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 public class CandleAccumulatorService {
 
     private static final LocalTime PRE_MARKET_OPEN    = LocalTime.of(8, 0);
-    private static final LocalTime PRE_MARKET_CLOSE   = LocalTime.of(8, 50);
+    private static final LocalTime PRE_MARKET_CLOSE   = LocalTime.of(9, 0);
     private static final LocalTime MARKET_OPEN        = LocalTime.of(9, 0);
-    private static final LocalTime MARKET_CLOSE       = LocalTime.of(15, 30);
+    private static final LocalTime MARKET_CLOSE       = LocalTime.of(15, 40);
     private static final LocalTime AFTER_MARKET_OPEN  = LocalTime.of(15, 40);
     private static final LocalTime AFTER_MARKET_CLOSE = LocalTime.of(20, 0);
 
@@ -37,130 +37,118 @@ public class CandleAccumulatorService {
     private static final String KEY_60MIN = "candle:60min:";
     private static final String KEY_1DAY  = "candle:1day:";
 
-    private static final List<String> ALL_PREFIXES = List.of(
-            KEY_1MIN, KEY_5MIN, KEY_30MIN, KEY_60MIN, KEY_1DAY
-    );
-
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+
+    // Lua 스크립트: OHLCV 원자적 누적
+    private static final DefaultRedisScript<Void> ACCUMULATE_SCRIPT;
+    static {
+        ACCUMULATE_SCRIPT = new DefaultRedisScript<>();
+        ACCUMULATE_SCRIPT.setLocation(new ClassPathResource("scripts/accumulate-candle.lua"));
+        ACCUMULATE_SCRIPT.setResultType(Void.class);
+    }
 
     private final StringRedisTemplate redisTemplate;
     private final MinuteCandleRepository minuteCandleRepository;
     private final DailyCandleRepository dailyCandleRepository;
 
-    // 체결 수신 시 프리마켓/정규장/에프터마켓 여부 확인 후 봉 Redis 키 업데이트
+    // 장 시간 내 체결 수신 시 모든 주기 Redis 키에 OHLCV 누적
     public void accumulate(LsWsStockResponse.Body body) {
         LocalTime now = LocalTime.now(KST);
 
-        boolean isPreMarket    = !now.isBefore(PRE_MARKET_OPEN)   && !now.isAfter(PRE_MARKET_CLOSE);
+        boolean isPreMarket     = !now.isBefore(PRE_MARKET_OPEN)   && !now.isAfter(PRE_MARKET_CLOSE);
         boolean isRegularMarket = !now.isBefore(MARKET_OPEN)       && !now.isAfter(MARKET_CLOSE);
-        boolean isAfterMarket  = !now.isBefore(AFTER_MARKET_OPEN)  && !now.isAfter(AFTER_MARKET_CLOSE);
+        boolean isAfterMarket   = !now.isBefore(AFTER_MARKET_OPEN) && !now.isAfter(AFTER_MARKET_CLOSE);
 
         if (!isPreMarket && !isRegularMarket && !isAfterMarket) return;
 
         String stockCode = body.shcode();
-        long price   = Long.parseLong(body.price().trim());
-        long cvolume = Long.parseLong(body.cvolume().trim());
+        String price     = body.price().trim();
+        String cvolume   = body.cvolume().trim();
+        String startTime = LocalDateTime.now(KST).format(TIME_FORMATTER);
 
-        accumulateKey(KEY_1MIN  + stockCode, price, cvolume);
-        accumulateKey(KEY_5MIN  + stockCode, price, cvolume);
-        accumulateKey(KEY_30MIN + stockCode, price, cvolume);
-        accumulateKey(KEY_60MIN + stockCode, price, cvolume);
-        accumulateKey(KEY_1DAY  + stockCode, price, cvolume);
+        accumulateKey(KEY_1MIN  + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_5MIN  + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_30MIN + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_60MIN + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_1DAY  + stockCode, price, cvolume, startTime);
     }
 
-    // Redis 키에 체결가/거래량 누적 (첫 체결이면 open 세팅, 이후엔 high/low/close/volume 갱신)
-    private void accumulateKey(String key, long price, long cvolume) {
-        Map<Object, Object> current = redisTemplate.opsForHash().entries(key);
-
-        if (current.isEmpty()) {
-            redisTemplate.opsForHash().putAll(key, Map.of(
-                    "open",      String.valueOf(price),
-                    "high",      String.valueOf(price),
-                    "low",       String.valueOf(price),
-                    "close",     String.valueOf(price),
-                    "volume",    String.valueOf(cvolume),
-                    "startTime", LocalDateTime.now(KST).format(TIME_FORMATTER)
-            ));
-        } else {
-            long high   = Math.max(price, Long.parseLong((String) current.get("high")));
-            long low    = Math.min(price, Long.parseLong((String) current.get("low")));
-            long volume = Long.parseLong((String) current.get("volume")) + cvolume;
-
-            redisTemplate.opsForHash().putAll(key, Map.of(
-                    "high",   String.valueOf(high),
-                    "low",    String.valueOf(low),
-                    "close",  String.valueOf(price),
-                    "volume", String.valueOf(volume)
-            ));
-        }
+    private void accumulateKey(String key, String price, String cvolume, String startTime) {
+        redisTemplate.execute(ACCUMULATE_SCRIPT, List.of(key), price, cvolume, startTime);
     }
 
-    // 1분봉 DB 저장 (매 분 00초)
     public void flushMinuteCandle(String stockCode) {
         flushToMinuteDb(stockCode);
     }
 
-    // 5분봉 Redis 초기화 (매 5분)
     public void flush5MinCandle(String stockCode) {
         redisTemplate.delete(KEY_5MIN + stockCode);
-        log.debug("5분봉 초기화: {}", stockCode);
     }
 
-    // 30분봉 Redis 초기화 (매 30분)
     public void flush30MinCandle(String stockCode) {
         redisTemplate.delete(KEY_30MIN + stockCode);
-        log.debug("30분봉 초기화: {}", stockCode);
     }
 
-    // 60분봉 Redis 초기화 (매 60분)
     public void flush60MinCandle(String stockCode) {
         redisTemplate.delete(KEY_60MIN + stockCode);
-        log.debug("60분봉 초기화: {}", stockCode);
     }
 
-    // 일봉 DB 저장 (장 마감 15:30)
     public void flushDailyCandle(String stockCode) {
-        String key = KEY_1DAY + stockCode;
-        Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
-        if (data.isEmpty()) return;
+        String key     = KEY_1DAY + stockCode;
+        String snapKey = key + ":snap";
+
+        try {
+            redisTemplate.rename(key, snapKey);
+        } catch (Exception e) {
+            return;
+        }
+
+        Map<Object, Object> data = redisTemplate.opsForHash().entries(snapKey);
+        if (data.isEmpty() || !isValidCandleData(data)) {
+            log.warn("일봉 불완전 데이터 삭제: {}", stockCode);
+            redisTemplate.delete(snapKey);
+            return;
+        }
 
         try {
             LocalDateTime candleTime = LocalDate.now(KST).atStartOfDay();
 
-            DailyCandle candle = DailyCandle.builder()
-                    .stockCode(stockCode)
-                    .openPrice(Long.parseLong((String) data.get("open")))
-                    .highPrice(Long.parseLong((String) data.get("high")))
-                    .lowPrice(Long.parseLong((String) data.get("low")))
-                    .closePrice(Long.parseLong((String) data.get("close")))
-                    .volume(Long.parseLong((String) data.get("volume")))
-                    .candleTime(candleTime)
-                    .build();
-
-            dailyCandleRepository.save(candle);
-            redisTemplate.delete(key);
+            dailyCandleRepository.insertIgnoreDuplicate(
+                    stockCode,
+                    Long.parseLong((String) data.get("open")),
+                    Long.parseLong((String) data.get("high")),
+                    Long.parseLong((String) data.get("low")),
+                    Long.parseLong((String) data.get("close")),
+                    Long.parseLong((String) data.get("volume")),
+                    candleTime);
             log.info("일봉 저장 완료: {}", stockCode);
         } catch (Exception e) {
             log.error("일봉 저장 실패: {}", stockCode, e);
+        } finally {
+            redisTemplate.delete(snapKey);
         }
     }
 
-    // 현재 진행 중인 봉 Redis 데이터 조회 (API 응답용)
     public Map<Object, Object> getCurrentCandle(String stockCode, String prefix) {
         return redisTemplate.opsForHash().entries(prefix + stockCode);
     }
 
-    // 1분봉 Redis 데이터를 DB에 저장하고 키 삭제
+    // RENAME으로 스냅샷 이동 후 처리 (flush 중 새 체결 유실 방지)
     private void flushToMinuteDb(String stockCode) {
-        String key = KEY_1MIN + stockCode;
-        Map<Object, Object> data = redisTemplate.opsForHash().entries(key);
-        if (data.isEmpty()) return;
+        String key     = KEY_1MIN + stockCode;
+        String snapKey = key + ":snap";
 
-        // 필수 필드 누락 시 불완전한 키 삭제 후 종료
-        if (!isValidCandleData(data)) {
+        try {
+            redisTemplate.rename(key, snapKey); // 원자적 이동, key 없으면 예외
+        } catch (Exception e) {
+            return; // 쌓인 데이터 없음
+        }
+
+        Map<Object, Object> data = redisTemplate.opsForHash().entries(snapKey);
+        if (data.isEmpty() || !isValidCandleData(data)) {
             log.warn("1분봉 불완전 데이터 삭제: {}", stockCode);
-            redisTemplate.delete(key);
+            redisTemplate.delete(snapKey);
             return;
         }
 
@@ -170,21 +158,19 @@ public class CandleAccumulatorService {
                     ? LocalDateTime.parse(startTime, TIME_FORMATTER)
                     : LocalDateTime.now(KST).withSecond(0).withNano(0);
 
-            MinuteCandle candle = MinuteCandle.builder()
-                    .stockCode(stockCode)
-                    .openPrice(Long.parseLong((String) data.get("open")))
-                    .highPrice(Long.parseLong((String) data.get("high")))
-                    .lowPrice(Long.parseLong((String) data.get("low")))
-                    .closePrice(Long.parseLong((String) data.get("close")))
-                    .volume(Long.parseLong((String) data.get("volume")))
-                    .candleTime(candleTime)
-                    .build();
-
-            minuteCandleRepository.save(candle);
-            redisTemplate.delete(key);
+            minuteCandleRepository.insertIgnoreDuplicate(
+                    stockCode,
+                    Long.parseLong((String) data.get("open")),
+                    Long.parseLong((String) data.get("high")),
+                    Long.parseLong((String) data.get("low")),
+                    Long.parseLong((String) data.get("close")),
+                    Long.parseLong((String) data.get("volume")),
+                    candleTime);
             log.debug("1분봉 저장 완료: {} {}", stockCode, candleTime);
         } catch (Exception e) {
             log.error("1분봉 저장 실패: {}", stockCode, e);
+        } finally {
+            redisTemplate.delete(snapKey);
         }
     }
 

--- a/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
@@ -35,14 +35,13 @@ public class CandleLoadService {
     private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+    private static final int MAX_PAGE = 50;
+
     private final LsApiClient lsApiClient;
     private final DataSource dataSource;
     private final StockRepository stockRepository;
 
-    /**
-     * t8452 통합 1분봉 과거 데이터 적재 (KRX+NXT, 프리/에프터마켓 포함)
-     * exchgubun: "K"=KRX, "N"=NXT, "U"=통합
-     */
+    // t8452 통합 1분봉 과거 데이터 적재 (exchgubun: K=KRX, N=NXT, U=통합)
     public boolean loadUnifiedMinuteCandles(String stockCode, String sdate, String edate, String exchgubun) {
         List<MinuteCandle> candles = new ArrayList<>();
 
@@ -51,13 +50,19 @@ public class CandleLoadService {
                     lsApiClient.getUnifiedMinuteCandles(stockCode, sdate, edate, exchgubun);
             collectUnifiedMinuteCandles(response, stockCode, candles);
 
+            int page = 1;
             while (response.hasNext()) {
+                if (page >= MAX_PAGE) {
+                    log.warn("  [통합분봉] 최대 페이지({}) 초과, 중단: stockCode={}", MAX_PAGE, stockCode);
+                    break;
+                }
                 sleep();
                 String ctsDate = response.t8452OutBlock().cts_date();
                 String ctsTime = response.t8452OutBlock().cts_time();
                 response = lsApiClient.getUnifiedMinuteCandlesContinue(
                         stockCode, sdate, edate, ctsDate, ctsTime, exchgubun);
                 collectUnifiedMinuteCandles(response, stockCode, candles);
+                page++;
             }
 
             saveMinuteCandles(candles, stockCode);
@@ -78,7 +83,6 @@ public class CandleLoadService {
         log.info("  [t8452 응답] 건수={}, 첫 봉={} {}, 마지막 봉={} {}",
                 response.candles().size(), first.date(), first.time(), last.date(), last.time());
 
-        // NXT 세션 시간 로깅 (첫 페이지에만 출력됨)
         if (response.t8452OutBlock() != null) {
             log.info("  [NXT 세션] 프리마켓={}-{}, 에프터마켓={}-{}",
                     response.t8452OutBlock().nxt_fm_s_time(), response.t8452OutBlock().nxt_fm_e_time(),
@@ -100,14 +104,12 @@ public class CandleLoadService {
                         .candleTime(candleTime)
                         .build());
             } catch (Exception e) {
-                // log.warn("[통합분봉 파싱 실패] stockCode={}, date={}, time={}", stockCode, item.date(), item.time());
+                // 파싱 실패 항목 스킵
             }
         }
     }
 
-    /**
-     * t8451: 통합 일봉 과거 데이터 적재 (KRX+NXT, 프리/에프터마켓 포함)
-     */
+    // t8451 통합 일봉 과거 데이터 적재
     public boolean loadUnifiedDailyCandles(String stockCode, String sdate, String edate) {
         List<DailyCandle> candles = new ArrayList<>();
 
@@ -115,11 +117,17 @@ public class CandleLoadService {
             LsUnifiedDailyCandleResponse response = lsApiClient.getUnifiedDailyCandles(stockCode, sdate, edate);
             collectUnifiedDailyCandles(response, stockCode, candles);
 
+            int page = 1;
             while (response.hasNext()) {
+                if (page >= MAX_PAGE) {
+                    log.warn("  [통합일봉] 최대 페이지({}) 초과, 중단: stockCode={}", MAX_PAGE, stockCode);
+                    break;
+                }
                 sleep();
                 String ctsDate = response.t8451OutBlock().cts_date();
                 response = lsApiClient.getUnifiedDailyCandlesContinue(stockCode, sdate, edate, ctsDate);
                 collectUnifiedDailyCandles(response, stockCode, candles);
+                page++;
             }
 
             saveDailyCandles(candles, stockCode);
@@ -146,12 +154,12 @@ public class CandleLoadService {
                         .candleTime(candleTime)
                         .build());
             } catch (Exception e) {
-                // log.warn("[통합일봉 파싱 실패] stockCode={}, date={}", stockCode, item.date());
+                // 파싱 실패 항목 스킵
             }
         }
     }
 
-    /** 전체 종목 일괄 적재 - 백그라운드 실행 (HTTP 타임아웃 방지) */
+    // 전체 종목 일괄 적재 (백그라운드)
     @Async
     public void loadAllAsync(int minuteDays, int dailyDays) {
         List<String> codes = stockRepository.findAllTickerCodes();
@@ -183,7 +191,7 @@ public class CandleLoadService {
         log.info("└─────────────────────────────────────────────");
     }
 
-    /** 실패 종목 재적재 - 백그라운드 실행 (HTTP 타임아웃 방지) */
+    // 실패 종목 재적재 (백그라운드)
     @Async
     public void retryAsync(List<String> stockCodes, int minuteDays, int dailyDays) {
         int total = stockCodes.size();
@@ -214,7 +222,7 @@ public class CandleLoadService {
         log.info("└─────────────────────────────────────────────");
     }
 
-    /** LS API rate limit 준수를 위한 대기 (2000ms, WebSocket 호출과 합산 고려) */
+    // LS API rate limit 준수 대기
     private void sleep() {
         try {
             Thread.sleep(2000);

--- a/src/main/java/org/solmate/domain/stock/service/StockService.java
+++ b/src/main/java/org/solmate/domain/stock/service/StockService.java
@@ -76,7 +76,6 @@ public class StockService {
         return StockQuoteResponse.from(response, stockLogo, sectorType);
     }
 
-    @Transactional
     public void updateAllMarketCap() {
         List<Stock> stocks = stockRepository.findAll();
         for (Stock stock : stocks) {
@@ -84,7 +83,8 @@ public class StockService {
                 LsQuoteResponse response = lsApiClient.getQuote(stock.getTickerCode());
                 BigDecimal total = BigDecimal.valueOf(response.t1102OutBlock().total());
                 stock.updateTotal(total);
-                Thread.sleep(200);
+                stockRepository.save(stock);
+                Thread.sleep(1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.warn("시가총액 업데이트 중단 - 종목: {}", stock.getTickerCode());

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -207,7 +207,7 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                 }
             }
         } catch (Exception e) {
-            // log.warn("LS WebSocket 메시지 파싱 실패: {}", e.getMessage());
+            log.debug("LS WebSocket 메시지 파싱 실패: {}", e.getMessage());
         }
     }
 

--- a/src/main/resources/scripts/accumulate-candle.lua
+++ b/src/main/resources/scripts/accumulate-candle.lua
@@ -1,0 +1,48 @@
+-- 캔들 OHLCV 누적 (원자적 실행)
+-- KEYS[1] : Redis 해시 키
+-- ARGV[1] : price (체결가, string)
+-- ARGV[2] : volume (체결량, string)
+-- ARGV[3] : startTime (yyyyMMddHHmm)
+
+local key       = KEYS[1]
+local priceNum  = tonumber(ARGV[1])
+local volumeNum = tonumber(ARGV[2])
+local today     = string.sub(ARGV[3], 1, 8)
+
+if redis.call('EXISTS', key) == 0 then
+    redis.call('HMSET', key,
+        'open',      ARGV[1],
+        'high',      ARGV[1],
+        'low',       ARGV[1],
+        'close',     ARGV[1],
+        'volume',    ARGV[2],
+        'startTime', ARGV[3])
+    return
+end
+
+-- stale 감지: 저장된 날짜가 오늘과 다르면 키 초기화
+local storedStart = redis.call('HGET', key, 'startTime')
+if storedStart and string.sub(storedStart, 1, 8) ~= today then
+    redis.call('DEL', key)
+    redis.call('HMSET', key,
+        'open',      ARGV[1],
+        'high',      ARGV[1],
+        'low',       ARGV[1],
+        'close',     ARGV[1],
+        'volume',    ARGV[2],
+        'startTime', ARGV[3])
+    return
+end
+
+local high = tonumber(redis.call('HGET', key, 'high'))
+local low  = tonumber(redis.call('HGET', key, 'low'))
+local vol  = tonumber(redis.call('HGET', key, 'volume'))
+
+local newHigh = priceNum > high and priceNum or high
+local newLow  = priceNum < low  and priceNum or low
+
+redis.call('HMSET', key,
+    'high',   tostring(math.floor(newHigh)),
+    'low',    tostring(math.floor(newLow)),
+    'close',  ARGV[1],
+    'volume', tostring(math.floor(vol + volumeNum)))


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #149 

## 💡 작업 배경
> 실시간 체결 데이터를 Redis에 누적 후 DB에 저장하는 봉 로직에서 아래 문제들이 발견됨.

  - 스케줄러 시간 변경(8:50 → 7:00) 이후 1분봉 중복 키 제약 위반 오류 발생
  
  - flush 중 새 체결 데이터가 유실되는 구조적 race condition 존재
  
  - OHLCV 누적 과정에서 동시 체결 시 lost update 가능성
  
  - Redis TTL 없는 stale 키로 인해 서버 재시작 시 일봉 데이터 오염 가능성
  
  - 프리마켓 08:50:01 ~ 08:59:59 구간 체결 누락
  
  - 스케줄러 단일 스레드로 인한 flush 지연 가능성
  
  - 월요일 백필 시 직전 영업일 계산 버그

## 🧩 작업 내용

  중복 저장 방지
  - MinuteCandleRepository, DailyCandleRepository에 INSERT... ON CONFLICT DO NOTHING native query 추가
  
  - 백필과 flush가 같은 (stock_code, candle_time)을 동시에 INSERT해도 예외 없이 무시

  flush 중 체결 유실 방지 — Redis RENAME 스냅샷 패턴
  - flush 시 RENAME key → key:snap (원자적)으로 스냅샷 이동
  
  - RENAME 이후 새 체결은 원래 키에 정상 누적, 스냅샷 키에서DB 저장 후 삭제
  
  - 1분봉, 일봉 모두 동일 패턴 적용

  OHLCV 원자적 누적 — Redis Lua 스크립트
  - 기존 Java에서 HGET → 계산 → HSET 방식은 동시 체결 시 lost update 발생
  
  - accumulate-candle.lua로 HGET-계산-HMSET 전체를 단일 원자 연산으로 처리
  
  - stale 키 감지 로직 추가: 저장된 startTime 날짜 ≠ 오늘이면 DEL 후 새 봉 초기화

  프리마켓 gap 수정
  - PRE_MARKET_CLOSE 8:50 → 9:00으로 변경해 08:50:01 ~ 08:59:59 체결 누락 해소
  
  - 기존 AFTER_MARKET_OPEN == MARKET_CLOSE(15:40) 패턴과 동일하게 통일

  스케줄러 안정화
  - lastTradingDay 일요일 케이스 버그 수정: minusDays(1) → minusDays(2) (토→금)
  
  - 백필 전 종목 실패 시 공휴일 가능성 warn 로그 추가
  
  - CandleLoadService 무한 페이지 루프 방지 MAX_PAGE = 50 추가

  스케줄러 멀티스레드 설정
  - SchedulerConfig에 ThreadPoolTaskScheduler(poolSize=5) 등록
  
  - 1분/5분/30분/60분 flush가 동시 실행될 때 스레드 경합 없이 병렬 처리

  시가총액 업데이트 트랜잭션 범위 수정
  - updateAllMarketCap()의 @Transactional 제거: 전체 종목을 단일 트랜잭션으로 묶어 100초+ DB 커넥션 점유하던 문제 해소
  
  - 종목별 stockRepository.save() 명시 호출로 건별 즉시 커밋
  
  - LS API rate limit 대응 sleep 200ms → 1000ms

  WebSocket 예외 처리 개선
  - handleTextMessage 파싱 실패 silent 처리 → log.debug로 추적 가능하게 변경

## 📸 스크린샷(선택)


## 📝 기타
  - Redis Lua 스크립트는 Redis 싱글 스레드 이벤트 루프 위에서 실행되므로 별도 락 없이 원자성 보장
  
  - RENAME 패턴은 Redis 공식 문서에서 권장하는 atomic snapshot 방식
  
  - ON CONFLICT DO NOTHING은 unique constraint 위반 시 예외 없이 skip — Hibernate warn 로그 미발생
  
  - stale 키 자가 치유 방식은 서버 재시작 시 별도 초기화 스크립트 없이 첫 체결 시점에 자동 복구