### PR TITLE
[Fix] 도커파일 한국시간대 지정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 
+# 타임존 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # 빌드 결과물만 복사 (1단계 gradle이나 소스는 버림)
 COPY --from=builder /app/build/libs/*.jar app.jar
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #183

## 💡 작업 배경
- 알림 저장 시에 바로 직전에 온 알림이 9시간 전으로 뜬다.

## 🧩 작업 내용
- 먼저 도커 파일에서 도커 컨테이너의 시간대를 KST 로 바꾸었다.
