### PR TITLE
[Feat] 멘토 신청 취소 api 구현

### DIFF
--- a/src/main/java/org/solmate/common/status/SuccessStatus.java
+++ b/src/main/java/org/solmate/common/status/SuccessStatus.java
@@ -45,6 +45,7 @@ public enum SuccessStatus implements BaseStatus {
     MENTORING_REQUEST_SUCCESS("MENTORING_201", HttpStatus.CREATED, "멘토링 신청 성공"),
     MENTORING_ACCEPT_SUCCESS("MENTORING_200_1", HttpStatus.OK, "멘토링 수락 성공"),
     MENTORING_REJECT_SUCCESS("MENTORING_200_2", HttpStatus.OK, "멘토링 거절 성공"),
+    MENTORING_REQUEST_CANCEL_SUCCESS("MENTORING_200_3", HttpStatus.OK, "멘토링 신청 취소 성공"),
     MENTORING_CANCEL_SUCCESS("MENTORING_200_4", HttpStatus.OK, "멘토링 취소 성공"),
     MY_MENTOR_SUCCESS("MENTORING_200_5", HttpStatus.OK, "내 멘토 조회 성공"),
     MY_MENTEE_LIST_SUCCESS("MENTORING_200_6", HttpStatus.OK, "내 멘티 목록 조회 성공"),

--- a/src/main/java/org/solmate/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/org/solmate/domain/notification/dto/response/NotificationResponse.java
@@ -13,7 +13,8 @@ public record NotificationResponse(
     String content,
     boolean isRead,
     String actUrl,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    String eventType
 ) {
     public static NotificationResponse of(Notification notification) {
         return new NotificationResponse(
@@ -23,7 +24,12 @@ public record NotificationResponse(
             notification.getContent(),
             notification.isRead(),
             notification.getActUrl(),
-            notification.getCreatedAt()
+            notification.getCreatedAt(),
+            "CREATE"
         );
+    }
+
+    public static NotificationResponse deleted(Long notificationId) {
+        return new NotificationResponse(notificationId, null, null, null, false, null, null, "DELETE");
     }
 }

--- a/src/main/java/org/solmate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/solmate/domain/notification/repository/NotificationRepository.java
@@ -1,10 +1,13 @@
 package org.solmate.domain.notification.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.solmate.domain.notification.entity.Notification;
 import org.solmate.domain.notification.enums.NotificationCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -15,4 +18,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     long countByUserIdAndIsReadFalseAndIsDeletedFalse(Long userId);
 
     long countByUserIdAndCategoryAndIsReadFalseAndIsDeletedFalse(Long userId, NotificationCategory category);
+
+    // 멘토 신청 취소 시 멘토에게 전송된 알림 조회 (payload의 mentoringRelationId로 식별)
+    @Query(value = "SELECT * FROM notification WHERE user_id = :mentorId AND notification_type = 'MENTORING_REQUEST' AND is_deleted = false AND payload::jsonb->>'mentoringRelationId' = CAST(:relationId AS TEXT)", nativeQuery = true)
+    Optional<Notification> findMentoringRequestNotification(@Param("mentorId") Long mentorId, @Param("relationId") Long relationId);
 }

--- a/src/main/java/org/solmate/domain/social/controller/MentoringController.java
+++ b/src/main/java/org/solmate/domain/social/controller/MentoringController.java
@@ -43,6 +43,21 @@ public class MentoringController {
     }
 
     /**
+     * 멘토 신청 취소 (멘티만 가능)
+     * - PENDING(대기 중) 상태의 신청만 취소 가능
+     * - 멘토에게 전송된 알림도 함께 삭제
+     */
+    @Operation(summary = "멘토 신청 취소")
+    @DeleteMapping("/mentor-requests/{mentorUserId}/pending")
+    public ResponseEntity<ApiResponse<Void>> cancelMentoringRequest(
+            @AuthenticationPrincipal Long menteeId,
+            @PathVariable Long mentorUserId
+    ) {
+        mentoringService.cancelMentoringRequest(menteeId, mentorUserId);
+        return ApiResponse.success(SuccessStatus.MENTORING_REQUEST_CANCEL_SUCCESS, null);
+    }
+
+    /**
      * 멘토링 취소 (멘티만 가능)
      * - ACCEPTED(수락된 관계) 상태만 취소 가능
      * - mentorUserId 기반으로 관계를 조회하므로 프론트에서 relationId 불필요

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -158,6 +158,31 @@ public class MentoringService {
     }
 
     /**
+     * 멘토 신청 취소 (멘티만 가능)
+     * - PENDING(대기 중) 상태의 신청만 취소 가능
+     * - 신청 취소 시 멘토에게 전송된 알림도 함께 소프트딜리트
+     */
+    @Transactional
+    public void cancelMentoringRequest(Long menteeId, Long mentorUserId) {
+        MentoringRelation relation = mentoringRepository
+                .findByMenteeIdAndMentorIdAndStatusIn(menteeId, mentorUserId, List.of(MentoringStatus.PENDING))
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MENTORING_RELATION_NOT_FOUND));
+
+        // 멘토에게 전송된 신청 알림 소프트딜리트 + 실시간 삭제 이벤트 푸시
+        notificationRepository.findMentoringRequestNotification(mentorUserId, relation.getId())
+                .ifPresent(notification -> {
+                    notification.delete();
+                    messagingTemplate.convertAndSend(
+                            "/topic/notifications/" + mentorUserId,
+                            NotificationResponse.deleted(notification.getId()));
+                });
+
+        mentoringRepository.delete(relation);
+    }
+
+    /**
      * 멘토 신청 거절
      * - NotificationService에서 알림의 payload를 파싱한 후 호출됨
      * - 거절 시 멘티에게 별도 알림은 전송하지 않음


### PR DESCRIPTION
 ## #️⃣  관련 이슈                               
  - closed #152 
                                                                                                                
  ## 💡 작업 배경                                                                                               
  멘토 신청 후 대기 중(PENDING) 상태인 신청을 취소하는 기능이 없어 구현                                         
                                                                                                                
  ## 🧩 작업 내용 
  - `DELETE /api/mentor-requests/{mentorUserId}/pending` 엔드포인트 추가                                        
  - 신청 취소 시 멘토에게 전송된 알림 소프트딜리트 처리                                                         
  - 신청 취소 시 `/topic/notifications/{mentorId}` 토픽으로 WebSocket 삭제 이벤트 푸시                          
  - `NotificationResponse`에 `eventType` 필드 추가 (`CREATE` / `DELETE`)                                        
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타                                                                                                    
  - 기존 `DELETE /api/mentor-requests/{mentorUserId}` (ACCEPTED 관계 취소)와 별개 API
  - WebSocket 메시지 수신 시 `eventType` 분기 처리 필요 (프론트 작업 필요)                                      
    - `CREATE` → 알림 추가 (기존 동작 유지)                                                                     
    - `DELETE` → `notificationId`로 해당 알림 목록에서 제거