### PR TITLE
[Refactor] 캔들 API to 파라미터 추가로 TradingView 무한스크롤   과거 데이터 조회 지원

### DIFF
--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -56,50 +56,56 @@ public class StockController {
     @Operation(
         summary = "분봉 조회",
         description = "unit=1: 1분봉 / unit=5|30|60: DB 1분봉 집계 + Redis 현재 봉. " +
-                      "days 미지정 시 unit별 기본값 적용 (1분=5일, 5분=20일, 30분=60일, 60분=90일)"
+                      "days 미지정 시 unit별 기본값 적용 (1분=5일, 5분=20일, 30분=60일, 60분=90일). " +
+                      "to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)"
     )
     @GetMapping("/{stockCode}/candles/minute")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getMinuteCandles(
             @PathVariable String stockCode,
             @RequestParam(defaultValue = "1") int unit,
-            @RequestParam(defaultValue = "0") int days) {
+            @RequestParam(defaultValue = "0") int days,
+            @RequestParam(required = false) Long to) {
         if (unit != 1 && unit != 5 && unit != 30 && unit != 60) {
             throw new org.solmate.common.exception.GeneralException(
                     org.solmate.common.status.ErrorStatus.INVALID_CANDLE_UNIT);
         }
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMinuteCandles(stockCode, unit, days));
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMinuteCandles(stockCode, unit, days, to));
     }
 
-    @Operation(summary = "일봉 조회", description = "days 미지정 시 365일")
+    @Operation(summary = "일봉 조회", description = "days 미지정 시 365일. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/daily")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getDailyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "365") int days) {
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getDailyCandles(stockCode, days));
+            @RequestParam(defaultValue = "365") int days,
+            @RequestParam(required = false) Long to) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getDailyCandles(stockCode, days, to));
     }
 
-    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). DB 일봉 집계.")
+    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/weekly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getWeeklyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "260") int weeks) {
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyCandles(stockCode, weeks));
+            @RequestParam(defaultValue = "260") int weeks,
+            @RequestParam(required = false) Long to) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyCandles(stockCode, weeks, to));
     }
 
-    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). DB 일봉 집계.")
+    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/monthly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getMonthlyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "120") int months) {
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyCandles(stockCode, months));
+            @RequestParam(defaultValue = "120") int months,
+            @RequestParam(required = false) Long to) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyCandles(stockCode, months, to));
     }
 
-    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. DB 일봉 집계.")
+    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/yearly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getYearlyCandles(
             @PathVariable String stockCode,
-            @RequestParam(defaultValue = "20") int years) {
-        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyCandles(stockCode, years));
+            @RequestParam(defaultValue = "20") int years,
+            @RequestParam(required = false) Long to) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyCandles(stockCode, years, to));
     }
 
     @Operation(summary = "종목 보유현황 조회", description = "보유수량/평균매수가/평가금액/수익률 조회. 수익률은 호출 시점 현재가 기준.")

--- a/src/main/java/org/solmate/domain/stock/service/CandleService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleService.java
@@ -35,14 +35,15 @@ public class CandleService {
      * 분봉 조회
      * unit=1  → DB minute_candle 직접 조회 + Redis 현재 1분봉
      * unit=5|30|60 → DB 1분봉 집계 + Redis 현재 N분봉
+     * to가 있으면 해당 epoch(초) 이전 데이터 조회 (TradingView 무한스크롤)
      */
     @Transactional(readOnly = true)
-    public List<CandleResponse> getMinuteCandles(String stockCode, int unit, int days) {
+    public List<CandleResponse> getMinuteCandles(String stockCode, int unit, int days, Long to) {
         int effectiveDays = days > 0 ? days : defaultDaysForUnit(unit);
         if (unit == 1) {
-            return getOneMinuteCandles(stockCode, effectiveDays);
+            return getOneMinuteCandles(stockCode, effectiveDays, to);
         }
-        return getAggregatedMinuteCandles(stockCode, unit, effectiveDays);
+        return getAggregatedMinuteCandles(stockCode, unit, effectiveDays, to);
     }
 
     // unit별 기본 조회 일수 (days=0으로 요청 시 적용)
@@ -57,12 +58,12 @@ public class CandleService {
     }
 
     // unit=1: DB minute_candle 직접 조회 + Redis 현재 봉
-    private List<CandleResponse> getOneMinuteCandles(String stockCode, int days) {
-        LocalDateTime from = LocalDate.now(KST).minusDays(days - 1).atStartOfDay();
-        LocalDateTime to   = LocalDate.now(KST).atTime(23, 59, 59);
+    private List<CandleResponse> getOneMinuteCandles(String stockCode, int days, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).atTime(23, 59, 59));
+        LocalDateTime from = toDateTime.minusDays(days - 1).toLocalDate().atStartOfDay();
 
         List<MinuteCandle> candles = minuteCandleRepository
-                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
 
         List<CandleResponse> result = new ArrayList<>(
                 candles.stream()
@@ -70,14 +71,15 @@ public class CandleService {
                         .toList()
         );
 
-        appendCurrentCandle(result, stockCode, "candle:1min:");
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:1min:");
         return result;
     }
 
     // unit=5|30|60: DB 1분봉을 N분 단위로 집계 + Redis 현재 N분봉
-    private List<CandleResponse> getAggregatedMinuteCandles(String stockCode, int unit, int days) {
-        LocalDateTime from = LocalDate.now(KST).minusDays(days - 1).atStartOfDay();
-        LocalDateTime to   = LocalDate.now(KST).atTime(23, 59, 59);
+    private List<CandleResponse> getAggregatedMinuteCandles(String stockCode, int unit, int days, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).atTime(23, 59, 59));
+        LocalDateTime from = toDateTime.minusDays(days - 1).toLocalDate().atStartOfDay();
+        LocalDateTime to   = toDateTime;
 
         List<MinuteCandle> oneMinCandles = minuteCandleRepository
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
@@ -95,18 +97,18 @@ public class CandleService {
         }
 
         String redisPrefix = "candle:" + unit + "min:";
-        appendCurrentCandle(result, stockCode, redisPrefix);
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, redisPrefix);
         return result;
     }
 
     // 일봉 조회 (DB + 오늘 진행 중인 봉 포함)
     @Transactional(readOnly = true)
-    public List<CandleResponse> getDailyCandles(String stockCode, int days) {
-        LocalDateTime from = LocalDate.now(KST).minusDays(days).atStartOfDay();
-        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
+    public List<CandleResponse> getDailyCandles(String stockCode, int days, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
+        LocalDateTime from = toDateTime.minusDays(days);
 
         List<DailyCandle> candles = dailyCandleRepository
-                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
 
         List<CandleResponse> result = new ArrayList<>(
                 candles.stream()
@@ -114,32 +116,32 @@ public class CandleService {
                         .toList()
         );
 
-        appendCurrentCandle(result, stockCode, "candle:1day:");
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:1day:");
         return result;
     }
 
     // 주봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
     @Transactional(readOnly = true)
-    public List<CandleResponse> getWeeklyCandles(String stockCode, int weeks) {
-        LocalDateTime from = LocalDate.now(KST).minusWeeks(weeks).atStartOfDay();
-        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
-        return aggregateDailyCandles(stockCode, from, to, this::toWeekBucketStart);
+    public List<CandleResponse> getWeeklyCandles(String stockCode, int weeks, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
+        LocalDateTime from = toDateTime.minusWeeks(weeks);
+        return aggregateDailyCandles(stockCode, from, toDateTime, this::toWeekBucketStart, toEpoch == null);
     }
 
     // 월봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
     @Transactional(readOnly = true)
-    public List<CandleResponse> getMonthlyCandles(String stockCode, int months) {
-        LocalDateTime from = LocalDate.now(KST).minusMonths(months).atStartOfDay();
-        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
-        return aggregateDailyCandles(stockCode, from, to, this::toMonthBucketStart);
+    public List<CandleResponse> getMonthlyCandles(String stockCode, int months, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
+        LocalDateTime from = toDateTime.minusMonths(months);
+        return aggregateDailyCandles(stockCode, from, toDateTime, this::toMonthBucketStart, toEpoch == null);
     }
 
     // 년봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
     @Transactional(readOnly = true)
-    public List<CandleResponse> getYearlyCandles(String stockCode, int years) {
-        LocalDateTime from = LocalDate.now(KST).minusYears(years).atStartOfDay();
-        LocalDateTime to   = LocalDate.now(KST).plusDays(1).atStartOfDay();
-        return aggregateDailyCandles(stockCode, from, to, this::toYearBucketStart);
+    public List<CandleResponse> getYearlyCandles(String stockCode, int years, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
+        LocalDateTime from = toDateTime.minusYears(years);
+        return aggregateDailyCandles(stockCode, from, toDateTime, this::toYearBucketStart, toEpoch == null);
     }
 
     // DB 일봉을 주어진 버킷 함수로 그룹핑해 집계 + Redis 현재 일봉을 버킷에 merge
@@ -147,7 +149,8 @@ public class CandleService {
             String stockCode,
             LocalDateTime from,
             LocalDateTime to,
-            java.util.function.Function<LocalDate, LocalDate> bucketFn) {
+            java.util.function.Function<LocalDate, LocalDate> bucketFn,
+            boolean appendRedis) {
 
         List<DailyCandle> dailyCandles = dailyCandleRepository
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
@@ -163,8 +166,14 @@ public class CandleService {
             result.add(aggregateDailyCandleList(entry.getValue(), entry.getKey().atStartOfDay()));
         }
 
-        appendCurrentDayCandle(result, stockCode, bucketFn);
+        if (appendRedis) appendCurrentDayCandle(result, stockCode, bucketFn);
         return result;
+    }
+
+    // to epoch(초)가 있으면 해당 LocalDateTime으로 변환, 없으면 기본값 사용
+    private LocalDateTime resolveToDateTime(Long toEpoch, LocalDateTime defaultValue) {
+        if (toEpoch == null) return defaultValue;
+        return LocalDateTime.ofEpochSecond(toEpoch, 0, ZoneOffset.ofHours(9));
     }
 
     // Redis 현재 일봉을 버킷 기준으로 변환해 마지막 봉에 merge (주/월/년봉용)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #156 

## 💡 작업 배경
  연봉 차트 기본 조회 범위가 20년(오늘 기준)으로 고정되어 있었음 -> 2006년 이전 데이터가 표시되지 않는 문제가 있었음.
  근본 원인은 API가 "오늘부터 N년 전"만 지원하고, TradingView 무한스크롤이 요구하는 "특정 시점 이전 N기간"
  조회를 지원하지 않았기 때문.

## 🧩 작업 내용
  - 분봉 / 일봉 / 주봉 / 월봉 / 연봉 조회 API에 to 파라미터(Unix epoch 초) 추가
  - to 지정 시 해당 시점을 기준으로 N기간 이전 데이터 반환
  - to 지정 시 Redis 현재봉 append 스킵 (과거 구간 조회이므로)
  - 기존 to 미지정 요청은 동작 변경 없음 (하위 호환 유지)
  
  ▎ 프론트에서 TradingView getBars 콜백의 periodParams.to를 API의 to 파라미터로 전달, 
       빈 배열 반환 시 onHistoryCallback([], { noData: true }) 처리 필요

## 📸 스크린샷(선택)


## 📝 기타
   연봉 기본값(years=20) 자체는 유지. 무한스크롤로 그 이전 구간을 청크 단위로 추가 요청하는 방식으로 해결.