### PR TITLE
[Fix] 예약 매수/매도 대기 주문의 총자산 계산 오류 수정

### DIFF
--- a/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
+++ b/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
@@ -90,6 +90,17 @@ public class PortfolioCalculator {
                 .setScale(0, RoundingMode.HALF_UP);
     }
 
+    // PENDING BUY로 묶인 금액 = price × quantity 합산
+    @Transactional(readOnly = true)
+    public BigDecimal getPendingBuyAmount(Long userId) {
+        return tradeHistoryRepository
+                .findPendingByUserIdAndTradeType(userId, TradeType.BUY)
+                .stream()
+                .map(t -> t.getPrice().multiply(t.getQuantity()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .setScale(0, RoundingMode.HALF_UP);
+    }
+
     // 총 수익금 = 총 자산(평가금액 + 현금) - 시드머니
     public BigDecimal getTotalReturnAmount(BigDecimal totalAsset, BigDecimal initialCash) {
         return totalAsset.subtract(initialCash).setScale(0, RoundingMode.HALF_UP);

--- a/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
+++ b/src/main/java/org/solmate/common/portfolio/PortfolioCalculator.java
@@ -6,8 +6,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.solmate.common.exception.GeneralException;
 import org.solmate.common.status.ErrorStatus;
 import org.solmate.domain.account.entity.Account;
@@ -44,19 +42,11 @@ public class PortfolioCalculator {
         return cash.setScale(0, RoundingMode.HALF_UP);
     }
 
-    // 종목별 평가금액 (실제 보유 수량 = Holdings.quantity + PENDING SELL)
+    // 종목별 평가금액 (실제 보유 수량 = Holdings.quantity)
     @Transactional(readOnly = true)
     public List<PortfolioHoldingLine> getHoldingEvaluationLines(Long userId) {
         List<Holdings> holdingsList = holdingsRepository.findByUserId(userId);
         if (holdingsList.isEmpty()) return List.of();
-
-        // DB N+1 제거: PENDING SELL 전체를 한 번에 조회 후 메모리에서 그룹핑
-        Map<String, BigDecimal> pendingSellMap = tradeHistoryRepository
-                .findPendingByUserIdAndTradeTypeWithStock(userId, TradeType.SELL)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        t -> t.getStock().getTickerCode(),
-                        Collectors.reducing(BigDecimal.ZERO, TradeHistory::getQuantity, BigDecimal::add)));
 
         // Redis N+1 제거: 현재가 일괄 조회
         List<String> tickerCodes = holdingsList.stream().map(Holdings::getTickerCode).toList();
@@ -64,9 +54,8 @@ public class PortfolioCalculator {
 
         List<PortfolioHoldingLine> lines = new ArrayList<>();
         for (Holdings h : holdingsList) {
-            BigDecimal pendingSellQuantity = pendingSellMap.getOrDefault(h.getTickerCode(), BigDecimal.ZERO);
-            BigDecimal totalQuantity = h.getQuantity().add(pendingSellQuantity);
-            if (totalQuantity.compareTo(BigDecimal.ZERO) <= 0) continue;
+            BigDecimal quantity = h.getQuantity();
+            if (quantity.compareTo(BigDecimal.ZERO) <= 0) continue;
 
             BigDecimal price = prices.get(h.getTickerCode());
             if (price == null) throw new GeneralException(ErrorStatus.STOCK_PRICE_NOT_FOUND);
@@ -74,14 +63,14 @@ public class PortfolioCalculator {
             lines.add(new PortfolioHoldingLine(
                     h.getTickerCode(),
                     h.getStock().getStockName(),
-                    price.multiply(totalQuantity)));
+                    price.multiply(quantity)));
         }
 
         lines.sort(Comparator.comparing(PortfolioHoldingLine::evaluation).reversed());
         return lines;
     }
 
-    // 총 평가금액 = (Holdings.quantity + PENDING SELL 수량) × 현재가의 합
+    // 총 평가금액 = Holdings.quantity × 현재가의 합
     @Transactional(readOnly = true)
     public BigDecimal getTotalEvaluation(Long userId) {
         return getHoldingEvaluationLines(userId).stream()

--- a/src/main/java/org/solmate/domain/account/service/AccountService.java
+++ b/src/main/java/org/solmate/domain/account/service/AccountService.java
@@ -30,7 +30,8 @@ public class AccountService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND));
 
         BigDecimal initialCash = account.getInitialCash();
-        BigDecimal cash = portfolioCalculator.getCash(userId);
+        BigDecimal cash = portfolioCalculator.getCash(userId)
+                .add(portfolioCalculator.getPendingBuyAmount(userId));
 
         List<PortfolioHoldingLine> lines = portfolioCalculator.getHoldingEvaluationLines(userId);
         BigDecimal sumEvaluationRaw = lines.stream()


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #194

## 💡 작업 배경
  예약 매수 주문 시 Account.cash에서 금액이 선차감되는 구조로 인해, 대기 중인 매수 금액이 총자산 계산에서 누락되는 버그가 발견되었습니다.

  또한 sellOrder 로직이 수량 선차감 방식에서 가용 수량 검증 방식으로 변경되면서, 기존의 PENDING SELL 수량 보정 로직이 평가금액을 이중으로 계산하는 문제도 함께   
  확인되었습니다.

## 🧩 작업 내용
  1. 예약 매수 대기 금액 총자산 반영 (PortfolioCalculator, AccountService)
  - PENDING BUY 주문의 price × quantity 합산 메서드 getPendingBuyAmount() 추가
  - 총자산 계산 시 cash = Account.cash + PENDING BUY 금액 으로 보정

  2. 주식 평가금액 이중 계산 제거 (PortfolioCalculator)
  - 기존 getHoldingEvaluationLines()에서 PENDING SELL 수량을 Holdings.quantity에 더하던 보정 로직 제거
  - sellOrder가 수량 비선차감 구조로 변경됨에 따라 Holdings.quantity 그대로 사용


## 📸 스크린샷(선택)


## 📝 기타
