### PR TITLE
[Feat]  SharedWorker을 위한 경로 허용 설정

### DIFF
--- a/src/main/java/org/solmate/common/config/SecurityConfig.java
+++ b/src/main/java/org/solmate/common/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
 				.requestMatchers("/api/test/**").permitAll()
 				.requestMatchers("/api/dev/**").permitAll()
 				.requestMatchers("/ws/**").permitAll()
+				.requestMatchers("/ws-sockjs").permitAll()
 				.requestMatchers("/static/**", "/*.html").permitAll()
 				.requestMatchers("/api/stocks/**").permitAll()
 				.requestMatchers("/api/admin/**").permitAll()

--- a/src/main/java/org/solmate/common/config/WebSocketConfig.java
+++ b/src/main/java/org/solmate/common/config/WebSocketConfig.java
@@ -18,7 +18,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        //순수 WebSocket -> SharedWorker 등 SockJS 미지원 환경용
         registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*");
+
+        //SockJS 폴백 -기존 브라우저 호환용
+        registry.addEndpoint("/ws-sockjs")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -70,6 +70,9 @@ springdoc:
   swagger-ui:
     tags-sorter: alpha
     operations-sorter: method
+  servers:
+    - url: https://solmate.kro.kr
+      description: Production server
 
 cloud:
   aws:


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #151 

## 💡 작업 배경
-  SharedWorker을 위gotj security에서 경로를 허용해줘야한다.

## 🧩 작업 내용
-  SharedWorker을 위해 security에서 경로를 허용해줘야한다.

## 📸 스크린샷(선택)


## 📝 기타
