### PR TITLE
[Refactor] 5분봉/30분봉/주봉/월봉 전용 테이블 추가 및 전 봉 백필/실시간 누적/차트 조회 로직 통합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+k6/
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/org/solmate/domain/auth/service/AuthService.java
+++ b/src/main/java/org/solmate/domain/auth/service/AuthService.java
@@ -99,7 +99,7 @@ public class AuthService {
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(true)  // prod 환경에서는 true로 바꾸어 줄 예정!!
+                .secure(false)  // prod 환경에서는 true로 바꾸어 줄 예정!!
                 .path("/")
                 .maxAge(refreshExpiration / 1000)
                 .sameSite("None")

--- a/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/CandleLoadController.java
@@ -30,16 +30,15 @@ public class CandleLoadController {
 
     @Operation(
             summary = "과거 캔들 데이터 일괄 적재",
-            description = "전체 종목의 분봉(최근 minuteDays일)과 일봉(최근 dailyDays일)을 통합 API(t8452/t8451)로 적재합니다. "
+            description = "전체 종목의 분봉(최근 minuteDays일)과 일봉(상장일 전체)을 통합 API(t8452/t8451)로 적재합니다. "
                         + "백그라운드에서 실행되며 즉시 202를 반환합니다. "
                         + "이미 DB에 존재하는 데이터는 자동으로 스킵됩니다."
     )
     @PostMapping("/load")
     public ResponseEntity<ApiResponse<Void>> loadAll(
-            @RequestParam(defaultValue = "30") int minuteDays,
-            @RequestParam(defaultValue = "3650") int dailyDays
+            @RequestParam(defaultValue = "30") int minuteDays
     ) {
-        candleLoadService.loadAllAsync(minuteDays, dailyDays);
+        candleLoadService.loadAllAsync(minuteDays);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(
                 new ApiResponse<>(true, SuccessStatus.SUCCESS_200.getCode(), "캔들 일괄 적재가 백그라운드에서 시작됐습니다. 서버 로그를 확인하세요.", null)
         );
@@ -76,17 +75,43 @@ public class CandleLoadController {
     }
 
     @Operation(
+            summary = "5분봉/30분봉/주봉/월봉 일괄 적재",
+            description = "전체 종목의 5분봉/30분봉(최근 1500개)과 주봉/월봉(상장일 전체)을 백그라운드에서 적재합니다."
+    )
+    @PostMapping("/load/extended")
+    public ResponseEntity<ApiResponse<Void>> loadExtended() {
+        candleLoadService.loadExtendedAsync();
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(
+                new ApiResponse<>(true, SuccessStatus.SUCCESS_200.getCode(), "확장 캔들 일괄 적재가 백그라운드에서 시작됐습니다.", null)
+        );
+    }
+
+    @Operation(
+            summary = "특정 날짜 5분봉/30분봉/주봉/월봉 수동 백필",
+            description = "전체 종목의 5분봉/30분봉/주봉/월봉을 지정한 날짜 기준으로 적재합니다. "
+                        + "date 형식: yyyyMMdd (예: 20260401). 백그라운드에서 실행되며 즉시 202를 반환합니다."
+    )
+    @PostMapping("/backfill")
+    public ResponseEntity<ApiResponse<Void>> backfill(@RequestParam String date) {
+        log.info("[수동 백필 요청] date={}", date);
+        candleLoadService.backfillForDateAsync(date);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(
+                new ApiResponse<>(true, SuccessStatus.SUCCESS_200.getCode(),
+                        date + " 백필이 백그라운드에서 시작됐습니다. 서버 로그를 확인하세요.", null)
+        );
+    }
+
+    @Operation(
             summary = "특정 종목 캔들 재적재",
-            description = "실패한 종목 코드 목록을 받아 분봉/일봉을 재시도합니다. "
+            description = "실패한 종목 코드 목록을 받아 분봉/일봉(상장일 전체)을 재시도합니다. "
                         + "백그라운드에서 실행되며 즉시 202를 반환합니다."
     )
     @PostMapping("/retry")
     public ResponseEntity<ApiResponse<Void>> retry(
             @RequestBody List<String> stockCodes,
-            @RequestParam(defaultValue = "30") int minuteDays,
-            @RequestParam(defaultValue = "3650") int dailyDays
+            @RequestParam(defaultValue = "30") int minuteDays
     ) {
-        candleLoadService.retryAsync(stockCodes, minuteDays, dailyDays);
+        candleLoadService.retryAsync(stockCodes, minuteDays);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(
                 new ApiResponse<>(true, SuccessStatus.SUCCESS_200.getCode(), "캔들 재적재가 백그라운드에서 시작됐습니다. 서버 로그를 확인하세요.", null)
         );

--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -81,7 +81,7 @@ public class StockController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getDailyCandles(stockCode, days, to));
     }
 
-    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
+    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/weekly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getWeeklyCandles(
             @PathVariable String stockCode,
@@ -90,7 +90,7 @@ public class StockController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyCandles(stockCode, weeks, to));
     }
 
-    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
+    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/monthly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getMonthlyCandles(
             @PathVariable String stockCode,
@@ -99,7 +99,7 @@ public class StockController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyCandles(stockCode, months, to));
     }
 
-    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
+    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/yearly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getYearlyCandles(
             @PathVariable String stockCode,

--- a/src/main/java/org/solmate/domain/stock/entity/FiveMinuteCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/FiveMinuteCandle.java
@@ -1,0 +1,42 @@
+package org.solmate.domain.stock.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@Table(
+    name = "five_minute_candle",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_five_minute_candle_stock_code_candle_time",
+            columnNames = {"stock_code", "candle_time"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_five_minute_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class FiveMinuteCandle extends BaseCandle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "candle_time", nullable = false)
+    private LocalDateTime candleTime;
+}

--- a/src/main/java/org/solmate/domain/stock/entity/MonthlyCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/MonthlyCandle.java
@@ -1,0 +1,42 @@
+package org.solmate.domain.stock.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@Table(
+    name = "monthly_candle",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_monthly_candle_stock_code_candle_time",
+            columnNames = {"stock_code", "candle_time"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_monthly_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class MonthlyCandle extends BaseCandle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "candle_time", nullable = false)
+    private LocalDateTime candleTime;
+}

--- a/src/main/java/org/solmate/domain/stock/entity/ThirtyMinuteCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/ThirtyMinuteCandle.java
@@ -1,0 +1,42 @@
+package org.solmate.domain.stock.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@Table(
+    name = "thirty_minute_candle",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_thirty_minute_candle_stock_code_candle_time",
+            columnNames = {"stock_code", "candle_time"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_thirty_minute_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class ThirtyMinuteCandle extends BaseCandle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "candle_time", nullable = false)
+    private LocalDateTime candleTime;
+}

--- a/src/main/java/org/solmate/domain/stock/entity/WeeklyCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/WeeklyCandle.java
@@ -1,0 +1,42 @@
+package org.solmate.domain.stock.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@Table(
+    name = "weekly_candle",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_weekly_candle_stock_code_candle_time",
+            columnNames = {"stock_code", "candle_time"}
+        )
+    },
+    indexes = {
+        @Index(name = "idx_weekly_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class WeeklyCandle extends BaseCandle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "candle_time", nullable = false)
+    private LocalDateTime candleTime;
+}

--- a/src/main/java/org/solmate/domain/stock/repository/FiveMinuteCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/FiveMinuteCandleRepository.java
@@ -2,34 +2,23 @@ package org.solmate.domain.stock.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.FiveMinuteCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
+public interface FiveMinuteCandleRepository extends JpaRepository<FiveMinuteCandle, Long> {
 
-    List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
+    List<FiveMinuteCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
-
-    // 특정 종목의 가장 최근 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeDesc(String stockCode);
-
-    // 특정 종목의 가장 오래된 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeAsc(String stockCode);
-
-    // 여러 종목의 가장 최근 일봉 한 번에 조회
-    @Query("SELECT d FROM DailyCandle d WHERE d.stockCode IN :tickerCodes AND d.candleTime = (SELECT MAX(d2.candleTime) FROM DailyCandle d2 WHERE d2.stockCode = d.stockCode)")
-    List<DailyCandle> findLatestByStockCodes(@Param("tickerCodes") List<String> tickerCodes);
 
     @Modifying
     @Transactional
     @Query(value =
-        "INSERT INTO daily_candle " +
+        "INSERT INTO five_minute_candle " +
         "(stock_code, open_price, high_price, low_price, close_price, volume, candle_time) " +
         "VALUES (:stockCode, :openPrice, :highPrice, :lowPrice, :closePrice, :volume, :candleTime) " +
         "ON CONFLICT DO NOTHING",

--- a/src/main/java/org/solmate/domain/stock/repository/MonthlyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/MonthlyCandleRepository.java
@@ -2,34 +2,23 @@ package org.solmate.domain.stock.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.MonthlyCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
+public interface MonthlyCandleRepository extends JpaRepository<MonthlyCandle, Long> {
 
-    List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
+    List<MonthlyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
-
-    // 특정 종목의 가장 최근 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeDesc(String stockCode);
-
-    // 특정 종목의 가장 오래된 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeAsc(String stockCode);
-
-    // 여러 종목의 가장 최근 일봉 한 번에 조회
-    @Query("SELECT d FROM DailyCandle d WHERE d.stockCode IN :tickerCodes AND d.candleTime = (SELECT MAX(d2.candleTime) FROM DailyCandle d2 WHERE d2.stockCode = d.stockCode)")
-    List<DailyCandle> findLatestByStockCodes(@Param("tickerCodes") List<String> tickerCodes);
 
     @Modifying
     @Transactional
     @Query(value =
-        "INSERT INTO daily_candle " +
+        "INSERT INTO monthly_candle " +
         "(stock_code, open_price, high_price, low_price, close_price, volume, candle_time) " +
         "VALUES (:stockCode, :openPrice, :highPrice, :lowPrice, :closePrice, :volume, :candleTime) " +
         "ON CONFLICT DO NOTHING",

--- a/src/main/java/org/solmate/domain/stock/repository/ThirtyMinuteCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/ThirtyMinuteCandleRepository.java
@@ -2,34 +2,23 @@ package org.solmate.domain.stock.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.ThirtyMinuteCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
+public interface ThirtyMinuteCandleRepository extends JpaRepository<ThirtyMinuteCandle, Long> {
 
-    List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
+    List<ThirtyMinuteCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
-
-    // 특정 종목의 가장 최근 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeDesc(String stockCode);
-
-    // 특정 종목의 가장 오래된 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeAsc(String stockCode);
-
-    // 여러 종목의 가장 최근 일봉 한 번에 조회
-    @Query("SELECT d FROM DailyCandle d WHERE d.stockCode IN :tickerCodes AND d.candleTime = (SELECT MAX(d2.candleTime) FROM DailyCandle d2 WHERE d2.stockCode = d.stockCode)")
-    List<DailyCandle> findLatestByStockCodes(@Param("tickerCodes") List<String> tickerCodes);
 
     @Modifying
     @Transactional
     @Query(value =
-        "INSERT INTO daily_candle " +
+        "INSERT INTO thirty_minute_candle " +
         "(stock_code, open_price, high_price, low_price, close_price, volume, candle_time) " +
         "VALUES (:stockCode, :openPrice, :highPrice, :lowPrice, :closePrice, :volume, :candleTime) " +
         "ON CONFLICT DO NOTHING",

--- a/src/main/java/org/solmate/domain/stock/repository/WeeklyCandleRepository.java
+++ b/src/main/java/org/solmate/domain/stock/repository/WeeklyCandleRepository.java
@@ -2,34 +2,23 @@ package org.solmate.domain.stock.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
-import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.WeeklyCandle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-public interface DailyCandleRepository extends JpaRepository<DailyCandle, Long> {
+public interface WeeklyCandleRepository extends JpaRepository<WeeklyCandle, Long> {
 
-    List<DailyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
+    List<WeeklyCandle> findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(
             String stockCode, LocalDateTime from, LocalDateTime to);
-
-    // 특정 종목의 가장 최근 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeDesc(String stockCode);
-
-    // 특정 종목의 가장 오래된 일봉 조회
-    Optional<DailyCandle> findTopByStockCodeOrderByCandleTimeAsc(String stockCode);
-
-    // 여러 종목의 가장 최근 일봉 한 번에 조회
-    @Query("SELECT d FROM DailyCandle d WHERE d.stockCode IN :tickerCodes AND d.candleTime = (SELECT MAX(d2.candleTime) FROM DailyCandle d2 WHERE d2.stockCode = d.stockCode)")
-    List<DailyCandle> findLatestByStockCodes(@Param("tickerCodes") List<String> tickerCodes);
 
     @Modifying
     @Transactional
     @Query(value =
-        "INSERT INTO daily_candle " +
+        "INSERT INTO weekly_candle " +
         "(stock_code, open_price, high_price, low_price, close_price, volume, candle_time) " +
         "VALUES (:stockCode, :openPrice, :highPrice, :lowPrice, :closePrice, :volume, :candleTime) " +
         "ON CONFLICT DO NOTHING",

--- a/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
+++ b/src/main/java/org/solmate/domain/stock/scheduler/CandleScheduler.java
@@ -39,13 +39,13 @@ public class CandleScheduler {
         codes.forEach(candleAccumulatorService::flushMinuteCandle);
     }
 
-    // 매 5분: 5분봉 Redis 초기화
+    // 매 5분: 5분봉 DB 저장
     @Scheduled(cron = "0 */5 * * * MON-FRI")
     public void flush5MinCandles() {
         lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flush5MinCandle);
     }
 
-    // 매 30분: 30분봉 Redis 초기화
+    // 매 30분: 30분봉 DB 저장
     @Scheduled(cron = "0 */30 * * * MON-FRI")
     public void flush30MinCandles() {
         lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flush30MinCandle);
@@ -57,46 +57,49 @@ public class CandleScheduler {
         lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flush60MinCandle);
     }
 
-    // 20:00 에프터마켓 종료: 일봉 DB 저장
+    // 20:00 에프터마켓 종료: 일봉 DB 저장 + 이번 달 마지막 영업일이면 월봉도 저장
     @Scheduled(cron = "0 0 20 * * MON-FRI")
     public void flushDailyCandles() {
-        lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flushDailyCandle);
+        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
+        codes.forEach(candleAccumulatorService::flushDailyCandle);
+
+        if (isLastTradingDayOfMonth(LocalDate.now(KST))) {
+            log.info("[월봉 flush] 이번 달 마지막 영업일 - 월봉 DB 저장 시작");
+            codes.forEach(candleAccumulatorService::flushMonthlyCandle);
+        }
     }
 
-    // 07:00 전 영업일 분봉/일봉 백필 (누락 데이터 보정)
+    // 매주 금요일 20:00: 주봉 DB 저장
+    @Scheduled(cron = "0 0 20 * * FRI")
+    public void flushWeeklyCandles() {
+        log.info("[주봉 flush] 금요일 장 마감 - 주봉 DB 저장 시작");
+        lsWebSocketClient.getSubscribedCodes().forEach(candleAccumulatorService::flushWeeklyCandle);
+    }
+
+    // 05:30 전 영업일 캔들 백필 (누락 데이터 보정) - DB 전체 종목 대상
     @Async
-    @Scheduled(cron = "0 0 7 * * MON-FRI")
+    @Scheduled(cron = "0 30 5 * * MON-FRI")
     public void backfillCandles() {
-        Set<String> codes = lsWebSocketClient.getSubscribedCodes();
-        if (codes.isEmpty()) return;
-
         String yesterday = lastTradingDay(LocalDate.now(KST)).format(DATE_FMT);
-        log.info("┌─────────────────────────────────────────────");
-        log.info("│ [캔들 백필 시작] 종목={}개, 대상={}", codes.size(), yesterday);
-        log.info("└─────────────────────────────────────────────");
+        candleLoadService.backfillYesterday(yesterday);
+    }
 
-        int minuteSuccess = 0, minuteFail = 0, dailySuccess = 0, dailyFail = 0;
-        for (String code : codes) {
-            if (candleLoadService.loadUnifiedMinuteCandles(code, yesterday, yesterday, "U")) minuteSuccess++;
-            else minuteFail++;
-            if (candleLoadService.loadUnifiedDailyCandles(code, yesterday, yesterday)) dailySuccess++;
-            else dailyFail++;
+    // 이번 달의 마지막 영업일(월~금)인지 판단
+    private boolean isLastTradingDayOfMonth(LocalDate today) {
+        LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
+        // 말일부터 역으로 탐색해서 첫 영업일 찾기
+        while (lastDay.getDayOfWeek() == DayOfWeek.SATURDAY
+                || lastDay.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            lastDay = lastDay.minusDays(1);
         }
-
-        log.info("┌─────────────────────────────────────────────");
-        log.info("│ [캔들 백필 완료] 분봉 성공={}건/실패={}건, 일봉 성공={}건/실패={}건",
-                minuteSuccess, minuteFail, dailySuccess, dailyFail);
-        if (minuteSuccess == 0) {
-            log.warn("│ [백필 경고] 분봉 적재 성공 0건 - 대상일({})이 공휴일이거나 API 오류일 수 있음", yesterday);
-        }
-        log.info("└─────────────────────────────────────────────");
+        return today.equals(lastDay);
     }
 
     // 직전 영업일 계산
     private LocalDate lastTradingDay(LocalDate date) {
         LocalDate prev = date.minusDays(1);
-        if (prev.getDayOfWeek() == DayOfWeek.SUNDAY)   return prev.minusDays(2); // 일 → 금
-        if (prev.getDayOfWeek() == DayOfWeek.SATURDAY) return prev.minusDays(1); // 토 → 금
+        if (prev.getDayOfWeek() == DayOfWeek.SUNDAY)   return prev.minusDays(2);
+        if (prev.getDayOfWeek() == DayOfWeek.SATURDAY) return prev.minusDays(1);
         return prev;
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleAccumulatorService.java
@@ -1,5 +1,6 @@
 package org.solmate.domain.stock.service;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -9,7 +10,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.solmate.domain.stock.repository.DailyCandleRepository;
+import org.solmate.domain.stock.repository.FiveMinuteCandleRepository;
 import org.solmate.domain.stock.repository.MinuteCandleRepository;
+import org.solmate.domain.stock.repository.MonthlyCandleRepository;
+import org.solmate.domain.stock.repository.ThirtyMinuteCandleRepository;
+import org.solmate.domain.stock.repository.WeeklyCandleRepository;
 import org.solmate.external.ls.dto.websocket.LsWsStockResponse;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -31,16 +36,17 @@ public class CandleAccumulatorService {
     private static final LocalTime AFTER_MARKET_OPEN  = LocalTime.of(15, 40);
     private static final LocalTime AFTER_MARKET_CLOSE = LocalTime.of(20, 0);
 
-    private static final String KEY_1MIN  = "candle:1min:";
-    private static final String KEY_5MIN  = "candle:5min:";
-    private static final String KEY_30MIN = "candle:30min:";
-    private static final String KEY_60MIN = "candle:60min:";
-    private static final String KEY_1DAY  = "candle:1day:";
+    private static final String KEY_1MIN   = "candle:1min:";
+    private static final String KEY_5MIN   = "candle:5min:";
+    private static final String KEY_30MIN  = "candle:30min:";
+    private static final String KEY_60MIN  = "candle:60min:";
+    private static final String KEY_1DAY   = "candle:1day:";
+    private static final String KEY_1WEEK  = "candle:1week:";
+    private static final String KEY_1MONTH = "candle:1month:";
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
-    // Lua 스크립트: OHLCV 원자적 누적
     private static final DefaultRedisScript<Void> ACCUMULATE_SCRIPT;
     static {
         ACCUMULATE_SCRIPT = new DefaultRedisScript<>();
@@ -51,6 +57,10 @@ public class CandleAccumulatorService {
     private final StringRedisTemplate redisTemplate;
     private final MinuteCandleRepository minuteCandleRepository;
     private final DailyCandleRepository dailyCandleRepository;
+    private final FiveMinuteCandleRepository fiveMinuteCandleRepository;
+    private final ThirtyMinuteCandleRepository thirtyMinuteCandleRepository;
+    private final WeeklyCandleRepository weeklyCandleRepository;
+    private final MonthlyCandleRepository monthlyCandleRepository;
 
     // 장 시간 내 체결 수신 시 모든 주기 Redis 키에 OHLCV 누적
     public void accumulate(LsWsStockResponse.Body body) {
@@ -67,35 +77,115 @@ public class CandleAccumulatorService {
         String cvolume   = body.cvolume().trim();
         String startTime = LocalDateTime.now(KST).format(TIME_FORMATTER);
 
-        accumulateKey(KEY_1MIN  + stockCode, price, cvolume, startTime);
-        accumulateKey(KEY_5MIN  + stockCode, price, cvolume, startTime);
-        accumulateKey(KEY_30MIN + stockCode, price, cvolume, startTime);
-        accumulateKey(KEY_60MIN + stockCode, price, cvolume, startTime);
-        accumulateKey(KEY_1DAY  + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_1MIN   + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_5MIN   + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_30MIN  + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_60MIN  + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_1DAY   + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_1WEEK  + stockCode, price, cvolume, startTime);
+        accumulateKey(KEY_1MONTH + stockCode, price, cvolume, startTime);
     }
 
     private void accumulateKey(String key, String price, String cvolume, String startTime) {
         redisTemplate.execute(ACCUMULATE_SCRIPT, List.of(key), price, cvolume, startTime);
     }
 
+    // 1분봉: Redis → DB 저장
     public void flushMinuteCandle(String stockCode) {
-        flushToMinuteDb(stockCode);
+        flushToDb(stockCode, KEY_1MIN, 1, (data, candleTime) ->
+            minuteCandleRepository.insertIgnoreDuplicate(
+                stockCode,
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume")),
+                candleTime),
+            "1분봉");
     }
 
+    // 5분봉: Redis → DB 저장 (startTime을 5분 버킷 시작으로 내림 ex. 09:03 → 09:00)
     public void flush5MinCandle(String stockCode) {
-        redisTemplate.delete(KEY_5MIN + stockCode);
+        flushToDb(stockCode, KEY_5MIN, 5, (data, candleTime) ->
+            fiveMinuteCandleRepository.insertIgnoreDuplicate(
+                stockCode,
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume")),
+                candleTime),
+            "5분봉");
     }
 
+    // 30분봉: Redis → DB 저장 (startTime을 30분 버킷 시작으로 내림 ex. 09:17 → 09:00)
     public void flush30MinCandle(String stockCode) {
-        redisTemplate.delete(KEY_30MIN + stockCode);
+        flushToDb(stockCode, KEY_30MIN, 30, (data, candleTime) ->
+            thirtyMinuteCandleRepository.insertIgnoreDuplicate(
+                stockCode,
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume")),
+                candleTime),
+            "30분봉");
     }
 
+    // 60분봉: Redis 초기화만 (전용 테이블 없음, 30분봉 2개 집계로 조회)
     public void flush60MinCandle(String stockCode) {
         redisTemplate.delete(KEY_60MIN + stockCode);
     }
 
+    // 일봉: Redis → DB 저장
     public void flushDailyCandle(String stockCode) {
-        String key     = KEY_1DAY + stockCode;
+        LocalDateTime candleTime = LocalDate.now(KST).atStartOfDay();
+        flushToDbFixed(stockCode, KEY_1DAY, candleTime, (data, ct) ->
+            dailyCandleRepository.insertIgnoreDuplicate(
+                stockCode,
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume")),
+                ct),
+            "일봉");
+    }
+
+    // 주봉: Redis → DB 저장 (이번 주 월요일 기준 시각으로 저장)
+    public void flushWeeklyCandle(String stockCode) {
+        LocalDateTime candleTime = LocalDate.now(KST).with(DayOfWeek.MONDAY).atStartOfDay();
+        flushToDbFixed(stockCode, KEY_1WEEK, candleTime, (data, ct) ->
+            weeklyCandleRepository.insertIgnoreDuplicate(
+                stockCode,
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume")),
+                ct),
+            "주봉");
+    }
+
+    // 월봉: Redis → DB 저장 (이번 달 1일 기준 시각으로 저장)
+    public void flushMonthlyCandle(String stockCode) {
+        LocalDateTime candleTime = LocalDate.now(KST).withDayOfMonth(1).atStartOfDay();
+        flushToDbFixed(stockCode, KEY_1MONTH, candleTime, (data, ct) ->
+            monthlyCandleRepository.insertIgnoreDuplicate(
+                stockCode,
+                Long.parseLong((String) data.get("open")),
+                Long.parseLong((String) data.get("high")),
+                Long.parseLong((String) data.get("low")),
+                Long.parseLong((String) data.get("close")),
+                Long.parseLong((String) data.get("volume")),
+                ct),
+            "월봉");
+    }
+
+    // startTime을 Redis에서 파싱 후 bucketUnit 분 단위로 내림해서 candleTime으로 사용
+    // bucketUnit=1: 1분봉(그대로), bucketUnit=5: 5분봉, bucketUnit=30: 30분봉
+    private void flushToDb(String stockCode, String keyPrefix, int bucketUnit, CandleSaveAction action, String label) {
+        String key     = keyPrefix + stockCode;
         String snapKey = key + ":snap";
 
         try {
@@ -106,25 +196,54 @@ public class CandleAccumulatorService {
 
         Map<Object, Object> data = redisTemplate.opsForHash().entries(snapKey);
         if (data.isEmpty() || !isValidCandleData(data)) {
-            log.warn("일봉 불완전 데이터 삭제: {}", stockCode);
+            log.warn("{} 불완전 데이터 삭제: {}", label, stockCode);
             redisTemplate.delete(snapKey);
             return;
         }
 
         try {
-            LocalDateTime candleTime = LocalDate.now(KST).atStartOfDay();
+            String startTime = (String) data.get("startTime");
+            LocalDateTime rawTime = (startTime != null)
+                    ? LocalDateTime.parse(startTime, TIME_FORMATTER)
+                    : LocalDateTime.now(KST).withSecond(0).withNano(0);
 
-            dailyCandleRepository.insertIgnoreDuplicate(
-                    stockCode,
-                    Long.parseLong((String) data.get("open")),
-                    Long.parseLong((String) data.get("high")),
-                    Long.parseLong((String) data.get("low")),
-                    Long.parseLong((String) data.get("close")),
-                    Long.parseLong((String) data.get("volume")),
-                    candleTime);
-            log.info("일봉 저장 완료: {}", stockCode);
+            // 버킷 시작 시각으로 내림 (ex. 09:03 → 09:00 for bucketUnit=5)
+            int flooredMinute = (rawTime.getMinute() / bucketUnit) * bucketUnit;
+            LocalDateTime candleTime = rawTime.toLocalDate().atTime(rawTime.getHour(), flooredMinute);
+
+            action.save(data, candleTime);
+            log.debug("{} 저장 완료: {} {}", label, stockCode, candleTime);
         } catch (Exception e) {
-            log.error("일봉 저장 실패: {}", stockCode, e);
+            log.error("{} 저장 실패: {}", label, stockCode, e);
+        } finally {
+            redisTemplate.delete(snapKey);
+        }
+    }
+
+    // candleTime이 고정된 경우 (일봉/주봉/월봉 - 버킷 시작 시각)
+    private void flushToDbFixed(String stockCode, String keyPrefix, LocalDateTime candleTime,
+                                 CandleSaveAction action, String label) {
+        String key     = keyPrefix + stockCode;
+        String snapKey = key + ":snap";
+
+        try {
+            redisTemplate.rename(key, snapKey);
+        } catch (Exception e) {
+            return;
+        }
+
+        Map<Object, Object> data = redisTemplate.opsForHash().entries(snapKey);
+        if (data.isEmpty() || !isValidCandleData(data)) {
+            log.warn("{} 불완전 데이터 삭제: {}", label, stockCode);
+            redisTemplate.delete(snapKey);
+            return;
+        }
+
+        try {
+            action.save(data, candleTime);
+            log.info("{} 저장 완료: {}", label, stockCode);
+        } catch (Exception e) {
+            log.error("{} 저장 실패: {}", label, stockCode, e);
         } finally {
             redisTemplate.delete(snapKey);
         }
@@ -134,51 +253,16 @@ public class CandleAccumulatorService {
         return redisTemplate.opsForHash().entries(prefix + stockCode);
     }
 
-    // RENAME으로 스냅샷 이동 후 처리 (flush 중 새 체결 유실 방지)
-    private void flushToMinuteDb(String stockCode) {
-        String key     = KEY_1MIN + stockCode;
-        String snapKey = key + ":snap";
-
-        try {
-            redisTemplate.rename(key, snapKey); // 원자적 이동, key 없으면 예외
-        } catch (Exception e) {
-            return; // 쌓인 데이터 없음
-        }
-
-        Map<Object, Object> data = redisTemplate.opsForHash().entries(snapKey);
-        if (data.isEmpty() || !isValidCandleData(data)) {
-            log.warn("1분봉 불완전 데이터 삭제: {}", stockCode);
-            redisTemplate.delete(snapKey);
-            return;
-        }
-
-        try {
-            String startTime = (String) data.get("startTime");
-            LocalDateTime candleTime = (startTime != null)
-                    ? LocalDateTime.parse(startTime, TIME_FORMATTER)
-                    : LocalDateTime.now(KST).withSecond(0).withNano(0);
-
-            minuteCandleRepository.insertIgnoreDuplicate(
-                    stockCode,
-                    Long.parseLong((String) data.get("open")),
-                    Long.parseLong((String) data.get("high")),
-                    Long.parseLong((String) data.get("low")),
-                    Long.parseLong((String) data.get("close")),
-                    Long.parseLong((String) data.get("volume")),
-                    candleTime);
-            log.debug("1분봉 저장 완료: {} {}", stockCode, candleTime);
-        } catch (Exception e) {
-            log.error("1분봉 저장 실패: {}", stockCode, e);
-        } finally {
-            redisTemplate.delete(snapKey);
-        }
-    }
-
     private boolean isValidCandleData(Map<Object, Object> data) {
         return data.get("open") != null
                 && data.get("high") != null
                 && data.get("low") != null
                 && data.get("close") != null
                 && data.get("volume") != null;
+    }
+
+    @FunctionalInterface
+    private interface CandleSaveAction {
+        void save(Map<Object, Object> data, LocalDateTime candleTime);
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
@@ -2,6 +2,8 @@ package org.solmate.domain.stock.service;
 
 import java.io.StringReader;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -15,8 +17,17 @@ import javax.sql.DataSource;
 import org.postgresql.copy.CopyManager;
 import org.postgresql.core.BaseConnection;
 import org.solmate.domain.stock.entity.DailyCandle;
+import org.solmate.domain.stock.entity.FiveMinuteCandle;
 import org.solmate.domain.stock.entity.MinuteCandle;
+import org.solmate.domain.stock.entity.MonthlyCandle;
+import org.solmate.domain.stock.entity.ThirtyMinuteCandle;
+import org.solmate.domain.stock.entity.WeeklyCandle;
+import org.solmate.domain.stock.repository.DailyCandleRepository;
+import org.solmate.domain.stock.repository.FiveMinuteCandleRepository;
+import org.solmate.domain.stock.repository.MonthlyCandleRepository;
 import org.solmate.domain.stock.repository.StockRepository;
+import org.solmate.domain.stock.repository.ThirtyMinuteCandleRepository;
+import org.solmate.domain.stock.repository.WeeklyCandleRepository;
 import org.solmate.external.ls.client.LsApiClient;
 import org.solmate.external.ls.dto.response.LsUnifiedDailyCandleResponse;
 import org.solmate.external.ls.dto.response.LsUnifiedMinuteCandleResponse;
@@ -35,11 +46,17 @@ public class CandleLoadService {
     private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
-    private static final int MAX_PAGE = 50;
+    private static final int MAX_PAGE = 200;
+    private static final int MINUTE_CANDLE_LIMIT = 1500;
 
     private final LsApiClient lsApiClient;
     private final DataSource dataSource;
     private final StockRepository stockRepository;
+    private final DailyCandleRepository dailyCandleRepository;
+    private final FiveMinuteCandleRepository fiveMinuteCandleRepository;
+    private final ThirtyMinuteCandleRepository thirtyMinuteCandleRepository;
+    private final WeeklyCandleRepository weeklyCandleRepository;
+    private final MonthlyCandleRepository monthlyCandleRepository;
 
     // t8452 통합 1분봉 과거 데이터 적재 (exchgubun: K=KRX, N=NXT, U=통합)
     public boolean loadUnifiedMinuteCandles(String stockCode, String sdate, String edate, String exchgubun) {
@@ -47,7 +64,7 @@ public class CandleLoadService {
 
         try {
             LsUnifiedMinuteCandleResponse response =
-                    lsApiClient.getUnifiedMinuteCandles(stockCode, sdate, edate, exchgubun);
+                    lsApiClient.getUnifiedMinuteCandles(stockCode, 1, sdate, edate, exchgubun);
             collectUnifiedMinuteCandles(response, stockCode, candles);
 
             int page = 1;
@@ -60,7 +77,7 @@ public class CandleLoadService {
                 String ctsDate = response.t8452OutBlock().cts_date();
                 String ctsTime = response.t8452OutBlock().cts_time();
                 response = lsApiClient.getUnifiedMinuteCandlesContinue(
-                        stockCode, sdate, edate, ctsDate, ctsTime, exchgubun);
+                        stockCode, 1, sdate, edate, ctsDate, ctsTime, exchgubun);
                 collectUnifiedMinuteCandles(response, stockCode, candles);
                 page++;
             }
@@ -70,6 +87,137 @@ public class CandleLoadService {
             return true;
         } catch (Exception e) {
             log.error("  ✗ [통합분봉 적재 실패] stockCode={}, exchgubun={} - {}", stockCode, exchgubun, e.getMessage());
+            sleep();
+            return false;
+        }
+    }
+
+    // t8452 통합 5분봉 과거 데이터 적재 (최근 1500개) - 초기 일괄 적재용
+    public boolean loadFiveMinuteCandles(String stockCode) {
+        List<FiveMinuteCandle> candles = new ArrayList<>();
+        String today = LocalDate.now(KST).format(DATE_FMT);
+
+        try {
+            LsUnifiedMinuteCandleResponse response =
+                    lsApiClient.getUnifiedMinuteCandles(stockCode, 5, "19560101", today, "U");
+            collectFiveMinuteCandles(response, stockCode, candles);
+
+            int page = 1;
+            while (response.hasNext() && candles.size() < MINUTE_CANDLE_LIMIT) {
+                if (page >= MAX_PAGE) break;
+                sleep();
+                String ctsDate = response.t8452OutBlock().cts_date();
+                String ctsTime = response.t8452OutBlock().cts_time();
+                response = lsApiClient.getUnifiedMinuteCandlesContinue(stockCode, 5, "19560101", today, ctsDate, ctsTime, "U");
+                collectFiveMinuteCandles(response, stockCode, candles);
+                page++;
+            }
+
+            if (candles.size() > MINUTE_CANDLE_LIMIT) {
+                candles = candles.subList(0, MINUTE_CANDLE_LIMIT);
+            }
+
+            saveFiveMinuteCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [5분봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
+            return false;
+        }
+    }
+
+    // t8452 통합 5분봉 날짜 범위 적재 - 백필용 (어제 하루만 ~144개)
+    public boolean loadFiveMinuteCandlesForDate(String stockCode, String sdate, String edate) {
+        List<FiveMinuteCandle> candles = new ArrayList<>();
+
+        try {
+            LsUnifiedMinuteCandleResponse response =
+                    lsApiClient.getUnifiedMinuteCandles(stockCode, 5, sdate, edate, "U");
+            collectFiveMinuteCandles(response, stockCode, candles);
+
+            int page = 1;
+            while (response.hasNext()) {
+                if (page >= MAX_PAGE) break;
+                sleep();
+                String ctsDate = response.t8452OutBlock().cts_date();
+                String ctsTime = response.t8452OutBlock().cts_time();
+                response = lsApiClient.getUnifiedMinuteCandlesContinue(stockCode, 5, sdate, edate, ctsDate, ctsTime, "U");
+                collectFiveMinuteCandles(response, stockCode, candles);
+                page++;
+            }
+
+            saveFiveMinuteCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [5분봉 백필 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
+            return false;
+        }
+    }
+
+    // t8452 통합 30분봉 과거 데이터 적재 (최근 1500개) - 초기 일괄 적재용
+    public boolean loadThirtyMinuteCandles(String stockCode) {
+        List<ThirtyMinuteCandle> candles = new ArrayList<>();
+        String today = LocalDate.now(KST).format(DATE_FMT);
+
+        try {
+            LsUnifiedMinuteCandleResponse response =
+                    lsApiClient.getUnifiedMinuteCandles(stockCode, 30, "19560101", today, "U");
+            collectThirtyMinuteCandles(response, stockCode, candles);
+
+            int page = 1;
+            while (response.hasNext() && candles.size() < MINUTE_CANDLE_LIMIT) {
+                if (page >= MAX_PAGE) break;
+                sleep();
+                String ctsDate = response.t8452OutBlock().cts_date();
+                String ctsTime = response.t8452OutBlock().cts_time();
+                response = lsApiClient.getUnifiedMinuteCandlesContinue(stockCode, 30, "19560101", today, ctsDate, ctsTime, "U");
+                collectThirtyMinuteCandles(response, stockCode, candles);
+                page++;
+            }
+
+            if (candles.size() > MINUTE_CANDLE_LIMIT) {
+                candles = candles.subList(0, MINUTE_CANDLE_LIMIT);
+            }
+
+            saveThirtyMinuteCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [30분봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
+            return false;
+        }
+    }
+
+    // t8452 통합 30분봉 날짜 범위 적재 - 백필용 (어제 하루만 ~24개)
+    public boolean loadThirtyMinuteCandlesForDate(String stockCode, String sdate, String edate) {
+        List<ThirtyMinuteCandle> candles = new ArrayList<>();
+
+        try {
+            LsUnifiedMinuteCandleResponse response =
+                    lsApiClient.getUnifiedMinuteCandles(stockCode, 30, sdate, edate, "U");
+            collectThirtyMinuteCandles(response, stockCode, candles);
+
+            int page = 1;
+            while (response.hasNext()) {
+                if (page >= MAX_PAGE) break;
+                sleep();
+                String ctsDate = response.t8452OutBlock().cts_date();
+                String ctsTime = response.t8452OutBlock().cts_time();
+                response = lsApiClient.getUnifiedMinuteCandlesContinue(stockCode, 30, sdate, edate, ctsDate, ctsTime, "U");
+                collectThirtyMinuteCandles(response, stockCode, candles);
+                page++;
+            }
+
+            saveThirtyMinuteCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [30분봉 백필 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
             return false;
         }
     }
@@ -114,7 +262,7 @@ public class CandleLoadService {
         List<DailyCandle> candles = new ArrayList<>();
 
         try {
-            LsUnifiedDailyCandleResponse response = lsApiClient.getUnifiedDailyCandles(stockCode, sdate, edate);
+            LsUnifiedDailyCandleResponse response = lsApiClient.getUnifiedDailyCandles(stockCode, "2", sdate, edate);
             collectUnifiedDailyCandles(response, stockCode, candles);
 
             int page = 1;
@@ -125,7 +273,7 @@ public class CandleLoadService {
                 }
                 sleep();
                 String ctsDate = response.t8451OutBlock().cts_date();
-                response = lsApiClient.getUnifiedDailyCandlesContinue(stockCode, sdate, edate, ctsDate);
+                response = lsApiClient.getUnifiedDailyCandlesContinue(stockCode, "2", sdate, edate, ctsDate);
                 collectUnifiedDailyCandles(response, stockCode, candles);
                 page++;
             }
@@ -135,7 +283,156 @@ public class CandleLoadService {
             return true;
         } catch (Exception e) {
             log.error("  ✗ [통합일봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
             return false;
+        }
+    }
+
+    // 일봉 전체 적재 (상장일부터 오늘까지, 중복은 ON CONFLICT DO NOTHING으로 스킵)
+    public boolean loadMissingDailyCandles(String stockCode) {
+        String today = LocalDate.now(KST).format(DATE_FMT);
+        return loadUnifiedDailyCandles(stockCode, "19560101", today);
+    }
+
+    // t8451 통합 주봉 과거 데이터 적재
+    public boolean loadWeeklyCandles(String stockCode, String sdate, String edate) {
+        List<WeeklyCandle> candles = new ArrayList<>();
+
+        try {
+            LsUnifiedDailyCandleResponse response = lsApiClient.getUnifiedDailyCandles(stockCode, "3", sdate, edate);
+            collectWeeklyCandles(response, stockCode, candles);
+
+            int page = 1;
+            while (response.hasNext()) {
+                if (page >= MAX_PAGE) break;
+                sleep();
+                String ctsDate = response.t8451OutBlock().cts_date();
+                response = lsApiClient.getUnifiedDailyCandlesContinue(stockCode, "3", sdate, edate, ctsDate);
+                collectWeeklyCandles(response, stockCode, candles);
+                page++;
+            }
+
+            saveWeeklyCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [주봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
+            return false;
+        }
+    }
+
+    // t8451 통합 월봉 과거 데이터 적재
+    public boolean loadMonthlyCandles(String stockCode, String sdate, String edate) {
+        List<MonthlyCandle> candles = new ArrayList<>();
+
+        try {
+            LsUnifiedDailyCandleResponse response = lsApiClient.getUnifiedDailyCandles(stockCode, "4", sdate, edate);
+            collectMonthlyCandles(response, stockCode, candles);
+
+            int page = 1;
+            while (response.hasNext()) {
+                if (page >= MAX_PAGE) break;
+                sleep();
+                String ctsDate = response.t8451OutBlock().cts_date();
+                response = lsApiClient.getUnifiedDailyCandlesContinue(stockCode, "4", sdate, edate, ctsDate);
+                collectMonthlyCandles(response, stockCode, candles);
+                page++;
+            }
+
+            saveMonthlyCandles(candles, stockCode);
+            sleep();
+            return true;
+        } catch (Exception e) {
+            log.error("  ✗ [월봉 적재 실패] stockCode={} - {}", stockCode, e.getMessage());
+            sleep();
+            return false;
+        }
+    }
+
+    private void collectFiveMinuteCandles(LsUnifiedMinuteCandleResponse response, String stockCode,
+                                          List<FiveMinuteCandle> candles) {
+        for (LsUnifiedMinuteCandleResponse.OutBlock1 item : response.candles()) {
+            try {
+                String timeStr = item.time().length() >= 6 ? item.time().substring(0, 6) : item.time();
+                LocalDateTime raw = LocalDateTime.parse(item.date() + timeStr, DATETIME_FMT);
+                int floored = (raw.getMinute() / 5) * 5;
+                LocalDateTime candleTime = raw.toLocalDate().atTime(raw.getHour(), floored);
+                candles.add(FiveMinuteCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                // 파싱 실패 항목 스킵
+            }
+        }
+    }
+
+    private void collectThirtyMinuteCandles(LsUnifiedMinuteCandleResponse response, String stockCode,
+                                             List<ThirtyMinuteCandle> candles) {
+        for (LsUnifiedMinuteCandleResponse.OutBlock1 item : response.candles()) {
+            try {
+                String timeStr = item.time().length() >= 6 ? item.time().substring(0, 6) : item.time();
+                LocalDateTime raw = LocalDateTime.parse(item.date() + timeStr, DATETIME_FMT);
+                int floored = (raw.getMinute() / 30) * 30;
+                LocalDateTime candleTime = raw.toLocalDate().atTime(raw.getHour(), floored);
+                candles.add(ThirtyMinuteCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                // 파싱 실패 항목 스킵
+            }
+        }
+    }
+
+    private void collectWeeklyCandles(LsUnifiedDailyCandleResponse response, String stockCode,
+                                       List<WeeklyCandle> candles) {
+        for (LsUnifiedDailyCandleResponse.OutBlock1 item : response.candles()) {
+            try {
+                LocalDateTime candleTime = LocalDate.parse(item.date(), DATE_FMT).atStartOfDay();
+                candles.add(WeeklyCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                // 파싱 실패 항목 스킵
+            }
+        }
+    }
+
+    private void collectMonthlyCandles(LsUnifiedDailyCandleResponse response, String stockCode,
+                                        List<MonthlyCandle> candles) {
+        for (LsUnifiedDailyCandleResponse.OutBlock1 item : response.candles()) {
+            try {
+                LocalDateTime candleTime = LocalDate.parse(item.date(), DATE_FMT).atStartOfDay();
+                candles.add(MonthlyCandle.builder()
+                        .stockCode(stockCode)
+                        .openPrice(item.open())
+                        .highPrice(item.high())
+                        .lowPrice(item.low())
+                        .closePrice(item.close())
+                        .volume(item.jdiff_vol())
+                        .candleTime(candleTime)
+                        .build());
+            } catch (Exception e) {
+                // 파싱 실패 항목 스킵
+            }
         }
     }
 
@@ -161,15 +458,14 @@ public class CandleLoadService {
 
     // 전체 종목 일괄 적재 (백그라운드)
     @Async
-    public void loadAllAsync(int minuteDays, int dailyDays) {
+    public void loadAllAsync(int minuteDays) {
         List<String> codes = stockRepository.findAllTickerCodes();
         int total = codes.size();
         String today      = LocalDate.now(KST).format(DATE_FMT);
         String minuteFrom = LocalDate.now(KST).minusDays(minuteDays).format(DATE_FMT);
-        String dailyFrom  = LocalDate.now(KST).minusDays(dailyDays).format(DATE_FMT);
 
         log.info("┌─────────────────────────────────────────────");
-        log.info("│ [캔들 일괄 적재 시작] 종목={}개, 분봉={}일, 일봉={}일", total, minuteDays, dailyDays);
+        log.info("│ [캔들 일괄 적재 시작] 종목={}개, 분봉={}일, 일봉=상장일 전체", total, minuteDays);
         log.info("└─────────────────────────────────────────────");
 
         AtomicInteger minuteSuccess = new AtomicInteger(), minuteFail = new AtomicInteger();
@@ -180,7 +476,7 @@ public class CandleLoadService {
             log.info("[{}/{}] 적재 중: {}", i + 1, total, code);
             if (loadUnifiedMinuteCandles(code, minuteFrom, today, "U")) minuteSuccess.incrementAndGet();
             else minuteFail.incrementAndGet();
-            if (loadUnifiedDailyCandles(code, dailyFrom, today)) dailySuccess.incrementAndGet();
+            if (loadUnifiedDailyCandles(code, "19560101", today)) dailySuccess.incrementAndGet();
             else dailyFail.incrementAndGet();
         }
 
@@ -191,13 +487,88 @@ public class CandleLoadService {
         log.info("└─────────────────────────────────────────────");
     }
 
+    // 일봉 누락분 + 5분봉/30분봉/주봉/월봉 전체 종목 일괄 적재 (백그라운드)
+    @Async
+    public void loadExtendedAsync() {
+        List<String> codes = stockRepository.findAllTickerCodes();
+        int total = codes.size();
+        String today = LocalDate.now(KST).format(DATE_FMT);
+
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [확장 캔들 일괄 적재 시작] 종목={}개", total);
+        log.info("└─────────────────────────────────────────────");
+
+        int fiveSuccess = 0, fiveFail = 0;
+        int thirtySuccess = 0, thirtyFail = 0;
+        int weeklySuccess = 0, weeklyFail = 0;
+        int monthlySuccess = 0, monthlyFail = 0;
+
+        for (int i = 0; i < codes.size(); i++) {
+            String code = codes.get(i);
+            log.info("[{}/{}] 확장 캔들 적재 중: {}", i + 1, total, code);
+            if (loadFiveMinuteCandles(code)) fiveSuccess++; else fiveFail++;
+            if (loadThirtyMinuteCandles(code)) thirtySuccess++; else thirtyFail++;
+            if (loadWeeklyCandles(code, "19560101", today)) weeklySuccess++; else weeklyFail++;
+            if (loadMonthlyCandles(code, "19560101", today)) monthlySuccess++; else monthlyFail++;
+        }
+
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [확장 캔들 일괄 적재 완료]");
+        log.info("│ 5분봉: 성공 {}건 / 실패 {}건", fiveSuccess, fiveFail);
+        log.info("│ 30분봉: 성공 {}건 / 실패 {}건", thirtySuccess, thirtyFail);
+        log.info("│ 주봉: 성공 {}건 / 실패 {}건", weeklySuccess, weeklyFail);
+        log.info("│ 월봉: 성공 {}건 / 실패 {}건", monthlySuccess, monthlyFail);
+        log.info("└─────────────────────────────────────────────");
+    }
+
+    // 전날 캔들 백필 (스케줄러용) - DB 전체 종목 대상
+    public void backfillYesterday(String date) {
+        backfill(date);
+    }
+
+    // 특정 날짜 5분봉/30분봉/주봉/월봉 백필 (백그라운드) - 수동 보정용
+    @Async
+    public void backfillForDateAsync(String date) {
+        backfill(date);
+    }
+
+    private void backfill(String date) {
+        List<String> codes = stockRepository.findAllTickerCodes();
+        int total = codes.size();
+
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [백필 시작] 종목={}개, 대상={}", total, date);
+        log.info("└─────────────────────────────────────────────");
+
+        int fiveSuccess = 0, fiveFail = 0;
+        int thirtySuccess = 0, thirtyFail = 0;
+        int weeklySuccess = 0, weeklyFail = 0;
+        int monthlySuccess = 0, monthlyFail = 0;
+
+        for (int i = 0; i < codes.size(); i++) {
+            String code = codes.get(i);
+            log.info("[{}/{}] 백필 중: {}", i + 1, total, code);
+            if (loadFiveMinuteCandlesForDate(code, date, date)) fiveSuccess++; else fiveFail++;
+            if (loadThirtyMinuteCandlesForDate(code, date, date)) thirtySuccess++; else thirtyFail++;
+            if (loadWeeklyCandles(code, date, date)) weeklySuccess++; else weeklyFail++;
+            if (loadMonthlyCandles(code, date, date)) monthlySuccess++; else monthlyFail++;
+        }
+
+        log.info("┌─────────────────────────────────────────────");
+        log.info("│ [백필 완료] 대상={}", date);
+        log.info("│ 5분봉:  성공={}건/실패={}건", fiveSuccess, fiveFail);
+        log.info("│ 30분봉: 성공={}건/실패={}건", thirtySuccess, thirtyFail);
+        log.info("│ 주봉:   성공={}건/실패={}건", weeklySuccess, weeklyFail);
+        log.info("│ 월봉:   성공={}건/실패={}건", monthlySuccess, monthlyFail);
+        log.info("└─────────────────────────────────────────────");
+    }
+
     // 실패 종목 재적재 (백그라운드)
     @Async
-    public void retryAsync(List<String> stockCodes, int minuteDays, int dailyDays) {
+    public void retryAsync(List<String> stockCodes, int minuteDays) {
         int total = stockCodes.size();
         String today      = LocalDate.now(KST).format(DATE_FMT);
         String minuteFrom = LocalDate.now(KST).minusDays(minuteDays).format(DATE_FMT);
-        String dailyFrom  = LocalDate.now(KST).minusDays(dailyDays).format(DATE_FMT);
 
         log.info("┌─────────────────────────────────────────────");
         log.info("│ [캔들 재적재 시작] 종목={}개", total);
@@ -211,7 +582,7 @@ public class CandleLoadService {
             log.info("[{}/{}] 재적재 중: {}", i + 1, total, code);
             if (loadUnifiedMinuteCandles(code, minuteFrom, today, "U")) minuteSuccess.incrementAndGet();
             else minuteFail.incrementAndGet();
-            if (loadUnifiedDailyCandles(code, dailyFrom, today)) dailySuccess.incrementAndGet();
+            if (loadUnifiedDailyCandles(code, "19560101", today)) dailySuccess.incrementAndGet();
             else dailyFail.incrementAndGet();
         }
 
@@ -246,10 +617,90 @@ public class CandleLoadService {
                    .append(c.getVolume()).append(',')
                    .append(c.getCandleTime().format(COPY_FMT)).append('\n');
             }
-            bulkCopy("minute_candle", csv.toString());
-            log.info("  ✓ [분봉] stockCode={}, {}건 적재 완료", stockCode, candles.size());
+            int inserted = bulkCopy("minute_candle", csv.toString());
+            log.info("  ✓ [분봉] stockCode={}, 조회={}건, 신규삽입={}건", stockCode, candles.size(), inserted);
         } catch (Exception e) {
             log.error("  ✗ [분봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
+        }
+    }
+
+    private void saveFiveMinuteCandles(List<FiveMinuteCandle> candles, String stockCode) {
+        if (candles.isEmpty()) return;
+        try {
+            StringBuilder csv = new StringBuilder();
+            for (FiveMinuteCandle c : candles) {
+                csv.append(c.getStockCode()).append(',')
+                   .append(c.getOpenPrice()).append(',')
+                   .append(c.getHighPrice()).append(',')
+                   .append(c.getLowPrice()).append(',')
+                   .append(c.getClosePrice()).append(',')
+                   .append(c.getVolume()).append(',')
+                   .append(c.getCandleTime().format(COPY_FMT)).append('\n');
+            }
+            int inserted = bulkCopy("five_minute_candle", csv.toString());
+            log.info("  ✓ [5분봉] stockCode={}, 조회={}건, 신규삽입={}건", stockCode, candles.size(), inserted);
+        } catch (Exception e) {
+            log.error("  ✗ [5분봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
+        }
+    }
+
+    private void saveThirtyMinuteCandles(List<ThirtyMinuteCandle> candles, String stockCode) {
+        if (candles.isEmpty()) return;
+        try {
+            StringBuilder csv = new StringBuilder();
+            for (ThirtyMinuteCandle c : candles) {
+                csv.append(c.getStockCode()).append(',')
+                   .append(c.getOpenPrice()).append(',')
+                   .append(c.getHighPrice()).append(',')
+                   .append(c.getLowPrice()).append(',')
+                   .append(c.getClosePrice()).append(',')
+                   .append(c.getVolume()).append(',')
+                   .append(c.getCandleTime().format(COPY_FMT)).append('\n');
+            }
+            int inserted = bulkCopy("thirty_minute_candle", csv.toString());
+            log.info("  ✓ [30분봉] stockCode={}, 조회={}건, 신규삽입={}건", stockCode, candles.size(), inserted);
+        } catch (Exception e) {
+            log.error("  ✗ [30분봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
+        }
+    }
+
+    private void saveWeeklyCandles(List<WeeklyCandle> candles, String stockCode) {
+        if (candles.isEmpty()) return;
+        try {
+            StringBuilder csv = new StringBuilder();
+            for (WeeklyCandle c : candles) {
+                csv.append(c.getStockCode()).append(',')
+                   .append(c.getOpenPrice()).append(',')
+                   .append(c.getHighPrice()).append(',')
+                   .append(c.getLowPrice()).append(',')
+                   .append(c.getClosePrice()).append(',')
+                   .append(c.getVolume()).append(',')
+                   .append(c.getCandleTime().format(COPY_FMT)).append('\n');
+            }
+            int inserted = bulkCopy("weekly_candle", csv.toString());
+            log.info("  ✓ [주봉] stockCode={}, 조회={}건, 신규삽입={}건", stockCode, candles.size(), inserted);
+        } catch (Exception e) {
+            log.error("  ✗ [주봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
+        }
+    }
+
+    private void saveMonthlyCandles(List<MonthlyCandle> candles, String stockCode) {
+        if (candles.isEmpty()) return;
+        try {
+            StringBuilder csv = new StringBuilder();
+            for (MonthlyCandle c : candles) {
+                csv.append(c.getStockCode()).append(',')
+                   .append(c.getOpenPrice()).append(',')
+                   .append(c.getHighPrice()).append(',')
+                   .append(c.getLowPrice()).append(',')
+                   .append(c.getClosePrice()).append(',')
+                   .append(c.getVolume()).append(',')
+                   .append(c.getCandleTime().format(COPY_FMT)).append('\n');
+            }
+            int inserted = bulkCopy("monthly_candle", csv.toString());
+            log.info("  ✓ [월봉] stockCode={}, 조회={}건, 신규삽입={}건", stockCode, candles.size(), inserted);
+        } catch (Exception e) {
+            log.error("  ✗ [월봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
         }
     }
 
@@ -266,14 +717,14 @@ public class CandleLoadService {
                    .append(c.getVolume()).append(',')
                    .append(c.getCandleTime().format(COPY_FMT)).append('\n');
             }
-            bulkCopy("daily_candle", csv.toString());
-            log.info("  ✓ [일봉] stockCode={}, {}건 적재 완료", stockCode, candles.size());
+            int inserted = bulkCopy("daily_candle", csv.toString());
+            log.info("  ✓ [일봉] stockCode={}, 조회={}건, 신규삽입={}건", stockCode, candles.size(), inserted);
         } catch (Exception e) {
             log.error("  ✗ [일봉 저장 실패] stockCode={} - {}", stockCode, e.getMessage());
         }
     }
 
-    private void bulkCopy(String table, String csv) throws Exception {
+    private int bulkCopy(String table, String csv) throws Exception {
         try (Connection conn = dataSource.getConnection()) {
             conn.setAutoCommit(false);
             String cols = "stock_code, open_price, high_price, low_price, close_price, volume, candle_time";
@@ -288,11 +739,12 @@ public class CandleLoadService {
                 "COPY tmp_" + table + " (" + cols + ") FROM STDIN WITH (FORMAT csv)",
                 new StringReader(csv)
             );
-            conn.createStatement().execute(
+            int inserted = conn.createStatement().executeUpdate(
                 "INSERT INTO " + table + " (" + cols + ") " +
                 "SELECT " + cols + " FROM tmp_" + table + " ON CONFLICT DO NOTHING"
             );
             conn.commit();
+            return inserted;
         }
     }
 }

--- a/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleLoadService.java
@@ -540,6 +540,8 @@ public class CandleLoadService {
         log.info("│ [백필 시작] 종목={}개, 대상={}", total, date);
         log.info("└─────────────────────────────────────────────");
 
+        int minuteSuccess = 0, minuteFail = 0;
+        int dailySuccess = 0, dailyFail = 0;
         int fiveSuccess = 0, fiveFail = 0;
         int thirtySuccess = 0, thirtyFail = 0;
         int weeklySuccess = 0, weeklyFail = 0;
@@ -548,6 +550,8 @@ public class CandleLoadService {
         for (int i = 0; i < codes.size(); i++) {
             String code = codes.get(i);
             log.info("[{}/{}] 백필 중: {}", i + 1, total, code);
+            if (loadUnifiedMinuteCandles(code, date, date, "U")) minuteSuccess++; else minuteFail++;
+            if (loadUnifiedDailyCandles(code, date, date)) dailySuccess++; else dailyFail++;
             if (loadFiveMinuteCandlesForDate(code, date, date)) fiveSuccess++; else fiveFail++;
             if (loadThirtyMinuteCandlesForDate(code, date, date)) thirtySuccess++; else thirtyFail++;
             if (loadWeeklyCandles(code, date, date)) weeklySuccess++; else weeklyFail++;
@@ -556,8 +560,10 @@ public class CandleLoadService {
 
         log.info("┌─────────────────────────────────────────────");
         log.info("│ [백필 완료] 대상={}", date);
+        log.info("│ 1분봉:  성공={}건/실패={}건", minuteSuccess, minuteFail);
         log.info("│ 5분봉:  성공={}건/실패={}건", fiveSuccess, fiveFail);
         log.info("│ 30분봉: 성공={}건/실패={}건", thirtySuccess, thirtyFail);
+        log.info("│ 일봉:   성공={}건/실패={}건", dailySuccess, dailyFail);
         log.info("│ 주봉:   성공={}건/실패={}건", weeklySuccess, weeklyFail);
         log.info("│ 월봉:   성공={}건/실패={}건", monthlySuccess, monthlyFail);
         log.info("└─────────────────────────────────────────────");

--- a/src/main/java/org/solmate/domain/stock/service/CandleService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleService.java
@@ -9,12 +9,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.solmate.domain.stock.dto.response.CandleResponse;
+import org.solmate.domain.stock.entity.FiveMinuteCandle;
+import org.solmate.domain.stock.entity.MonthlyCandle;
+import org.solmate.domain.stock.entity.ThirtyMinuteCandle;
+import org.solmate.domain.stock.entity.WeeklyCandle;
 import org.solmate.domain.stock.entity.DailyCandle;
 import org.solmate.domain.stock.entity.MinuteCandle;
 import org.solmate.domain.stock.repository.DailyCandleRepository;
+import org.solmate.domain.stock.repository.FiveMinuteCandleRepository;
 import org.solmate.domain.stock.repository.MinuteCandleRepository;
+import org.solmate.domain.stock.repository.MonthlyCandleRepository;
+import org.solmate.domain.stock.repository.ThirtyMinuteCandleRepository;
+import org.solmate.domain.stock.repository.WeeklyCandleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,35 +38,43 @@ public class CandleService {
 
     private final MinuteCandleRepository minuteCandleRepository;
     private final DailyCandleRepository dailyCandleRepository;
+    private final FiveMinuteCandleRepository fiveMinuteCandleRepository;
+    private final ThirtyMinuteCandleRepository thirtyMinuteCandleRepository;
+    private final WeeklyCandleRepository weeklyCandleRepository;
+    private final MonthlyCandleRepository monthlyCandleRepository;
     private final CandleAccumulatorService candleAccumulatorService;
 
     /**
      * 분봉 조회
-     * unit=1  → DB minute_candle 직접 조회 + Redis 현재 1분봉
-     * unit=5|30|60 → DB 1분봉 집계 + Redis 현재 N분봉
-     * to가 있으면 해당 epoch(초) 이전 데이터 조회 (TradingView 무한스크롤)
+     * unit=1  → minute_candle DB 직접 조회 + Redis 현재 봉
+     * unit=5  → five_minute_candle DB 직접 조회 + Redis 현재 봉
+     * unit=30 → thirty_minute_candle DB 직접 조회 + Redis 현재 봉
+     * unit=60 → thirty_minute_candle 2개 집계 + Redis 현재 봉
+     * to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤)
      */
     @Transactional(readOnly = true)
     public List<CandleResponse> getMinuteCandles(String stockCode, int unit, int days, Long to) {
         int effectiveDays = days > 0 ? days : defaultDaysForUnit(unit);
-        if (unit == 1) {
-            return getOneMinuteCandles(stockCode, effectiveDays, to);
-        }
-        return getAggregatedMinuteCandles(stockCode, unit, effectiveDays, to);
+        return switch (unit) {
+            case 1  -> getOneMinuteCandles(stockCode, effectiveDays, to);
+            case 5  -> getFiveMinuteCandles(stockCode, effectiveDays, to);
+            case 30 -> getThirtyMinuteCandles(stockCode, effectiveDays, to);
+            case 60 -> getSixtyMinuteCandles(stockCode, effectiveDays, to);
+            default -> getOneMinuteCandles(stockCode, effectiveDays, to);
+        };
     }
 
-    // unit별 기본 조회 일수 (days=0으로 요청 시 적용)
     private int defaultDaysForUnit(int unit) {
         return switch (unit) {
-            case 1  -> 5;   // 1분봉:  5 영업일  (~1,950개)
-            case 5  -> 20;  // 5분봉:  20 영업일 (~1,560개)
-            case 30 -> 60;  // 30분봉: 60 영업일 (~780개)
-            case 60 -> 90;  // 60분봉: 90 영업일 (~630개)
+            case 1  -> 5;
+            case 5  -> 20;
+            case 30 -> 60;
+            case 60 -> 90;
             default -> 5;
         };
     }
 
-    // unit=1: DB minute_candle 직접 조회 + Redis 현재 봉
+    // 1분봉: minute_candle 직접 조회 + Redis 현재 봉
     private List<CandleResponse> getOneMinuteCandles(String stockCode, int days, Long toEpoch) {
         LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).atTime(23, 59, 59));
         LocalDateTime from = toDateTime.minusDays(days - 1).toLocalDate().atStartOfDay();
@@ -66,42 +83,69 @@ public class CandleService {
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
 
         List<CandleResponse> result = new ArrayList<>(
-                candles.stream()
-                        .map(c -> CandleResponse.from(c, c.getCandleTime()))
-                        .toList()
+                candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList()
         );
 
-        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:1min:");
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:1min:", 1);
         return result;
     }
 
-    // unit=5|30|60: DB 1분봉을 N분 단위로 집계 + Redis 현재 N분봉
-    private List<CandleResponse> getAggregatedMinuteCandles(String stockCode, int unit, int days, Long toEpoch) {
+    // 5분봉: five_minute_candle 직접 조회 + Redis 현재 봉
+    private List<CandleResponse> getFiveMinuteCandles(String stockCode, int days, Long toEpoch) {
         LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).atTime(23, 59, 59));
         LocalDateTime from = toDateTime.minusDays(days - 1).toLocalDate().atStartOfDay();
-        LocalDateTime to   = toDateTime;
 
-        List<MinuteCandle> oneMinCandles = minuteCandleRepository
-                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        List<FiveMinuteCandle> candles = fiveMinuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
 
-        // N분 단위 버킷으로 그룹핑 (버킷 시작 시각 기준)
-        TreeMap<LocalDateTime, List<MinuteCandle>> buckets = new TreeMap<>();
-        for (MinuteCandle c : oneMinCandles) {
-            LocalDateTime bucketStart = toBucketStart(c.getCandleTime(), unit);
+        List<CandleResponse> result = new ArrayList<>(
+                candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList()
+        );
+
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:5min:", 5);
+        return result;
+    }
+
+    // 30분봉: thirty_minute_candle 직접 조회 + Redis 현재 봉
+    private List<CandleResponse> getThirtyMinuteCandles(String stockCode, int days, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).atTime(23, 59, 59));
+        LocalDateTime from = toDateTime.minusDays(days - 1).toLocalDate().atStartOfDay();
+
+        List<ThirtyMinuteCandle> candles = thirtyMinuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
+
+        List<CandleResponse> result = new ArrayList<>(
+                candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList()
+        );
+
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:30min:", 30);
+        return result;
+    }
+
+    // 60분봉: thirty_minute_candle 2개씩 집계 + Redis 현재 봉
+    private List<CandleResponse> getSixtyMinuteCandles(String stockCode, int days, Long toEpoch) {
+        LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).atTime(23, 59, 59));
+        LocalDateTime from = toDateTime.minusDays(days - 1).toLocalDate().atStartOfDay();
+
+        List<ThirtyMinuteCandle> candles = thirtyMinuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
+
+        TreeMap<LocalDateTime, List<ThirtyMinuteCandle>> buckets = new TreeMap<>();
+        for (ThirtyMinuteCandle c : candles) {
+            LocalDateTime bucketStart = toBucketStart(c.getCandleTime(), 60);
             buckets.computeIfAbsent(bucketStart, k -> new ArrayList<>()).add(c);
         }
 
         List<CandleResponse> result = new ArrayList<>();
-        for (Map.Entry<LocalDateTime, List<MinuteCandle>> entry : buckets.entrySet()) {
-            result.add(aggregateMinuteCandles(entry.getValue(), entry.getKey()));
+        for (Map.Entry<LocalDateTime, List<ThirtyMinuteCandle>> entry : buckets.entrySet()) {
+            result.add(aggregateThirtyMinuteCandles(entry.getValue(), entry.getKey()));
         }
 
-        String redisPrefix = "candle:" + unit + "min:";
-        if (toEpoch == null) appendCurrentCandle(result, stockCode, redisPrefix);
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:60min:", 60);
         return result;
     }
 
-    // 일봉 조회 (DB + 오늘 진행 중인 봉 포함)
+    // 일봉: daily_candle 직접 조회 + Redis 현재 봉
     @Transactional(readOnly = true)
     public List<CandleResponse> getDailyCandles(String stockCode, int days, Long toEpoch) {
         LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
@@ -111,62 +155,68 @@ public class CandleService {
                 .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
 
         List<CandleResponse> result = new ArrayList<>(
-                candles.stream()
-                        .map(c -> CandleResponse.from(c, c.getCandleTime()))
-                        .toList()
+                candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList()
         );
 
-        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:1day:");
+        if (toEpoch == null) appendCurrentCandle(result, stockCode, "candle:1day:", 1);
         return result;
     }
 
-    // 주봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
+    // 주봉: weekly_candle 직접 조회 + Redis 현재 봉
     @Transactional(readOnly = true)
     public List<CandleResponse> getWeeklyCandles(String stockCode, int weeks, Long toEpoch) {
         LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
         LocalDateTime from = toDateTime.minusWeeks(weeks);
-        return aggregateDailyCandles(stockCode, from, toDateTime, this::toWeekBucketStart, toEpoch == null);
+
+        List<WeeklyCandle> candles = weeklyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
+
+        List<CandleResponse> result = new ArrayList<>(
+                candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList()
+        );
+
+        if (toEpoch == null) appendCurrentPeriodCandle(result, stockCode, "candle:1week:", this::toWeekBucketStart);
+        return result;
     }
 
-    // 월봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
+    // 월봉: monthly_candle 직접 조회 + Redis 현재 봉
     @Transactional(readOnly = true)
     public List<CandleResponse> getMonthlyCandles(String stockCode, int months, Long toEpoch) {
         LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
         LocalDateTime from = toDateTime.minusMonths(months);
-        return aggregateDailyCandles(stockCode, from, toDateTime, this::toMonthBucketStart, toEpoch == null);
+
+        List<MonthlyCandle> candles = monthlyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
+
+        List<CandleResponse> result = new ArrayList<>(
+                candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList()
+        );
+
+        if (toEpoch == null) appendCurrentPeriodCandle(result, stockCode, "candle:1month:", this::toMonthBucketStart);
+        return result;
     }
 
-    // 년봉 조회 (DB 일봉 집계 + 오늘 진행 중인 봉 포함)
+    // 년봉: monthly_candle 12개씩 집계 + Redis 현재 월봉을 연 버킷에 merge
     @Transactional(readOnly = true)
     public List<CandleResponse> getYearlyCandles(String stockCode, int years, Long toEpoch) {
         LocalDateTime toDateTime = resolveToDateTime(toEpoch, LocalDate.now(KST).plusDays(1).atStartOfDay());
         LocalDateTime from = toDateTime.minusYears(years);
-        return aggregateDailyCandles(stockCode, from, toDateTime, this::toYearBucketStart, toEpoch == null);
-    }
 
-    // DB 일봉을 주어진 버킷 함수로 그룹핑해 집계 + Redis 현재 일봉을 버킷에 merge
-    private List<CandleResponse> aggregateDailyCandles(
-            String stockCode,
-            LocalDateTime from,
-            LocalDateTime to,
-            java.util.function.Function<LocalDate, LocalDate> bucketFn,
-            boolean appendRedis) {
+        List<MonthlyCandle> candles = monthlyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, toDateTime);
 
-        List<DailyCandle> dailyCandles = dailyCandleRepository
-                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
-
-        TreeMap<LocalDate, List<DailyCandle>> buckets = new TreeMap<>();
-        for (DailyCandle c : dailyCandles) {
-            LocalDate bucketStart = bucketFn.apply(c.getCandleTime().toLocalDate());
-            buckets.computeIfAbsent(bucketStart, k -> new ArrayList<>()).add(c);
+        TreeMap<LocalDate, List<MonthlyCandle>> buckets = new TreeMap<>();
+        for (MonthlyCandle c : candles) {
+            LocalDate yearStart = c.getCandleTime().toLocalDate().withDayOfYear(1);
+            buckets.computeIfAbsent(yearStart, k -> new ArrayList<>()).add(c);
         }
 
         List<CandleResponse> result = new ArrayList<>();
-        for (Map.Entry<LocalDate, List<DailyCandle>> entry : buckets.entrySet()) {
-            result.add(aggregateDailyCandleList(entry.getValue(), entry.getKey().atStartOfDay()));
+        for (Map.Entry<LocalDate, List<MonthlyCandle>> entry : buckets.entrySet()) {
+            result.add(aggregateMonthlyCandles(entry.getValue(), entry.getKey().atStartOfDay()));
         }
 
-        if (appendRedis) appendCurrentDayCandle(result, stockCode, bucketFn);
+        if (toEpoch == null) appendCurrentPeriodCandle(result, stockCode, "candle:1month:", this::toYearBucketStart);
         return result;
     }
 
@@ -176,13 +226,32 @@ public class CandleService {
         return LocalDateTime.ofEpochSecond(toEpoch, 0, ZoneOffset.ofHours(9));
     }
 
-    // Redis 현재 일봉을 버킷 기준으로 변환해 마지막 봉에 merge (주/월/년봉용)
-    private void appendCurrentDayCandle(
+    // Redis에서 현재 진행 중인 봉을 꺼내 리스트 끝에 추가 (1분/5분/30분/60분/일봉용)
+    private void appendCurrentCandle(List<CandleResponse> result, String stockCode, String prefix, int bucketUnit) {
+        Map<Object, Object> current = candleAccumulatorService.getCurrentCandle(stockCode, prefix);
+        if (current.isEmpty()) return;
+
+        String startTime = (String) current.get("startTime");
+        if (startTime == null || current.get("open") == null || current.get("close") == null
+                || current.get("high") == null || current.get("low") == null || current.get("volume") == null) return;
+
+        LocalDateTime rawTime = LocalDateTime.parse(startTime, TIME_FORMATTER);
+        int flooredMinute = (rawTime.getMinute() / bucketUnit) * bucketUnit;
+        LocalDateTime candleTime = rawTime.toLocalDate().atTime(rawTime.getHour(), flooredMinute);
+        long epochTime = candleTime.toEpochSecond(ZoneOffset.ofHours(9));
+
+        result.removeIf(c -> c.time() == epochTime);
+        result.add(CandleResponse.fromRedis(current, candleTime));
+    }
+
+    // Redis 봉을 버킷 함수로 변환해 주봉/월봉/년봉 마지막 봉에 merge
+    private void appendCurrentPeriodCandle(
             List<CandleResponse> result,
             String stockCode,
-            java.util.function.Function<LocalDate, LocalDate> bucketFn) {
+            String redisPrefix,
+            Function<LocalDate, LocalDate> bucketFn) {
 
-        Map<Object, Object> current = candleAccumulatorService.getCurrentCandle(stockCode, "candle:1day:");
+        Map<Object, Object> current = candleAccumulatorService.getCurrentCandle(stockCode, redisPrefix);
         if (current.isEmpty()) return;
 
         String startTime = (String) current.get("startTime");
@@ -190,8 +259,6 @@ public class CandleService {
                 || current.get("high") == null || current.get("low") == null || current.get("volume") == null) return;
 
         LocalDateTime candleTime = LocalDateTime.parse(startTime, TIME_FORMATTER);
-
-        // Redis 봉의 날짜를 버킷 시작으로 변환 (월요일 / 1일 / 1월1일)
         LocalDate bucketDate = bucketFn.apply(candleTime.toLocalDate());
         LocalDateTime bucketStart = bucketDate.atStartOfDay();
         long bucketEpoch = bucketStart.toEpochSecond(ZoneOffset.ofHours(9));
@@ -202,7 +269,6 @@ public class CandleService {
         long redisClose  = Long.parseLong((String) current.get("close"));
         long redisVolume = Long.parseLong((String) current.get("volume"));
 
-        // 같은 버킷이 이미 집계 결과에 있으면 close/high/low/volume 갱신
         for (int i = 0; i < result.size(); i++) {
             if (result.get(i).time() == bucketEpoch) {
                 CandleResponse existing = result.get(i);
@@ -218,66 +284,45 @@ public class CandleService {
             }
         }
 
-        // 버킷이 없으면 새 봉으로 추가 (조회 범위 안에 오늘이 포함된 첫 거래일)
         result.add(new CandleResponse(bucketEpoch, redisOpen, redisHigh, redisLow, redisClose, redisVolume));
     }
 
-    // 일봉 리스트를 하나의 집계 봉으로 변환
-    private CandleResponse aggregateDailyCandleList(List<DailyCandle> candles, LocalDateTime bucketStart) {
+    // 30분봉 리스트 → 60분봉 집계
+    private CandleResponse aggregateThirtyMinuteCandles(List<ThirtyMinuteCandle> candles, LocalDateTime bucketStart) {
         long open   = candles.get(0).getOpenPrice();
         long close  = candles.get(candles.size() - 1).getClosePrice();
-        long high   = candles.stream().mapToLong(DailyCandle::getHighPrice).max().orElse(0);
-        long low    = candles.stream().mapToLong(DailyCandle::getLowPrice).min().orElse(0);
-        long volume = candles.stream().mapToLong(DailyCandle::getVolume).sum();
+        long high   = candles.stream().mapToLong(ThirtyMinuteCandle::getHighPrice).max().orElse(0);
+        long low    = candles.stream().mapToLong(ThirtyMinuteCandle::getLowPrice).min().orElse(0);
+        long volume = candles.stream().mapToLong(ThirtyMinuteCandle::getVolume).sum();
         return CandleResponse.ofAggregated(bucketStart, open, high, low, close, volume);
     }
 
-    // 주봉 버킷: 해당 날짜가 속한 주의 월요일
-    private LocalDate toWeekBucketStart(LocalDate date) {
-        return date.with(java.time.DayOfWeek.MONDAY);
+    // 월봉 리스트 → 년봉 집계
+    private CandleResponse aggregateMonthlyCandles(List<MonthlyCandle> candles, LocalDateTime bucketStart) {
+        long open   = candles.get(0).getOpenPrice();
+        long close  = candles.get(candles.size() - 1).getClosePrice();
+        long high   = candles.stream().mapToLong(MonthlyCandle::getHighPrice).max().orElse(0);
+        long low    = candles.stream().mapToLong(MonthlyCandle::getLowPrice).min().orElse(0);
+        long volume = candles.stream().mapToLong(MonthlyCandle::getVolume).sum();
+        return CandleResponse.ofAggregated(bucketStart, open, high, low, close, volume);
     }
 
-    // 월봉 버킷: 해당 날짜가 속한 달의 1일
-    private LocalDate toMonthBucketStart(LocalDate date) {
-        return date.withDayOfMonth(1);
-    }
-
-    // 년봉 버킷: 해당 날짜가 속한 해의 1월 1일
-    private LocalDate toYearBucketStart(LocalDate date) {
-        return date.withDayOfYear(1);
-    }
-
-    // 절대 분 단위 버킷 시작 시각 계산 (프리/에프터 마켓 포함)
+    // 절대 분 단위 버킷 시작 시각
     private LocalDateTime toBucketStart(LocalDateTime candleTime, int unit) {
         int minuteOfDay = candleTime.getHour() * 60 + candleTime.getMinute();
         int bucketMinute = Math.floorDiv(minuteOfDay, unit) * unit;
         return candleTime.toLocalDate().atTime(bucketMinute / 60, bucketMinute % 60);
     }
 
-    // 1분봉 리스트를 하나의 N분봉으로 집계
-    private CandleResponse aggregateMinuteCandles(List<MinuteCandle> candles, LocalDateTime bucketStart) {
-        long open   = candles.get(0).getOpenPrice();
-        long close  = candles.get(candles.size() - 1).getClosePrice();
-        long high   = candles.stream().mapToLong(MinuteCandle::getHighPrice).max().orElse(0);
-        long low    = candles.stream().mapToLong(MinuteCandle::getLowPrice).min().orElse(0);
-        long volume = candles.stream().mapToLong(MinuteCandle::getVolume).sum();
-        return CandleResponse.ofAggregated(bucketStart, open, high, low, close, volume);
+    private LocalDate toWeekBucketStart(LocalDate date) {
+        return date.with(java.time.DayOfWeek.MONDAY);
     }
 
-    // Redis에서 현재 진행 중인 봉을 꺼내 리스트 끝에 추가
-    private void appendCurrentCandle(List<CandleResponse> result, String stockCode, String prefix) {
-        Map<Object, Object> current = candleAccumulatorService.getCurrentCandle(stockCode, prefix);
-        if (current.isEmpty()) return;
+    private LocalDate toMonthBucketStart(LocalDate date) {
+        return date.withDayOfMonth(1);
+    }
 
-        String startTime = (String) current.get("startTime");
-        if (startTime == null || current.get("open") == null || current.get("close") == null
-                || current.get("high") == null || current.get("low") == null || current.get("volume") == null) return;
-
-        LocalDateTime candleTime = LocalDateTime.parse(startTime, TIME_FORMATTER);
-        long epochTime = candleTime.toEpochSecond(ZoneOffset.ofHours(9));
-
-        // 이미 같은 시각의 봉이 집계 결과에 있으면 교체 (Redis 봉이 더 최신)
-        result.removeIf(c -> c.time() == epochTime);
-        result.add(CandleResponse.fromRedis(current, candleTime));
+    private LocalDate toYearBucketStart(LocalDate date) {
+        return date.withDayOfYear(1);
     }
 }

--- a/src/main/java/org/solmate/external/ls/client/LsApiClient.java
+++ b/src/main/java/org/solmate/external/ls/client/LsApiClient.java
@@ -51,8 +51,8 @@ public class LsApiClient {
                 .body(LsQuoteResponse.class));
     }
 
-    /** t8452: 통합 1분봉 조회 (KRX+NXT, exchgubun: K/N/U) */
-    public LsUnifiedMinuteCandleResponse getUnifiedMinuteCandles(String stockCode, String sdate, String edate,
+    /** t8452: 통합 N분봉 조회 (ncnt: 1/5/30/60 등) */
+    public LsUnifiedMinuteCandleResponse getUnifiedMinuteCandles(String stockCode, int ncnt, String sdate, String edate,
                                                                    String exchgubun) {
         return withTokenRetry(token -> restClient.post()
                 .uri(lsProperties.getBaseUrl() + "/stock/chart")
@@ -60,13 +60,13 @@ public class LsApiClient {
                 .header("authorization", "Bearer " + token)
                 .header("tr_cd", "t8452")
                 .header("tr_cont", "N")
-                .body(LsUnifiedMinuteCandleRequest.of(stockCode, sdate, edate, exchgubun))
+                .body(LsUnifiedMinuteCandleRequest.of(stockCode, ncnt, sdate, edate, exchgubun))
                 .retrieve()
                 .body(LsUnifiedMinuteCandleResponse.class));
     }
 
-    /** t8452: 통합 1분봉 연속 조회 */
-    public LsUnifiedMinuteCandleResponse getUnifiedMinuteCandlesContinue(String stockCode, String sdate, String edate,
+    /** t8452: 통합 N분봉 연속 조회 */
+    public LsUnifiedMinuteCandleResponse getUnifiedMinuteCandlesContinue(String stockCode, int ncnt, String sdate, String edate,
                                                                            String ctsDate, String ctsTime,
                                                                            String exchgubun) {
         return withTokenRetry(token -> restClient.post()
@@ -76,26 +76,26 @@ public class LsApiClient {
                 .header("tr_cd", "t8452")
                 .header("tr_cont", "Y")
                 .header("tr_cont_key", ctsDate + ctsTime)
-                .body(LsUnifiedMinuteCandleRequest.ofContinue(stockCode, sdate, edate, ctsDate, ctsTime, exchgubun))
+                .body(LsUnifiedMinuteCandleRequest.ofContinue(stockCode, ncnt, sdate, edate, ctsDate, ctsTime, exchgubun))
                 .retrieve()
                 .body(LsUnifiedMinuteCandleResponse.class));
     }
 
-    /** t8451: 통합 일봉 조회 (KRX+NXT, 처음 조회) */
-    public LsUnifiedDailyCandleResponse getUnifiedDailyCandles(String stockCode, String sdate, String edate) {
+    /** t8451: 통합 일/주/월봉 조회 (gubun: 2=일, 3=주, 4=월) */
+    public LsUnifiedDailyCandleResponse getUnifiedDailyCandles(String stockCode, String gubun, String sdate, String edate) {
         return withTokenRetry(token -> restClient.post()
                 .uri(lsProperties.getBaseUrl() + "/stock/chart")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("authorization", "Bearer " + token)
                 .header("tr_cd", "t8451")
                 .header("tr_cont", "N")
-                .body(LsUnifiedDailyCandleRequest.of(stockCode, sdate, edate))
+                .body(LsUnifiedDailyCandleRequest.of(stockCode, gubun, sdate, edate))
                 .retrieve()
                 .body(LsUnifiedDailyCandleResponse.class));
     }
 
-    /** t8451: 통합 일봉 연속 조회 */
-    public LsUnifiedDailyCandleResponse getUnifiedDailyCandlesContinue(String stockCode, String sdate, String edate,
+    /** t8451: 통합 일/주/월봉 연속 조회 */
+    public LsUnifiedDailyCandleResponse getUnifiedDailyCandlesContinue(String stockCode, String gubun, String sdate, String edate,
                                                                         String ctsDate) {
         return withTokenRetry(token -> restClient.post()
                 .uri(lsProperties.getBaseUrl() + "/stock/chart")
@@ -104,7 +104,7 @@ public class LsApiClient {
                 .header("tr_cd", "t8451")
                 .header("tr_cont", "Y")
                 .header("tr_cont_key", ctsDate)
-                .body(LsUnifiedDailyCandleRequest.ofContinue(stockCode, sdate, edate, ctsDate))
+                .body(LsUnifiedDailyCandleRequest.ofContinue(stockCode, gubun, sdate, edate, ctsDate))
                 .retrieve()
                 .body(LsUnifiedDailyCandleResponse.class));
     }

--- a/src/main/java/org/solmate/external/ls/dto/request/LsUnifiedDailyCandleRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/request/LsUnifiedDailyCandleRequest.java
@@ -17,25 +17,25 @@ public record LsUnifiedDailyCandleRequest(
             String exchgubun
     ) {}
 
-    public static LsUnifiedDailyCandleRequest of(String shcode, String sdate, String edate) {
+    public static LsUnifiedDailyCandleRequest of(String shcode, String gubun, String sdate, String edate) {
         return new LsUnifiedDailyCandleRequest(new InBlock(
                 shcode,
-                "2",     // 일봉
+                gubun,
                 500,
                 sdate,
                 edate,
                 " ",
-                "N",     // 비압축
-                "Y",     // 수정주가 적용
-                "U"      // 통합 (KRX+NXT)
+                "N",
+                "Y",
+                "U"
         ));
     }
 
-    public static LsUnifiedDailyCandleRequest ofContinue(String shcode, String sdate, String edate,
+    public static LsUnifiedDailyCandleRequest ofContinue(String shcode, String gubun, String sdate, String edate,
                                                           String ctsDate) {
         return new LsUnifiedDailyCandleRequest(new InBlock(
                 shcode,
-                "2",
+                gubun,
                 500,
                 sdate,
                 edate,

--- a/src/main/java/org/solmate/external/ls/dto/request/LsUnifiedMinuteCandleRequest.java
+++ b/src/main/java/org/solmate/external/ls/dto/request/LsUnifiedMinuteCandleRequest.java
@@ -20,10 +20,10 @@ public record LsUnifiedMinuteCandleRequest(
             String exchgubun
     ) {}
 
-    public static LsUnifiedMinuteCandleRequest of(String shcode, String sdate, String edate, String exchgubun) {
+    public static LsUnifiedMinuteCandleRequest of(String shcode, int ncnt, String sdate, String edate, String exchgubun) {
         return new LsUnifiedMinuteCandleRequest(new InBlock(
                 shcode,
-                1,
+                ncnt,
                 500,
                 "0",
                 sdate,
@@ -37,11 +37,11 @@ public record LsUnifiedMinuteCandleRequest(
         ));
     }
 
-    public static LsUnifiedMinuteCandleRequest ofContinue(String shcode, String sdate, String edate,
+    public static LsUnifiedMinuteCandleRequest ofContinue(String shcode, int ncnt, String sdate, String edate,
                                                            String ctsDate, String ctsTime, String exchgubun) {
         return new LsUnifiedMinuteCandleRequest(new InBlock(
                 shcode,
-                1,
+                ncnt,
                 500,
                 "0",
                 sdate,

--- a/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
+++ b/src/main/java/org/solmate/external/ls/websocket/LsWebSocketClient.java
@@ -194,11 +194,13 @@ public class LsWebSocketClient extends TextWebSocketHandler {
                         StockRealtimeResponse.from(response.body()));
                 candleAccumulatorService.accumulate(response.body());
                 orderMatchingService.match(stockCode);
-                broadcastCandle(stockCode, "candle:1min:",  "/topic/stocks/" + stockCode + "/candle/1min");
-                broadcastCandle(stockCode, "candle:5min:",  "/topic/stocks/" + stockCode + "/candle/5min");
-                broadcastCandle(stockCode, "candle:30min:", "/topic/stocks/" + stockCode + "/candle/30min");
-                broadcastCandle(stockCode, "candle:60min:", "/topic/stocks/" + stockCode + "/candle/60min");
-                broadcastCandle(stockCode, "candle:1day:",  "/topic/stocks/" + stockCode + "/candle/1day");
+                broadcastCandle(stockCode, "candle:1min:",    1, "/topic/stocks/" + stockCode + "/candle/1min");
+                broadcastCandle(stockCode, "candle:5min:",    5, "/topic/stocks/" + stockCode + "/candle/5min");
+                broadcastCandle(stockCode, "candle:30min:",  30, "/topic/stocks/" + stockCode + "/candle/30min");
+                broadcastCandle(stockCode, "candle:60min:",  60, "/topic/stocks/" + stockCode + "/candle/60min");
+                broadcastCandle(stockCode, "candle:1day:",    1, "/topic/stocks/" + stockCode + "/candle/1day");
+                broadcastCandle(stockCode, "candle:1week:",   1, "/topic/stocks/" + stockCode + "/candle/1week");
+                broadcastCandle(stockCode, "candle:1month:",  1, "/topic/stocks/" + stockCode + "/candle/1month");
 
             } else if ("UH1".equals(trCd)) {
                 LsWsOrderBookResponse response = objectMapper.treeToValue(node, LsWsOrderBookResponse.class);
@@ -216,13 +218,16 @@ public class LsWebSocketClient extends TextWebSocketHandler {
     }
 
     // Redis에서 해당 봉 데이터를 읽어 STOMP 토픽으로 브로드캐스트
-    private void broadcastCandle(String stockCode, String redisPrefix, String topic) {
+    // bucketUnit: 버킷 단위(분). startTime을 버킷 시작으로 내림 (ex. 5분봉이면 09:03 → 09:00)
+    private void broadcastCandle(String stockCode, String redisPrefix, int bucketUnit, String topic) {
         try {
             Map<Object, Object> data = candleAccumulatorService.getCurrentCandle(stockCode, redisPrefix);
             if (data.isEmpty()) return;
 
             String startTime = (String) data.get("startTime");
-            LocalDateTime candleTime = LocalDateTime.parse(startTime, DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+            LocalDateTime rawTime = LocalDateTime.parse(startTime, DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+            int flooredMinute = (rawTime.getMinute() / bucketUnit) * bucketUnit;
+            LocalDateTime candleTime = rawTime.toLocalDate().atTime(rawTime.getHour(), flooredMinute);
             messagingTemplate.convertAndSend(topic, CandleResponse.fromRedis(data, candleTime));
         } catch (Exception e) {
             log.debug("캔들 브로드캐스트 실패 - prefix: {}, stockCode: {}", redisPrefix, stockCode);


### PR DESCRIPTION
 ## #️⃣  관련 이슈
  - closed #168

  ## 💡 작업 배경
  기존에는 1분봉과 일봉 테이블만 존재하고, 5분봉/30분봉/60분봉/주봉/월봉/년봉은 모두 1분봉 또는 일봉 테이블에서
  실시간 집계하여 응답하는 구조였습니다.
  이 방식은 동시 요청이 증가할수록 DB CPU 부하가 급증하고 응답시간이 늘어나는 구조적 한계가 있어, 전용 테이블을
  도입하여 성능을 개선하였습니다.

  로컬 부하 테스트(k6, 100 VUs) 결과:
  - 집계 방식 p(95): ~430ms, 처리량: 118 RPS
  - 전용 테이블 방식 p(95): ~320ms, 처리량: 132 RPS (25% 응답속도 개선, 12% 처리량 향상)

  ## 🧩 작업 내용

  ### 신규 테이블 추가
  - `five_minute_candle` - 5분봉 전용 테이블
  - `thirty_minute_candle` - 30분봉 전용 테이블
  - `weekly_candle` - 주봉 전용 테이블
  - `monthly_candle` - 월봉 전용 테이블

  ### 캔들 조회 로직 변경
  - 5분봉: 1분봉 집계 → `five_minute_candle` 직접 조회
  - 30분봉: 1분봉 집계 → `thirty_minute_candle` 직접 조회
  - 60분봉: 1분봉 집계 → `thirty_minute_candle` 2개 집계 (중간 테이블 활용)
  - 주봉: 일봉 집계 → `weekly_candle` 직접 조회
  - 월봉: 일봉 집계 → `monthly_candle` 직접 조회
  - 년봉: 일봉 집계 → `monthly_candle` 12개 집계 (중간 테이블 활용)

  ### 실시간 누적 (Redis)
  - 체결 데이터 수신 시 7개 봉(1분/5분/30분/60분/일/주/월) Redis Hash 키에 동시 OHLCV 누적
  - 확정되지 않은 현재 진행 중인 봉을 차트에 실시간으로 반영

  ### Redis → DB flush 스케줄러
  - 5분봉: 매 5분 flush → `five_minute_candle` 저장
  - 30분봉: 매 30분 flush → `thirty_minute_candle` 저장
  - 주봉: 매주 금요일 20:00 flush → `weekly_candle` 저장
  - 월봉: 매월 마지막 영업일 20:00 flush → `monthly_candle` 저장
  - 버킷 시작 시각 flooring 적용 (ex. 09:03 → 09:00)

  ### 백필 스케줄러 (매일 05:30)
  - 전날 1분봉/5분봉/30분봉/일봉/주봉/월봉 전체 종목 대상 누락 데이터 보정
  - 5분봉/30분봉 백필 시 버킷 flooring 적용하여 시간 정합성 보장

  ### 수동 백필 API 추가
  - `POST /api/admin/candles/backfill?date=yyyyMMdd`
  - 서버 다운 등으로 누락된 특정 날짜의 전체 봉 데이터를 수동으로 적재

  ## 📸 스크린샷(선택)

  ## 📝 기타
  - `ddl-auto: update` 설정으로 신규 테이블은 배포 시 자동 생성됨
  - 기존 1분봉/일봉 테이블 및 관련 로직은 그대로 유지
  - `ON CONFLICT DO NOTHING`으로 중복 데이터 자동 스킵
  - 60분봉/년봉은 전용 테이블 없이 각각 30분봉/월봉 테이블에서 집계하여 응답