### PR TITLE
[Fix] 구글 최초 가입 시 계좌 및 시드머니 생성 누락 수정

### DIFF
--- a/src/main/java/org/solmate/domain/auth/service/GoogleService.java
+++ b/src/main/java/org/solmate/domain/auth/service/GoogleService.java
@@ -1,8 +1,11 @@
 package org.solmate.domain.auth.service;
 
+import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 
 import org.solmate.common.jwt.JwtProvider;
+import org.solmate.domain.account.entity.Account;
+import org.solmate.domain.account.repository.AccountRepository;
 import org.solmate.domain.auth.dto.response.GoogleInfoResponse;
 import org.solmate.domain.auth.dto.response.GoogleTokenResponse;
 import org.solmate.domain.auth.dto.response.LoginResponse;
@@ -35,9 +38,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class GoogleService {
 
+    private static final BigDecimal INITIAL_SEED_MONEY = new BigDecimal("10000000");
+
     private final UserRepository userRepository;
     private final LoginTypeRepository loginTypeRepository;
     private final TokenRepository tokenRepository;
+    private final AccountRepository accountRepository;
     private final JwtProvider jwtProvider;
     private final StringRedisTemplate redisTemplate;
 
@@ -152,6 +158,12 @@ public class GoogleService {
                 .providerToken(providerToken)
                 .build();
         tokenRepository.save(token);
+
+        Account account = Account.builder()
+                .user(user)
+                .cash(INITIAL_SEED_MONEY)
+                .build();
+        accountRepository.save(account);
 
         return user;
     }


### PR DESCRIPTION
  ## #️⃣  관련 이슈
  - closed #164                                                                                                 
                                                                                                                
  ## 💡 작업 배경                                                                                               
  구글 소셜 로그인으로 최초 가입 시 계좌가 생성되지 않아                                                        
  이메일 회원가입과 달리 시드머니(천만원)가 지급되지 않는 버그 수정                                             
                                                                                                                
  ## 🧩 작업 내용                                                                                               
  - `GoogleService.createGoogleUser()`에 Account 생성 로직 추가                                                 
  - 이메일 회원가입(`AuthService.signUp()`)과 동일하게 초기 잔액 10,000,000원 지급                              
                                                                                                                
  ## 📸 스크린샷(선택)                                                                                          
                                                                                                                
  ## 📝 기타