### PR TITLE
[Fix] 체결 시 Account 잔액 업데이트에 비관적 락 적용

### DIFF
--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -91,7 +91,7 @@ public class OrderMatchingService {
                         .subtract(currentPrice)
                         .multiply(quantity);
 
-                    Account account = accountRepository.findByUser(user).orElse(null);
+                    Account account = accountRepository.findByUserWithLock(user).orElse(null);
                     if (account != null && refund.compareTo(BigDecimal.ZERO) > 0) {
                         account.addCash(refund);
                     }
@@ -151,7 +151,7 @@ public class OrderMatchingService {
                     if (user == null) continue;
 
                     // 현재가 * 수량 → Account에 입금
-                    Account account = accountRepository.findByUser(user).orElse(null);
+                    Account account = accountRepository.findByUserWithLock(user).orElse(null);
                     if (account != null) {
                         account.addCash(currentPrice.multiply(quantity));
                     }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #20 

## 💡 작업 배경
  체결과 취소가 동시에 같은 유저의 Account에 접근할 경우:
  - 체결 스레드: findByUser (락 없음) → addCash(환불)
  - 취소 스레드: findByUserWithLock (비관적 락) → addCash(복원)

  두 스레드가 동시에 같은 Account 행을 읽고 수정하면서 Lost Update 발생 가능. 즉 어느 한 쪽의 잔액 변경분이 덮어써지는 정합성 버그가 존재했음.

## 🧩 작업 내용
 OrderMatchingService 매수/매도 체결 로직에서 Account 조회를 findByUserWithLock으로 변경.
  - matchBuyOrders: accountRepository.findByUser → findByUserWithLock
  - matchSellOrders: accountRepository.findByUser → findByUserWithLock


