### PR TITLE
[Fix] allowedOrigins에 운영 프론트 도메인 추가 및 CORS 설정 정리

### DIFF
--- a/src/main/java/org/solmate/common/config/SecurityConfig.java
+++ b/src/main/java/org/solmate/common/config/SecurityConfig.java
@@ -60,8 +60,7 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowCredentials(true);
-		config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8080"));
-		config.setAllowedOriginPatterns(List.of("*"));
+		config.setAllowedOrigins(List.of("http://localhost:3000", "https://pda-solmate.com"));
 		config.setAllowedMethods(List.of("GET", "POST", "DELETE", "PATCH", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setExposedHeaders(List.of("*"));


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #154

## 💡 작업 배경


## 🧩 작업 내용
  setAllowedOrigins — 어느 프론트에서 오는 요청을 허용할지

  config.setAllowedOrigins(List.of("http://localhost:3000", "https://pda-solmate.com"));
  ▎ "이 도메인에서 오는 요청만 받겠다"

  ▎ 여기 없는 도메인에서 요청하면 브라우저가 응답을 차단 → 로그인 안 됨

  ---
  setAllowCredentials — 쿠키 허용 여부

  config.setAllowCredentials(true);
  ▎ "요청할 때 쿠키도 같이 보내도 돼"

  ▎ 이게 없으면 JWT 토큰이 담긴 쿠키가 전송 안 됨 → 로그인 유지 안 됨

  ---
  setAllowedMethods — 어떤 HTTP 메서드 허용할지

  config.setAllowedMethods(List.of("GET", "POST", "DELETE", "PATCH", "OPTIONS"));
  ▎ "GET, POST 등 이런 방식의 요청만 받겠다"

  ---
  setAllowedHeaders — 어떤 헤더 허용할지

  config.setAllowedHeaders(List.of("*"));
  ▎ "요청에 어떤 헤더든 다 허용"

  ---
  뭐가 문제였고 왜 바꿨나

  문제 1 — 백엔드 도메인이 들어가 있었음

  // 이전 ❌
  List.of("http://localhost:3000", "http://localhost:8080")
  localhost:8080은 백엔드 자기 자신 → 프론트 도메인만 넣어야 하는데 백엔드가 들어가 있었음

  ---
  문제 2 — setAllowedOriginPatterns("*") 가 충돌

  // 이전 ❌
  config.setAllowedOriginPatterns(List.of("*"));
  - setAllowedOrigins랑 setAllowedOriginPatterns 둘 다 쓰면 충돌
  - allowCredentials(true)랑 "*" 같이 쓰면 보안 경고 (모든 도메인 + 쿠키 허용은 위험)

  ---
  결과

  // 이후 ✅
  config.setAllowedOrigins(List.of("http://localhost:3000", "https://pda-solmate.com"));
  // setAllowedOriginPatterns 제거
  프론트 도메인만 명확하게 지정 → 쿠키 정상 전송 + 보안 유지


## 📸 스크린샷(선택)


## 📝 기타
