### PR TITLE
[Fix] 주문 가능 금액과 총자산 계산용 현금 분리

### DIFF
--- a/src/main/java/org/solmate/domain/account/service/AccountService.java
+++ b/src/main/java/org/solmate/domain/account/service/AccountService.java
@@ -30,8 +30,8 @@ public class AccountService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND));
 
         BigDecimal initialCash = account.getInitialCash();
-        BigDecimal cash = portfolioCalculator.getCash(userId)
-                .add(portfolioCalculator.getPendingBuyAmount(userId));
+        BigDecimal availableCash = portfolioCalculator.getCash(userId);
+        BigDecimal cash = availableCash.add(portfolioCalculator.getPendingBuyAmount(userId));
 
         List<PortfolioHoldingLine> lines = portfolioCalculator.getHoldingEvaluationLines(userId);
         BigDecimal sumEvaluationRaw = lines.stream()
@@ -50,7 +50,7 @@ public class AccountService {
                 totalAsset,
                 totalReturnAmount,
                 totalReturnRate,
-                cash,
+                availableCash,
                 initialCash,
                 holdingsCount,
                 totalEvaluation,


### PR DESCRIPTION
## #️⃣ 관련 이슈
- closed #194 

## 💡 작업 배경
- 주문 가능 금액이 제대로 안나오는 오류 발생 

## 🧩 작업 내용
  - availableCash = Account.cash (주문 가능 금액, 선차감 반영) → response의 cash 필드로 내려감
  - cash = availableCash + PENDING BUY (총자산 계산 전용)

