### PR TITLE
[Fix] PENDING 매도 주문 시 보유 종목 미표시 버그 수정

### DIFF
--- a/src/main/java/org/solmate/domain/stock/dto/response/StockHoldingResponse.java
+++ b/src/main/java/org/solmate/domain/stock/dto/response/StockHoldingResponse.java
@@ -17,11 +17,11 @@ public record StockHoldingResponse(
             BigDecimal avgPrice,
             BigDecimal currentPrice) {
 
-        // 보유수량 = Holdings 수량(매도 접수 시 차감됨) + PENDING SELL 수량
-        BigDecimal holdingQuantity = holdingsQuantity.add(pendingSellQuantity);
+        // 보유수량 = Holdings 수량 그대로
+        BigDecimal holdingQuantity = holdingsQuantity;
 
-        // 즉시 매도 가능 수량 = Holdings 수량 (PENDING SELL 제외)
-        BigDecimal availableSellQuantity = holdingsQuantity;
+        // 즉시 매도 가능 수량 = 보유수량 - PENDING SELL 수량
+        BigDecimal availableSellQuantity = holdingsQuantity.subtract(pendingSellQuantity);
 
         if (holdingQuantity.compareTo(BigDecimal.ZERO) == 0 || avgPrice.compareTo(BigDecimal.ZERO) == 0) {
             return new StockHoldingResponse(

--- a/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
+++ b/src/main/java/org/solmate/domain/trade/service/HoldingsService.java
@@ -64,18 +64,16 @@ public class HoldingsService {
             .toList();
     }
 
-    // 특정 종목의 보유현황 조회 - PENDING 매도 주문까지 반영해 실제 보유수량을 계산 후 현재가 기준 평가손익 반환
+    // 특정 종목의 보유현황 조회 - PENDING 매도 주문 수량을 제외한 매도 가능 수량 계산 후 현재가 기준 평가손익 반환
     @Transactional(readOnly = true)
     public StockHoldingResponse getStockHolding(Long userId, String stockCode) {
-        // Holdings 조회 (없으면 수량/평균단가 0)
-        // Holdings.quantity는 매도 주문 접수 시 선차감되어 있으므로 PENDING SELL 수량을 다시 더해야 함
         Holdings holdings = holdingsRepository.findByUserIdAndTickerCode(userId, stockCode)
                 .orElse(null);
 
         BigDecimal holdingsQuantity = holdings != null ? holdings.getQuantity() : BigDecimal.ZERO;
         BigDecimal avgPrice = holdings != null ? holdings.getAvgPrice() : BigDecimal.ZERO;
 
-        // PENDING SELL 수량 합산
+        // PENDING SELL 수량 조회 (가용 매도 수량 계산용)
         List<TradeHistory> pendingSells = tradeHistoryRepository
                 .findPendingByUserIdAndTickerCodeAndTradeType(userId, stockCode, TradeType.SELL);
         BigDecimal pendingSellQuantity = pendingSells.stream()

--- a/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
+++ b/src/main/java/org/solmate/domain/trade/service/OrderMatchingService.java
@@ -177,6 +177,12 @@ public class OrderMatchingService {
                         account.addCash(currentPrice.multiply(quantity));
                     }
 
+                    // Holdings 수량 차감
+                    Holdings holdings = holdingsRepository.findByUserAndTickerCodeWithLock(user, ticker).orElse(null);
+                    if (holdings != null) {
+                        holdings.subtractQuantity(quantity);
+                    }
+
                     // TradeHistory 체결 처리
                     tradeHistory.updateStatus(TradeStatus.FILLED);
                     tradeHistory.updateFilledPrice(currentPrice);

--- a/src/main/java/org/solmate/domain/trade/service/TradeOrderService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeOrderService.java
@@ -6,11 +6,9 @@ import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.account.entity.Account;
 import org.solmate.domain.account.repository.AccountRepository;
-import org.solmate.domain.trade.entity.Holdings;
 import org.solmate.domain.trade.entity.TradeHistory;
 import org.solmate.domain.trade.enums.TradeStatus;
 import org.solmate.domain.trade.enums.TradeType;
-import org.solmate.domain.trade.repository.HoldingsRepository;
 import org.solmate.domain.trade.repository.TradeDiaryRepository;
 import org.solmate.domain.trade.repository.TradeHistoryRepository;
 import org.solmate.domain.user.entity.User;
@@ -33,7 +31,6 @@ public class TradeOrderService {
     private final TradeHistoryRepository tradeHistoryRepository;
     private final TradeDiaryRepository tradeDiaryRepository;
     private final AccountRepository accountRepository;
-    private final HoldingsRepository holdingsRepository;
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
 
@@ -63,12 +60,6 @@ public class TradeOrderService {
             Account account = accountRepository.findByUserWithLock(user)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND));
             account.addCash(tradeHistory.getPrice().multiply(tradeHistory.getQuantity()));
-        } else {
-            // 매도 취소 → 주문 접수 시 선차감했던 주식 수량 복원
-            // DB 비관적 락으로 Holdings row를 잠금 → 동시 복원 시 수량 덮어쓰기 방지
-            Holdings holdings = holdingsRepository.findByUserAndTickerCodeWithLock(user, tradeHistory.getStock().getTickerCode())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
-            holdings.addQuantity(tradeHistory.getQuantity());
         }
 
         // 주문 상태를 CANCELLED로 변경

--- a/src/main/java/org/solmate/domain/trade/service/TradeService.java
+++ b/src/main/java/org/solmate/domain/trade/service/TradeService.java
@@ -129,8 +129,14 @@ public class TradeService {
         Holdings holdings = holdingsRepository.findByUserAndTickerCodeWithLock(user, request.ticker())
             .orElseThrow(() -> new GeneralException(ErrorStatus.INSUFFICIENT_HOLDINGS));
 
-        // 보유 수량 검증
-        if (holdings.getQuantity().compareTo(request.quantity()) < 0) {
+        // 가용 수량 검증 (PENDING SELL 수량 제외)
+        BigDecimal pendingSellQuantity = tradeHistoryRepository
+                .findPendingByUserIdAndTickerCodeAndTradeType(userId, request.ticker(), TradeType.SELL)
+                .stream()
+                .map(TradeHistory::getQuantity)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal availableQuantity = holdings.getQuantity().subtract(pendingSellQuantity);
+        if (availableQuantity.compareTo(request.quantity()) < 0) {
             throw new GeneralException(ErrorStatus.INSUFFICIENT_HOLDINGS);
         }
 
@@ -147,9 +153,6 @@ public class TradeService {
 
         // 호가 단위 보정
         price = adjustToTickSize(price);
-
-        // 수량 선차감
-        holdings.subtractQuantity(request.quantity());
 
         // TradeHistory 저장
         // avgPriceSnapshot: 매도 시점의 평균단가 스냅샷 저장 (이후 추가 매수 시 avgPrice가 바뀌어도 수익 계산 가능)


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #192

## 💡 작업 배경
  매수 100주 후 100주 예약 매도를 걸었을 때, 아직 체결되지 않았음에도 GET /api/holdings에서 보유 종목이 사라지는 버그가 발생했습니다.
  매도 주문 접수 시 Holdings.quantity를 선차감하는 로직으로 인해 수량이 0이 되어 보유 종목이 표시되지 않는 문제였습니다.



## 🧩 작업 내용
  문제 원인
  - 매도 주문 접수(sellOrder) 시점에 Holdings.quantity를 즉시 차감하고 있었으나, PENDING 상태는 아직 내 보유 주식이므로 차감하면 안 됩니다.

  변경 사항

  - TradeService.java - 매도 접수 시 subtractQuantity() 선차감 제거, PENDING SELL 수량을 제외한 가용수량 기준으로 이중 매도 방지 검증 추가
  - OrderMatchingService.java - 매도 체결(FILLED) 시점에 subtractQuantity() 처리하도록 이동
  - TradeOrderService.java - 매도 취소 시 불필요해진 addQuantity() 수량 복원 로직 제거
  - HoldingsService.java - PENDING SELL 수량을 더하던 보정 로직 제거
  - StockHoldingResponse.java - availableSellQuantity = holdingsQuantity - pendingSellQuantity 로 변경



