### PR TITLE
[Feat] 탈퇴 회원 처리 로직 추가

### DIFF
--- a/src/main/java/org/solmate/domain/auth/service/GoogleService.java
+++ b/src/main/java/org/solmate/domain/auth/service/GoogleService.java
@@ -129,7 +129,7 @@ public class GoogleService {
 
 
     private User findOrCreateUser(GoogleInfoResponse googleInfo, String providerToken) {
-        return userRepository.findByEmail(googleInfo.email())
+        return userRepository.findByEmailAndDeletedAtIsNull(googleInfo.email())
                 .map(user -> {
                     if (!loginTypeRepository.existsByUserAndLoginType(user, OAuthProvider.GOOGLE)) {
                         throw new GeneralException(ErrorStatus.EMAIL_REGISTERED_WITH_EMAIL);

--- a/src/main/java/org/solmate/domain/notification/entity/Notification.java
+++ b/src/main/java/org/solmate/domain/notification/entity/Notification.java
@@ -62,15 +62,19 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private NotificationCategory category;
 
+    @Column(name = "sender_id")
+    private Long senderId;
+
     @Builder
     public Notification(User user, NotificationType notificationType, String content,
-                        String payload, String actUrl, NotificationCategory category) {
+                        String payload, String actUrl, NotificationCategory category, Long senderId) {
         this.user = user;
         this.notificationType = notificationType;
         this.content = content;
         this.payload = payload;
         this.actUrl = actUrl;
         this.category = category;
+        this.senderId = senderId;
         this.isRead = false;
         this.isDeleted = false;
     }

--- a/src/main/java/org/solmate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/solmate/domain/notification/repository/NotificationRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.solmate.domain.notification.entity.Notification;
 import org.solmate.domain.notification.enums.NotificationCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +23,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     // 멘토 신청 취소 시 멘토에게 전송된 알림 조회 (payload의 mentoringRelationId로 식별)
     @Query(value = "SELECT * FROM notification WHERE user_id = :mentorId AND notification_type = 'MENTORING_REQUEST' AND is_deleted = false AND payload::jsonb->>'mentoringRelationId' = CAST(:relationId AS TEXT)", nativeQuery = true)
     Optional<Notification> findMentoringRequestNotification(@Param("mentorId") Long mentorId, @Param("relationId") Long relationId);
+
+    // 탈퇴 시 해당 유저가 발신자인 알림 소프트 딜리트
+    @Modifying
+    @Query("UPDATE Notification n SET n.isDeleted = true WHERE n.senderId = :senderId")
+    void softDeleteBySenderId(@Param("senderId") Long senderId);
 }

--- a/src/main/java/org/solmate/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/solmate/domain/notification/service/NotificationService.java
@@ -190,6 +190,7 @@ public class NotificationService {
                 .category(NotificationCategory.SOCIAL)
                 .content(content)
                 .payload(finalPayload)
+                .senderId(trader.getId())
                 .build())
             .toList();
 

--- a/src/main/java/org/solmate/domain/social/dto/response/CommentResponse.java
+++ b/src/main/java/org/solmate/domain/social/dto/response/CommentResponse.java
@@ -12,9 +12,10 @@ public record CommentResponse(
     LocalDateTime createdAt
 ) {
     public static CommentResponse of(Comment comment, boolean isMentor) {
+        String nickname = comment.getUser().isWithdrawn() ? "탈퇴한 사용자" : comment.getUser().getNickname();
         return new CommentResponse(
             comment.getId(),
-            comment.getUser().getNickname(),
+            nickname,
             isMentor,
             comment.getContent(),
             comment.getCreatedAt()

--- a/src/main/java/org/solmate/domain/social/service/MentoringService.java
+++ b/src/main/java/org/solmate/domain/social/service/MentoringService.java
@@ -80,6 +80,7 @@ public class MentoringService {
                 .category(NotificationCategory.MENTORING)
                 .content(mentee.getNickname() + "님이 멘토 신청을 보냈습니다.")
                 .payload(payload)
+                .senderId(mentee.getId())
                 .build();
         Notification savedNotification = notificationRepository.save(notification);
         messagingTemplate.convertAndSend("/topic/notifications/" + mentor.getId(), NotificationResponse.of(savedNotification));
@@ -129,6 +130,7 @@ public class MentoringService {
                 .notificationType(NotificationType.MENTORING_ACCEPTED)
                 .category(NotificationCategory.MENTORING)
                 .content(relation.getMentor().getNickname() + "님이 멘토 신청을 수락하셨습니다.")
+                .senderId(relation.getMentor().getId())
                 .build();
         Notification savedNotification = notificationRepository.save(notification);
         messagingTemplate.convertAndSend("/topic/notifications/" + relation.getMentee().getId(), NotificationResponse.of(savedNotification));

--- a/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryDetailResponse.java
+++ b/src/main/java/org/solmate/domain/trade/dto/response/TradeDiaryDetailResponse.java
@@ -56,7 +56,7 @@ public record TradeDiaryDetailResponse(
         List<CommentInfo> commentInfos = comments.stream()
             .map(comment -> new CommentInfo(
                 comment.getId(),
-                comment.getUser().getNickname(),
+                comment.getUser().isWithdrawn() ? "탈퇴한 사용자" : comment.getUser().getNickname(),
                 mentoringRepository.existsByMentorIdAndMenteeIdAndStatus(
                     comment.getUser().getId(), currentUserId, MentoringStatus.ACCEPTED),
                 comment.getContent()

--- a/src/main/java/org/solmate/domain/user/entity/User.java
+++ b/src/main/java/org/solmate/domain/user/entity/User.java
@@ -63,6 +63,17 @@ public class User extends BaseEntity {
 
     public void withdraw() {
         this.deletedAt = LocalDateTime.now();
+        this.email = "탈퇴_" + this.id + "_" + this.email;
+        this.nickname = "탈퇴_" + this.id + "_" + this.nickname;
+    }
+
+    public void anonymizeIfNeeded() {
+        if (!this.email.startsWith("탈퇴_")) {
+            this.email = "탈퇴_" + this.id + "_" + this.email;
+        }
+        if (!this.nickname.startsWith("탈퇴_")) {
+            this.nickname = "탈퇴_" + this.id + "_" + this.nickname;
+        }
     }
 
     public boolean isWithdrawn() {

--- a/src/main/java/org/solmate/domain/user/service/UserService.java
+++ b/src/main/java/org/solmate/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.solmate.common.s3.S3Service;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.auth.enums.OAuthProvider;
 import org.solmate.domain.auth.repository.LoginTypeRepository;
+import org.solmate.domain.notification.repository.NotificationRepository;
 import org.solmate.domain.user.entity.User;
 import org.solmate.domain.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +24,7 @@ public class UserService {
     private final S3Service s3Service;
     private final PasswordEncoder passwordEncoder;
     private final LoginTypeRepository loginTypeRepository;
+    private final NotificationRepository notificationRepository;
 
 
     public User getUserByEmail(String email) {
@@ -93,6 +95,7 @@ public class UserService {
             s3Service.deleteFile(user.getImageUrl());
         }
 
+        notificationRepository.softDeleteBySenderId(user.getId());
         user.withdraw();
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #178

## 💡 작업 배경
  탈퇴 기능은 소프트딜리트로 구현되어 있었으나, 탈퇴 이후의 처리가 누락되어 있어 재가입 불가, 개인정보 노출 등의 문제가 발생했다.                                                                                                       
  탈퇴 회원과 관련된 전반적인 후처리 로직을 추가가 필요하다.
                                                                                                                                                                                  

## 🧩 작업 내용

  - 인증 메일 발송 시 이메일 중복 체크 추가                                                                                                                                        
  - 탈퇴 시 이메일/닉네임 익명화 (재가입 허용)                                                                                                                                     
  - 탈퇴 회원 댓글 닉네임 "탈퇴한 사용자"로 표시                                                                                                                                   
  - 탈퇴 시 해당 유저 발신 알림 소프트 딜리트                                                                                                                                      
  - 구글 로그인 시 탈퇴 계정 처리 (findByEmailAndDeletedAtIsNull 적용)      


## 📸 스크린샷(선택)


## 📝 기타
