### PR TITLE
[Test] 인덱스 중복 생성 제거 및 테스트를 위한 엔드포인트 생성

### DIFF
--- a/src/main/java/org/solmate/domain/stock/controller/StockController.java
+++ b/src/main/java/org/solmate/domain/stock/controller/StockController.java
@@ -81,7 +81,7 @@ public class StockController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getDailyCandles(stockCode, days, to));
     }
 
-    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
+    @Operation(summary = "주봉 조회", description = "weeks 미지정 시 260주(5년). DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/weekly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getWeeklyCandles(
             @PathVariable String stockCode,
@@ -90,7 +90,7 @@ public class StockController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyCandles(stockCode, weeks, to));
     }
 
-    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
+    @Operation(summary = "월봉 조회", description = "months 미지정 시 120개월(10년). DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/monthly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getMonthlyCandles(
             @PathVariable String stockCode,
@@ -99,13 +99,109 @@ public class StockController {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyCandles(stockCode, months, to));
     }
 
-    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
+    @Operation(summary = "년봉 조회", description = "years 미지정 시 20년. DB 일봉 집계. to 지정 시 해당 Unix epoch(초) 이전 데이터 조회 (TradingView 무한스크롤용)")
     @GetMapping("/{stockCode}/candles/yearly")
     public ResponseEntity<ApiResponse<List<CandleResponse>>> getYearlyCandles(
             @PathVariable String stockCode,
             @RequestParam(defaultValue = "20") int years,
             @RequestParam(required = false) Long to) {
         return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyCandles(stockCode, years, to));
+    }
+
+    @Operation(summary = "[벤치마크] 5분봉 직접 조회 (five_minute_candle)")
+    @GetMapping("/{stockCode}/candles/five-minute/table")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getFiveMinFromTable(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "20") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getFiveMinFromTable(stockCode, days));
+    }
+
+    @Operation(summary = "[벤치마크] 5분봉 집계 조회 (minute_candle)")
+    @GetMapping("/{stockCode}/candles/five-minute/aggregate")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getFiveMinFromAggregate(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "20") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getFiveMinFromAggregate(stockCode, days));
+    }
+
+    @Operation(summary = "[벤치마크] 30분봉 직접 조회 (thirty_minute_candle)")
+    @GetMapping("/{stockCode}/candles/thirty-minute/table")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getThirtyMinFromTable(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "46") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getThirtyMinFromTable(stockCode, days));
+    }
+
+    @Operation(summary = "[벤치마크] 30분봉 집계 조회 (minute_candle)")
+    @GetMapping("/{stockCode}/candles/thirty-minute/aggregate")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getThirtyMinFromAggregate(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "46") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getThirtyMinFromAggregate(stockCode, days));
+    }
+
+    @Operation(summary = "[벤치마크] 60분봉 직접 조회 (thirty_minute_candle 집계)")
+    @GetMapping("/{stockCode}/candles/sixty-minute/table")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getSixtyMinFromTable(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "90") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getSixtyMinFromTable(stockCode, days));
+    }
+
+    @Operation(summary = "[벤치마크] 60분봉 집계 조회 (minute_candle)")
+    @GetMapping("/{stockCode}/candles/sixty-minute/aggregate")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getSixtyMinFromAggregate(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "90") int days) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getSixtyMinFromAggregate(stockCode, days));
+    }
+
+    @Operation(summary = "[벤치마크] 주봉 직접 조회 (weekly_candle)")
+    @GetMapping("/{stockCode}/candles/weekly-bench/table")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getWeeklyFromTable(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "260") int weeks) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyFromTable(stockCode, weeks));
+    }
+
+    @Operation(summary = "[벤치마크] 주봉 집계 조회 (daily_candle)")
+    @GetMapping("/{stockCode}/candles/weekly-bench/aggregate")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getWeeklyFromAggregate(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "260") int weeks) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getWeeklyFromAggregate(stockCode, weeks));
+    }
+
+    @Operation(summary = "[벤치마크] 월봉 직접 조회 (monthly_candle)")
+    @GetMapping("/{stockCode}/candles/monthly-bench/table")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getMonthlyFromTable(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "120") int months) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyFromTable(stockCode, months));
+    }
+
+    @Operation(summary = "[벤치마크] 월봉 집계 조회 (daily_candle)")
+    @GetMapping("/{stockCode}/candles/monthly-bench/aggregate")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getMonthlyFromAggregate(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "120") int months) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getMonthlyFromAggregate(stockCode, months));
+    }
+
+    @Operation(summary = "[벤치마크] 년봉 직접 조회 (monthly_candle 집계)")
+    @GetMapping("/{stockCode}/candles/yearly-bench/table")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getYearlyFromTable(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "20") int years) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyFromTable(stockCode, years));
+    }
+
+    @Operation(summary = "[벤치마크] 년봉 집계 조회 (daily_candle)")
+    @GetMapping("/{stockCode}/candles/yearly-bench/aggregate")
+    public ResponseEntity<ApiResponse<List<CandleResponse>>> getYearlyFromAggregate(
+            @PathVariable String stockCode,
+            @RequestParam(defaultValue = "20") int years) {
+        return ApiResponse.success(SuccessStatus.SUCCESS_200, candleService.getYearlyFromAggregate(stockCode, years));
     }
 
     @Operation(summary = "종목 보유현황 조회", description = "보유수량/평균매수가/평가금액/수익률 조회. 수익률은 호출 시점 현재가 기준.")

--- a/src/main/java/org/solmate/domain/stock/entity/DailyCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/DailyCandle.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -24,9 +23,6 @@ import lombok.experimental.SuperBuilder;
 			name = "uk_daily_candle_stock_code_candle_time",
 			columnNames = {"stock_code", "candle_time"}
 		)
-	},
-	indexes = {
-		@Index(name = "idx_daily_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
 	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/solmate/domain/stock/entity/FiveMinuteCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/FiveMinuteCandle.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -24,9 +23,6 @@ import lombok.experimental.SuperBuilder;
             name = "uk_five_minute_candle_stock_code_candle_time",
             columnNames = {"stock_code", "candle_time"}
         )
-    },
-    indexes = {
-        @Index(name = "idx_five_minute_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/solmate/domain/stock/entity/MinuteCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/MinuteCandle.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -24,9 +23,6 @@ import lombok.experimental.SuperBuilder;
 			name = "uk_minute_candle_stock_code_candle_time",
 			columnNames = {"stock_code", "candle_time"}
 		)
-	},
-	indexes = {
-		@Index(name = "idx_minute_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
 	}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/solmate/domain/stock/entity/MonthlyCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/MonthlyCandle.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -24,9 +23,6 @@ import lombok.experimental.SuperBuilder;
             name = "uk_monthly_candle_stock_code_candle_time",
             columnNames = {"stock_code", "candle_time"}
         )
-    },
-    indexes = {
-        @Index(name = "idx_monthly_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/solmate/domain/stock/entity/ThirtyMinuteCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/ThirtyMinuteCandle.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -24,9 +23,6 @@ import lombok.experimental.SuperBuilder;
             name = "uk_thirty_minute_candle_stock_code_candle_time",
             columnNames = {"stock_code", "candle_time"}
         )
-    },
-    indexes = {
-        @Index(name = "idx_thirty_minute_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/solmate/domain/stock/entity/WeeklyCandle.java
+++ b/src/main/java/org/solmate/domain/stock/entity/WeeklyCandle.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -24,9 +23,6 @@ import lombok.experimental.SuperBuilder;
             name = "uk_weekly_candle_stock_code_candle_time",
             columnNames = {"stock_code", "candle_time"}
         )
-    },
-    indexes = {
-        @Index(name = "idx_weekly_candle_stock_code_candle_time", columnList = "stock_code, candle_time")
     }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/solmate/domain/stock/service/CandleService.java
+++ b/src/main/java/org/solmate/domain/stock/service/CandleService.java
@@ -196,6 +196,237 @@ public class CandleService {
         return result;
     }
 
+    // 5분봉 벤치마크: five_minute_candle 직접 조회
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getFiveMinFromTable(String stockCode, int days) {
+        LocalDateTime to = LocalDate.now(KST).atTime(23, 59, 59);
+        LocalDateTime from = to.minusDays(days - 1).toLocalDate().atStartOfDay();
+        List<FiveMinuteCandle> candles = fiveMinuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        return candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList();
+    }
+
+    // 5분봉 벤치마크: minute_candle 집계
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getFiveMinFromAggregate(String stockCode, int days) {
+        LocalDateTime to = LocalDate.now(KST).atTime(23, 59, 59);
+        LocalDateTime from = to.minusDays(days - 1).toLocalDate().atStartOfDay();
+        List<MinuteCandle> candles = minuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDateTime, List<MinuteCandle>> buckets = new TreeMap<>();
+        for (MinuteCandle c : candles) {
+            buckets.computeIfAbsent(toBucketStart(c.getCandleTime(), 5), k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDateTime, List<MinuteCandle>> entry : buckets.entrySet()) {
+            List<MinuteCandle> bucket = entry.getValue();
+            result.add(CandleResponse.ofAggregated(entry.getKey(),
+                    bucket.get(0).getOpenPrice(),
+                    bucket.stream().mapToLong(MinuteCandle::getHighPrice).max().orElse(0),
+                    bucket.stream().mapToLong(MinuteCandle::getLowPrice).min().orElse(0),
+                    bucket.get(bucket.size() - 1).getClosePrice(),
+                    bucket.stream().mapToLong(MinuteCandle::getVolume).sum()));
+        }
+        return result;
+    }
+
+    // 60분봉 벤치마크: thirty_minute_candle 집계 (table 방식)
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getSixtyMinFromTable(String stockCode, int days) {
+        LocalDateTime to = LocalDate.now(KST).atTime(23, 59, 59);
+        LocalDateTime from = to.minusDays(days - 1).toLocalDate().atStartOfDay();
+        List<ThirtyMinuteCandle> candles = thirtyMinuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDateTime, List<ThirtyMinuteCandle>> buckets = new TreeMap<>();
+        for (ThirtyMinuteCandle c : candles) {
+            buckets.computeIfAbsent(toBucketStart(c.getCandleTime(), 60), k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDateTime, List<ThirtyMinuteCandle>> entry : buckets.entrySet()) {
+            result.add(aggregateThirtyMinuteCandles(entry.getValue(), entry.getKey()));
+        }
+        return result;
+    }
+
+    // 60분봉 벤치마크: minute_candle 집계
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getSixtyMinFromAggregate(String stockCode, int days) {
+        LocalDateTime to = LocalDate.now(KST).atTime(23, 59, 59);
+        LocalDateTime from = to.minusDays(days - 1).toLocalDate().atStartOfDay();
+        List<MinuteCandle> candles = minuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDateTime, List<MinuteCandle>> buckets = new TreeMap<>();
+        for (MinuteCandle c : candles) {
+            buckets.computeIfAbsent(toBucketStart(c.getCandleTime(), 60), k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDateTime, List<MinuteCandle>> entry : buckets.entrySet()) {
+            List<MinuteCandle> bucket = entry.getValue();
+            result.add(CandleResponse.ofAggregated(entry.getKey(),
+                    bucket.get(0).getOpenPrice(),
+                    bucket.stream().mapToLong(MinuteCandle::getHighPrice).max().orElse(0),
+                    bucket.stream().mapToLong(MinuteCandle::getLowPrice).min().orElse(0),
+                    bucket.get(bucket.size() - 1).getClosePrice(),
+                    bucket.stream().mapToLong(MinuteCandle::getVolume).sum()));
+        }
+        return result;
+    }
+
+    // 주봉 벤치마크: weekly_candle 직접 조회
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getWeeklyFromTable(String stockCode, int weeks) {
+        LocalDateTime to = LocalDate.now(KST).plusDays(1).atStartOfDay();
+        LocalDateTime from = to.minusWeeks(weeks);
+        List<WeeklyCandle> candles = weeklyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        return candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList();
+    }
+
+    // 주봉 벤치마크: daily_candle 집계
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getWeeklyFromAggregate(String stockCode, int weeks) {
+        LocalDateTime to = LocalDate.now(KST).plusDays(1).atStartOfDay();
+        LocalDateTime from = to.minusWeeks(weeks);
+        List<DailyCandle> candles = dailyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDate, List<DailyCandle>> buckets = new TreeMap<>();
+        for (DailyCandle c : candles) {
+            LocalDate weekStart = c.getCandleTime().toLocalDate().with(java.time.DayOfWeek.MONDAY);
+            buckets.computeIfAbsent(weekStart, k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<DailyCandle>> entry : buckets.entrySet()) {
+            List<DailyCandle> bucket = entry.getValue();
+            long open   = bucket.get(0).getOpenPrice();
+            long close  = bucket.get(bucket.size() - 1).getClosePrice();
+            long high   = bucket.stream().mapToLong(DailyCandle::getHighPrice).max().orElse(0);
+            long low    = bucket.stream().mapToLong(DailyCandle::getLowPrice).min().orElse(0);
+            long volume = bucket.stream().mapToLong(DailyCandle::getVolume).sum();
+            result.add(CandleResponse.ofAggregated(entry.getKey().atStartOfDay(), open, high, low, close, volume));
+        }
+        return result;
+    }
+
+    // 월봉 벤치마크: monthly_candle 직접 조회
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getMonthlyFromTable(String stockCode, int months) {
+        LocalDateTime to = LocalDate.now(KST).plusDays(1).atStartOfDay();
+        LocalDateTime from = to.minusMonths(months);
+        List<MonthlyCandle> candles = monthlyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        return candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList();
+    }
+
+    // 월봉 벤치마크: daily_candle 집계
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getMonthlyFromAggregate(String stockCode, int months) {
+        LocalDateTime to = LocalDate.now(KST).plusDays(1).atStartOfDay();
+        LocalDateTime from = to.minusMonths(months);
+        List<DailyCandle> candles = dailyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDate, List<DailyCandle>> buckets = new TreeMap<>();
+        for (DailyCandle c : candles) {
+            LocalDate monthStart = c.getCandleTime().toLocalDate().withDayOfMonth(1);
+            buckets.computeIfAbsent(monthStart, k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<DailyCandle>> entry : buckets.entrySet()) {
+            List<DailyCandle> bucket = entry.getValue();
+            long open   = bucket.get(0).getOpenPrice();
+            long close  = bucket.get(bucket.size() - 1).getClosePrice();
+            long high   = bucket.stream().mapToLong(DailyCandle::getHighPrice).max().orElse(0);
+            long low    = bucket.stream().mapToLong(DailyCandle::getLowPrice).min().orElse(0);
+            long volume = bucket.stream().mapToLong(DailyCandle::getVolume).sum();
+            result.add(CandleResponse.ofAggregated(entry.getKey().atStartOfDay(), open, high, low, close, volume));
+        }
+        return result;
+    }
+
+    // 년봉 벤치마크: monthly_candle 집계 (table 방식)
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getYearlyFromTable(String stockCode, int years) {
+        LocalDateTime to = LocalDate.now(KST).plusDays(1).atStartOfDay();
+        LocalDateTime from = to.minusYears(years);
+        List<MonthlyCandle> candles = monthlyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDate, List<MonthlyCandle>> buckets = new TreeMap<>();
+        for (MonthlyCandle c : candles) {
+            LocalDate yearStart = c.getCandleTime().toLocalDate().withDayOfYear(1);
+            buckets.computeIfAbsent(yearStart, k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<MonthlyCandle>> entry : buckets.entrySet()) {
+            result.add(aggregateMonthlyCandles(entry.getValue(), entry.getKey().atStartOfDay()));
+        }
+        return result;
+    }
+
+    // 년봉 벤치마크: daily_candle 집계
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getYearlyFromAggregate(String stockCode, int years) {
+        LocalDateTime to = LocalDate.now(KST).plusDays(1).atStartOfDay();
+        LocalDateTime from = to.minusYears(years);
+        List<DailyCandle> candles = dailyCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+        TreeMap<LocalDate, List<DailyCandle>> buckets = new TreeMap<>();
+        for (DailyCandle c : candles) {
+            LocalDate yearStart = c.getCandleTime().toLocalDate().withDayOfYear(1);
+            buckets.computeIfAbsent(yearStart, k -> new ArrayList<>()).add(c);
+        }
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<DailyCandle>> entry : buckets.entrySet()) {
+            List<DailyCandle> bucket = entry.getValue();
+            long open   = bucket.get(0).getOpenPrice();
+            long close  = bucket.get(bucket.size() - 1).getClosePrice();
+            long high   = bucket.stream().mapToLong(DailyCandle::getHighPrice).max().orElse(0);
+            long low    = bucket.stream().mapToLong(DailyCandle::getLowPrice).min().orElse(0);
+            long volume = bucket.stream().mapToLong(DailyCandle::getVolume).sum();
+            result.add(CandleResponse.ofAggregated(entry.getKey().atStartOfDay(), open, high, low, close, volume));
+        }
+        return result;
+    }
+
+    // 30분봉 벤치마크: thirty_minute_candle 직접 조회
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getThirtyMinFromTable(String stockCode, int days) {
+        LocalDateTime to = LocalDate.now(KST).atTime(23, 59, 59);
+        LocalDateTime from = to.minusDays(days - 1).toLocalDate().atStartOfDay();
+
+        List<ThirtyMinuteCandle> candles = thirtyMinuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+
+        return candles.stream().map(c -> CandleResponse.from(c, c.getCandleTime())).toList();
+    }
+
+    // 30분봉 벤치마크: minute_candle 집계
+    @Transactional(readOnly = true)
+    public List<CandleResponse> getThirtyMinFromAggregate(String stockCode, int days) {
+        LocalDateTime to = LocalDate.now(KST).atTime(23, 59, 59);
+        LocalDateTime from = to.minusDays(days - 1).toLocalDate().atStartOfDay();
+
+        List<MinuteCandle> candles = minuteCandleRepository
+                .findByStockCodeAndCandleTimeBetweenOrderByCandleTimeAsc(stockCode, from, to);
+
+        TreeMap<LocalDateTime, List<MinuteCandle>> buckets = new TreeMap<>();
+        for (MinuteCandle c : candles) {
+            LocalDateTime bucketStart = toBucketStart(c.getCandleTime(), 30);
+            buckets.computeIfAbsent(bucketStart, k -> new ArrayList<>()).add(c);
+        }
+
+        List<CandleResponse> result = new ArrayList<>();
+        for (Map.Entry<LocalDateTime, List<MinuteCandle>> entry : buckets.entrySet()) {
+            List<MinuteCandle> bucket = entry.getValue();
+            long open   = bucket.get(0).getOpenPrice();
+            long close  = bucket.get(bucket.size() - 1).getClosePrice();
+            long high   = bucket.stream().mapToLong(MinuteCandle::getHighPrice).max().orElse(0);
+            long low    = bucket.stream().mapToLong(MinuteCandle::getLowPrice).min().orElse(0);
+            long volume = bucket.stream().mapToLong(MinuteCandle::getVolume).sum();
+            result.add(CandleResponse.ofAggregated(entry.getKey(), open, high, low, close, volume));
+        }
+
+        return result;
+    }
+
     // 년봉: monthly_candle 12개씩 집계 + Redis 현재 월봉을 연 버킷에 merge
     @Transactional(readOnly = true)
     public List<CandleResponse> getYearlyCandles(String stockCode, int years, Long toEpoch) {


### PR DESCRIPTION
## #️⃣  관련 이슈
  - closed #187                                                                                                                                         
                                                                                                                                                             
  ## 💡 작업 배경                                                                                                                                            
  전용 캔들 테이블 방식 vs 집계 방식의 성능 비교 검증 및 중복 인덱스 제거                                                                                    
                                                                                                                                                          
  ## 🧩 작업 내용
  - 캔들 엔티티 6개(MinuteCandle, DailyCandle, FiveMinuteCandle, ThirtyMinuteCandle, WeeklyCandle, MonthlyCandle)에서 중복 인덱스 제거
    - `@UniqueConstraint`로 이미 생성되는 인덱스에 `@Index`가 중복 선언되어 있던 문제 수정
  - 벤치마크용 엔드포인트 12개 추가 (전용 테이블 6개 / 집계 6개)
    - 5분봉 / 30분봉 / 60분봉 / 주봉 / 월봉 / 년봉
  - k6 부하 테스트 스크립트 추가
    - `benchmark_table.js` : 전용 테이블 방식 테스트
    - `benchmark_aggregate.js` : 집계 방식 테스트
    - `run_benchmark.sh` : 정순/역순 4라운드 실행 및 결과 자동 분석

  ## 📸 스크린샷(선택)

  ## 📝 기타
  벤치마크 엔드포인트는 배포 환경 테스트 완료 후 제거 예정