### PR TITLE
[Fix]: 무효화 시간 변경

### DIFF
--- a/src/main/java/org/solmate/external/ls/scheduler/LsTokenScheduler.java
+++ b/src/main/java/org/solmate/external/ls/scheduler/LsTokenScheduler.java
@@ -14,7 +14,7 @@ public class LsTokenScheduler {
 
     private final LsWebSocketClient lsWebSocketClient;
 
-    @Scheduled(cron = "0 10 9 * * *")
+    @Scheduled(cron = "0 55 6 * * *")
     public void refreshToken() {
         log.info("LS 토큰 만료 예정 - WebSocket 재연결 시작");
         lsWebSocketClient.reconnect();


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #169 

## 💡 작업 배경
  블루그린 배포 시 신 인스턴스가 LS 토큰을 새로 발급하면서 구 인스턴스의 토큰이 자동 무효화 (IGW00121) → 종목 데이터 로드 불가                                                                                                                                                                                                                                
  또한 토큰 무효화 후 WebSocket 재연결이 실패하면 session == null 상태에서 7시 스케줄러가 no-op이 되어 수동 재시작 전까지 복구 불가                                                
                  
                                                                                              
## 🧩 작업 내용

  원인 분석                                                                                                                                                                        
                  
  - LS는 앱키당 토큰 1개만 허용 → 새 토큰 발급 시 기존 토큰 자동 무효화                                                                                                            
  - reconnect()가 session == null이면 clearToken() 미호출 → Redis에 무효 토큰 유지
  - LsApiClient에 토큰 오류 시 재발급 로직 없음 → 500 에러 그대로 전파                                                                                                             
  - 스케줄러가 LS 토큰 만료 시각(07:00)과 동일하여 충돌 가능성 존재                                                                                                                
                                                                                                                                                                                   
  수정 내용                                                                                                                                                                        
                                                                                                                                                                                   
  - LsTokenScheduler: 크론 0 0 7 * * * → 0 55 6 * * * (LS 만료 5분 전 선제 갱신)                                                                                                   
  - LsWebSocketClient.reconnect(): session 상태와 무관하게 clearToken() 항상 호출, session이 null이면 connect() 직접 실행
  - LsTokenService.refreshToken(): 토큰 강제 재발급 메서드 추가                                                                                                                    
  - LsApiClient.withTokenRetry(): IGW00121 발생 시 토큰 재발급 후 1회 자동 재시도    

## 📸 스크린샷(선택)


## 📝 기타
